### PR TITLE
Adding updated powerfulseal pip version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 datetime
 pyfiglet
-git+https://github.com/bloomberg/powerfulseal.git@master
+powerfulseal==3.0.0rc11
 requests


### PR DESCRIPTION
The newest pip version came out with the regex namespace changes I had added. Want to change it from always pulling down the latest master in case there's a huge yaml layout change again and we are broken for some time. 