### PR TITLE
Litmus integration with node cpu hog experiment

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,7 +1,9 @@
 kraken:
     kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
-    chaos_scenarios:                                         # List of policies/chaos scenarios to load
+    litmus_version: v1.10.0                                # Litmus version to install
+    litmus_uninstall: False                                # If you want to uninstall litmus if failure
+    chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   pod_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/etcd.yml
             - -    scenarios/regex_openshift_pod_kill.yml
@@ -13,6 +15,9 @@ kraken:
             - -    scenarios/openshift-kube-apiserver.yml
         -   time_scenarios:                                # List of chaos time scenarios to load
             - scenarios/time_scenarios_example.yml
+        -   litmus_scenarios:                              # List of litmus scenarios to load
+            - - https://hub.litmuschaos.io/api/chaos/1.10.0?file=charts/generic/node-cpu-hog/rbac.yaml
+              - scenarios/node_hog_engine.yaml
 
 cerberus:
     cerberus_enabled: False                                # Enable it when cerberus is previously installed

--- a/docs/litmus_scenarios.md
+++ b/docs/litmus_scenarios.md
@@ -1,0 +1,41 @@
+### Litmus Scenarios
+Kraken consumes [Litmus](https://github.com/litmuschaos/litmus) under the hood for some infrastructure, pod, and node scenarios
+ 
+Official Litmus documentation and to read more information on specifics of Litmus resources can be found [here](https://docs.litmuschaos.io/docs/next/getstarted/)
+
+
+#### Litmus Chaos Custom Resources
+There are 3 custom resources that are created during each Litmus scenario. Below is a description of the resources:
+* ChaosEngine: A resource to link a Kubernetes application or Kubernetes node to a ChaosExperiment. ChaosEngine is watched by Litmus' Chaos-Operator which then invokes Chaos-Experiments
+* ChaosExperiment: A resource to group the configuration parameters of a chaos experiment. ChaosExperiment CRs are created by the operator when experiments are invoked by ChaosEngine.
+* ChaosResult : A resource to hold the results of a chaos-experiment. The Chaos-exporter reads the results and exports the metrics into a configured Prometheus server.
+
+### Understanding Litmus Scenarios  
+
+To run Litmus scenarios we need to apply 3 different resources/yaml files to our cluster
+1. **Chaos experiments** contain the actual chaos details of a scenario
+
+    i. This is installed automatically by Kraken (does not need to be specified in kraken scenario configuration)
+    
+2. **Service Account**: should be created to allow chaosengine to run experiments in your application namespace. Usually sets just enough permissions to a specific namespace to be able to run the experiment properly 
+
+    i. This can be defined using either a link to a yaml file or a downloaded file in the scenarios folder
+    
+3. **Chaos Engine** connects the application instance to a Chaos Experiment. This is where you define the specifics of your scenario; ie: the node or pod name you want to cause chaos within 
+
+    i. This is a downloaded yaml file in the scenarios folder, full list of scenarios can be found [here](https://hub.litmuschaos.io/)
+
+**NOTE**: By default all chaos experiments will be installed based on the version you give in the config file. 
+
+Adding a new Litmus based scenario is as simple as adding references to 2 new yaml files (the Service Account and Chaos engine files for your scenario ) in the Kraken config.
+
+### Current Scenarios
+
+Following are the start of scenarios for which a chaos scenario config exists today. 
+
+Component                | Description                                                                                        | Working
+------------------------ | ---------------------------------------------------------------------------------------------------| ------------------------- |
+Node CPU Hog             | Chaos scenario that hogs up the CPU on a defined node for a specific amount of time                | :heavy_check_mark:        |
+
+
+

--- a/kraken/litmus/common_litmus.py
+++ b/kraken/litmus/common_litmus.py
@@ -1,0 +1,103 @@
+import kraken.invoke.command as runcommand
+import logging
+import time
+import sys
+
+
+# Install litmus and wait until pod is running
+def install_litmus(version):
+    runcommand.invoke("kubectl apply -f "
+                      "https://litmuschaos.github.io/litmus/litmus-operator-%s.yaml" % version)
+
+    runcommand.invoke("oc patch -n litmus deployment.apps/chaos-operator-ce --type=json --patch ' "
+                      "[ { \"op\": \"add\", \"path\": \"/spec/template/spec/containers/0/env/-\", "
+                      "\"value\": { \"name\": \"ANALYTICS\", \"value\": \"FALSE\" } } ]'")
+
+    runcommand.invoke("oc wait deploy -n litmus chaos-operator-ce --for=condition=Available")
+
+
+def deploy_all_experiments(version_string):
+
+    if not version_string.startswith("v"):
+        logging.error("Incorrect version string for litmus, needs to start with 'v' "
+                      "followed by a number")
+        sys.exit(1)
+    version = version_string[1:]
+
+    runcommand.invoke("kubectl apply -f "
+                      "https://hub.litmuschaos.io/api/chaos/%s?file=charts/generic/experiments.yaml"
+                      % version)
+
+
+def delete_experiments():
+    runcommand.invoke("kubectl delete chaosengine --all")
+
+
+# Check status of experiment
+def check_experiment(engine_name, experiment_name, namespace):
+    chaos_engine = runcommand.invoke("kubectl get chaosengines/%s -n %s -o jsonpath="
+                                     "'{.status.engineStatus}'" % (engine_name, namespace))
+    engine_status = chaos_engine.strip()
+    max_tries = 30
+    engine_counter = 0
+    while engine_status.lower() != "running" and engine_status.lower() != "completed":
+        time.sleep(10)
+        logging.info("Waiting for engine to start running.")
+        chaos_engine = runcommand.invoke("kubectl get chaosengines/%s -n %s -o jsonpath="
+                                         "'{.status.engineStatus}'" % (engine_name, namespace))
+        engine_status = chaos_engine.strip()
+        if engine_counter >= max_tries:
+            logging.error("Chaos engine took longer than 5 minutes to be running or complete")
+            return False
+        engine_counter += 1
+        # need to see if error in run
+        if "notfound" in engine_status.lower():
+            logging.info("Chaos engine was not found")
+            return False
+
+    if not chaos_engine:
+        return False
+    chaos_result = runcommand.invoke("kubectl get chaosresult %s"
+                                     "-%s -n %s -o "
+                                     "jsonpath='{.status.experimentstatus.verdict}'"
+                                     % (engine_name, experiment_name, namespace))
+    result_counter = 0
+    status = chaos_result.strip()
+    while status == "Awaited":
+        logging.info("Waiting for chaos result to finish, sleeping 10 seconds")
+        time.sleep(10)
+        chaos_result = runcommand.invoke("kubectl get chaosresult %s"
+                                         "-%s -n %s -o "
+                                         "jsonpath='{.status.experimentstatus.verdict}'"
+                                         % (engine_name, experiment_name, namespace))
+        status = chaos_result.strip()
+        if result_counter >= max_tries:
+            logging.error("Chaos results took longer than 5 minutes to get a final result")
+            return False
+        result_counter += 1
+        if "notfound" in status.lower():
+            logging.info("Chaos result was not found")
+            return False
+
+    if status == "Pass":
+        return True
+    else:
+        chaos_result = runcommand.invoke("kubectl get chaosresult %s"
+                                         "-%s -n %s -o jsonpath="
+                                         "'{.status.experimentstatus.failStep}'" %
+                                         (engine_name, experiment_name, namespace))
+        logging.info("Chaos result failed information: " + str(chaos_result))
+        return False
+
+
+# Delete all chaos engines in a given namespace
+def delete_chaos(namespace):
+    runcommand.invoke("kubectl delete chaosengine --all -n " + str(namespace))
+    runcommand.invoke("kubectl delete chaosexperiment --all -n " + str(namespace))
+    runcommand.invoke("kubectl delete chaosresult --all -n " + str(namespace))
+
+
+# Uninstall litmus operator
+def uninstall_litmus(version):
+    runcommand.invoke("kubectl delete -f "
+                      "https://litmuschaos.github.io/litmus/litmus-operator-%s.yaml" % version)

--- a/scenarios/node_hog_engine.yaml
+++ b/scenarios/node_hog_engine.yaml
@@ -1,0 +1,25 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: nginx-chaos
+  namespace: default
+spec:
+  # It can be true/false
+  annotationCheck: 'false'
+  # It can be active/stop
+  engineState: 'active'
+  chaosServiceAccount: node-cpu-hog-sa
+  monitoring: false
+  # It can be delete/retain
+  jobCleanUpPolicy: 'delete'
+  experiments:
+    - name: node-cpu-hog
+      spec:
+        components:
+          env:
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '60'
+            # ENTER THE COMMA SEPARATED TARGET NODES NAME
+            - name: TARGET_NODES
+              value: ''


### PR DESCRIPTION
This PR is for https://github.com/openshift-scale/kraken/issues/31

This will install litmus, apply any experiments and check the status of them and then tear down litmus with each kraken run. 

The scenario I was able to run and am adding the scenario files here are for the node cpu hog. For this scenario you have to add the node you want to hog the cpu of in both the scenario/node_hog.yaml as well as scenario/node_hog_engine.yaml

Other scenarios that we can add can be found here: 
https://hub.litmuschaos.io/