### PR TITLE
Blank node name error message

### DIFF
--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -47,7 +47,6 @@ $ git rebase -i <commit_id_of_first_change_commit>
 
 In the interactive rebase screen, set the first commit to `pick` and all others to `squash` (or whatever else you may need to do).
 
-
 Push your rebased commits (you may need to force), then issue your PR.
 
 ```

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -47,6 +47,7 @@ $ git rebase -i <commit_id_of_first_change_commit>
 
 In the interactive rebase screen, set the first commit to `pick` and all others to `squash` (or whatever else you may need to do).
 
+
 Push your rebased commits (you may need to force), then issue your PR.
 
 ```

--- a/kraken/node_actions/common_node_functions.py
+++ b/kraken/node_actions/common_node_functions.py
@@ -10,7 +10,7 @@ import kraken.invoke.command as runcommand
 def get_node(node_name, label_selector):
     if node_name in kubecli.list_killable_nodes():
         return node_name
-    else:
+    elif node_name:
         logging.info("Node with provided node_name does not exist or the node might " "be in NotReady state.")
     nodes = kubecli.list_killable_nodes(label_selector)
     if not nodes:


### PR DESCRIPTION
### Description
If the user leaves the node_name blank in the node scenario config file an error message is printed out saying it couldn't find the node. But in our default node scenario we are matching based on the label selector so this message can be confusing. 
This update should only print off the error message if a node name is given and does not match and ready node names 

