### PR TITLE
Kill random openshift running pods

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,8 +2,9 @@ kraken:
     kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
     scenarios:                                             # List of policies/chaos scenarios to load
         -    scenarios/etcd.yml
-        -    scenarios/openshift-kube-apiserver.yml                           
+        -    scenarios/openshift-kube-apiserver.yml
         -    scenarios/openshift-apiserver.yml
+        -    scenarios/regex_openshift_pod_kill.yml
 
 cerberus:
     cerberus_enabled: False                                # Enable it when cerberus is previously installed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 datetime
 pyfiglet
-powerfulseal==3.0.0rc9
+git+https://github.com/bloomberg/powerfulseal.git@master
 requests

--- a/scenarios/regex_openshift_pod_kill.yml
+++ b/scenarios/regex_openshift_pod_kill.yml
@@ -1,0 +1,20 @@
+config:
+  runStrategy:
+    runs: 1
+    maxSecondsBetweenRuns: 30
+    minSecondsBetweenRuns: 1
+scenarios:
+  - name: kill up to 3 pods in any openshift namespace
+    steps:
+    - podAction:
+        matches:
+          - namespace: "openshift-.*"
+        filters:
+          - property:
+             name: "state"
+             value: "Running"
+          - randomSample:
+              size: 3
+        actions:
+          - kill:
+              probability: .7


### PR DESCRIPTION
Adding a scenario to kill a random openshift running pod from all namespaces for https://github.com/openshift-scale/kraken/issues/13

Based on the bash script Mike had said to base this scenario on there was a 2 second wait in between kills. Not sure if that is still necessary here, definitely can remove

