### PR TITLE
Adding shut down scenario for gcp, az, aws, openstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Kraken supports pod, node, time/date and [litmus](https://github.com/litmuschaos
 
 - [Litmus Scenarios](docs/litmus_scenarios.md)
 
+- [Cluster Shut Down Scenarios](docs/cluster_shut_down_scenarios.md)
 
 ### Kraken scenario pass/fail criteria and report
 It's important to make sure to check if the targeted component recovered from the chaos injection and also if the Kubernetes/OpenShift cluster is healthy as failures in one component can have an adverse impact on other components. Kraken does this by:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,7 +19,9 @@ kraken:
         -   litmus_scenarios:                              # List of litmus scenarios to load
             - - https://hub.litmuschaos.io/api/chaos/1.10.0?file=charts/generic/node-cpu-hog/rbac.yaml
               - scenarios/node_hog_engine.yaml
-
+        -   cluster_shut_down_scenarios:
+            - - scenarios/cluster_shut_down_scenario.yml
+              - scenarios/post_action_shut_down.py
 cerberus:
     cerberus_enabled: False                                # Enable it when cerberus is previously installed
     cerberus_url:                                          # When cerberus_enabled is set to True, provide the url where cerberus publishes go/no-go signal

--- a/docs/cloud_setup.md
+++ b/docs/cloud_setup.md
@@ -1,0 +1,41 @@
+Supported Cloud Providers:
+
+* [AWS](#aws)
+* [GCP](#gcp)
+* [Openstack](#openstack)
+* [Azure](#azure)
+
+
+## AWS
+
+**NOTE**: For clusters with AWS make sure [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) is installed and properly [configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html) using an AWS account
+
+## GCP
+**NOTE**: For clusters with GCP make sure [GCP CLI](https://cloud.google.com/sdk/docs/install#linux) is installed.
+
+A google service account is required to give proper authentication to GCP for node actions. See [here](https://cloud.google.com/docs/authentication/getting-started) for how to create a service account.
+
+**NOTE**: A user with 'resourcemanager.projects.setIamPolicy' permission is required to grant project-level permissions to the service account.
+
+After creating the service account you'll need to enable the account using the following: ```export GOOGLE_APPLICATION_CREDENTIALS="<serviceaccount.json>"```
+
+## Openstack
+
+**NOTE**: For clusters with Openstack Cloud, ensure to create and source the [OPENSTACK RC file](https://docs.openstack.org/newton/user-guide/common/cli-set-environment-variables-using-openstack-rc.html) to set the OPENSTACK environment variables from the server where Kraken runs.
+
+## Azure
+
+**NOTE**: For Azure node killing scenarios, make sure [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) is installed
+
+You will also need to create a service principal and give it the correct access, see [here](https://docs.openshift.com/container-platform/4.5/installing/installing_azure/installing-azure-account.html) for creating the service principal and setting the proper permissions
+
+To properly run the service principal requires “Azure Active Directory Graph/Application.ReadWrite.OwnedBy” api permission granted and “User Access Administrator”
+
+Before running you'll need to set the following:
+1. Login using ```az login```
+
+2. ```export AZURE_TENANT_ID=<tenant_id>```
+
+3. ```export AZURE_CLIENT_SECRET=<client secret>```
+
+4. ```export AZURE_CLIENT_ID=<client id>```

--- a/docs/cluster_shut_down_scenarios.md
+++ b/docs/cluster_shut_down_scenarios.md
@@ -1,0 +1,18 @@
+#### Kubernetes/OpenShift cluster shut down scenario
+Scenario to shut down all the nodes including the masters and restart them after specified duration. Cluster shut down scenario can be injected by placing the shut_down config file under cluster_shut_down_scenario option in the kraken config. Refer to [cluster_shut_down_scenario](https://github.com/openshift-scale/kraken/blob/master/scenarios/cluster_shut_down_scenario.yml) config file.
+
+Refer to [cloud setup](cloud_setup.md) to configure your cli properly for the cloud provider of the cluster you want to shut down
+
+Current accepted cloud types:
+* [Azure](cloud_setup.md#azure)
+* [GCP](cloud_setup.md#gcp)
+* [AWS](cloud_setup.md#aws)
+* [Openstack](cloud_setup.md#openstack)
+
+
+```
+cluster_shut_down_scenario:                          # Scenario to stop all the nodes for specified duration and restart the nodes
+  runs: 1                                            # Number of times to execute the cluster_shut_down scenario
+  shut_down_duration: 120                            # duration in seconds to shut down the cluster
+  cloud_type: aws                                    # cloud type on which Kubernetes/OpenShift runs
+```

--- a/docs/node_scenarios.md
+++ b/docs/node_scenarios.md
@@ -18,20 +18,14 @@ Following node chaos scenarios are supported:
 
 #### AWS
 
-**NOTE**: For clusters with AWS make sure [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) is installed and properly [configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html) using an AWS account
+How to set up AWS cli to run node scenarios is defined [here](cloud_setup.md#aws)
 
 #### GCP
-**NOTE**: For clusters with GCP make sure [GCP CLI](https://cloud.google.com/sdk/docs/install#linux) is installed.
+How to set up GCP cli to run node scenarios is defined [here](cloud_setup.md#gcp)
 
-A google service account is required to give proper authentication to GCP for node actions. See [here](https://cloud.google.com/docs/authentication/getting-started) for how to create a service account.
+#### Openstack
 
-**NOTE**: A user with 'resourcemanager.projects.setIamPolicy' permission is required to grant project-level permissions to the service account.
-
-After creating the service account you'll need to enable the account using the following: ```export GOOGLE_APPLICATION_CREDENTIALS="<serviceaccount.json>"```
-
-#### OPENSTACK
-
-**NOTE**: For clusters with OPENSTACK Cloud, ensure to create and source the [OPENSTACK RC file](https://docs.openstack.org/newton/user-guide/common/cli-set-environment-variables-using-openstack-rc.html) to set the OPENSTACK environment variables from the server where Kraken runs.
+How to set up Openstack cli to run node scenarios is defined [here](cloud_setup.md#openstack)
 
 The supported node level chaos scenarios on an OPENSTACK cloud are `node_stop_start_scenario`, `stop_start_kubelet_scenario` and `node_reboot_scenario`.
 
@@ -39,22 +33,10 @@ The supported node level chaos scenarios on an OPENSTACK cloud are `node_stop_st
 
 To execute the scenario, ensure the value for `ssh_private_key` in the node scenarios config file is set with the correct private key file path for ssh connection to the helper node. Ensure passwordless ssh is configured on the host running Kraken and the helper node to avoid connection errors.
 
+
 #### Azure
 
-**NOTE**: For Azure node killing scenarios, make sure [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) is installed
-
-You will also need to create a service principal and give it the correct access, see [here](https://docs.openshift.com/container-platform/4.5/installing/installing_azure/installing-azure-account.html) for creating the service principal and setting the proper permissions
-
-To properly run the service principal requires “Azure Active Directory Graph/Application.ReadWrite.OwnedBy” api permission granted and “User Access Administrator”
-
-Before running you'll need to set the following:
-1. Login using ```az login```
-
-2. ```export AZURE_TENANT_ID=<tenant_id>```
-
-3. ```export AZURE_CLIENT_SECRET=<client secret>```
-
-4. ```export AZURE_CLIENT_ID=<client id>```
+How to set up Azure cli to run node scenarios is defined [here](cloud_setup.md#azure)
 
 
 **NOTE**: The `node_crash_scenario` and `stop_kubelet_scenario` scenario is supported independent of the cloud platform.

--- a/kraken/node_actions/gcp_node_scenarios.py
+++ b/kraken/node_actions/gcp_node_scenarios.py
@@ -38,24 +38,56 @@ class GCP:
 
     # Start the node instance
     def start_instances(self, zone, instance_id):
-        self.client.instances().start(project=self.project, zone=zone, instance=instance_id).execute()
+        try:
+            self.client.instances().start(project=self.project, zone=zone, instance=instance_id).execute()
+            logging.info("vm name " + str(instance_id) + " started")
+        except Exception as e:
+            logging.error(
+                "Failed to start node instance %s. Encountered following " "exception: %s." % (instance_id, e)
+            )
+            sys.exit(1)
 
     # Stop the node instance
     def stop_instances(self, zone, instance_id):
-        self.client.instances().stop(project=self.project, zone=zone, instance=instance_id).execute()
+        try:
+            self.client.instances().stop(project=self.project, zone=zone, instance=instance_id).execute()
+            logging.info("vm name " + str(instance_id) + " stopped")
+        except Exception as e:
+            logging.error("Failed to stop node instance %s. Encountered following " "exception: %s." % (instance_id, e))
+            sys.exit(1)
 
     # Start the node instance
     def suspend_instances(self, zone, instance_id):
-        self.client.instances().suspend(project=self.project, zone=zone, instance=instance_id).execute()
+        try:
+            self.client.instances().suspend(project=self.project, zone=zone, instance=instance_id).execute()
+            logging.info("vm name " + str(instance_id) + " suspended")
+        except Exception as e:
+            logging.error(
+                "Failed to suspend node instance %s. Encountered following " "exception: %s." % (instance_id, e)
+            )
+            sys.exit(1)
 
     # Terminate the node instance
     def terminate_instances(self, zone, instance_id):
-        self.client.instances().delete(project=self.project, zone=zone, instance=instance_id).execute()
+        try:
+            self.client.instances().delete(project=self.project, zone=zone, instance=instance_id).execute()
+            logging.info("vm name " + str(instance_id) + " terminated")
+        except Exception as e:
+            logging.error(
+                "Failed to start node instance %s. Encountered following " "exception: %s." % (instance_id, e)
+            )
+            sys.exit(1)
 
     # Reboot the node instance
     def reboot_instances(self, zone, instance_id):
-        response = self.client.instances().reset(project=self.project, zone=zone, instance=instance_id).execute()
-        logging.info("response reboot " + str(response))
+        try:
+            self.client.instances().reset(project=self.project, zone=zone, instance=instance_id).execute()
+            logging.info("vm name " + str(instance_id) + " rebooted")
+        except Exception as e:
+            logging.error(
+                "Failed to start node instance %s. Encountered following " "exception: %s." % (instance_id, e)
+            )
+            sys.exit(1)
 
     # Get instance status
     def get_instance_status(self, zone, instance_id, expected_status, timeout):
@@ -70,19 +102,20 @@ class GCP:
                 return True
             time.sleep(sleeper)
             i += sleeper
-        logging.error("Status of %s was not %s in a")
+        logging.error("Status of %s was not %s in %s seconds" % (instance_id, expected_status, timeout))
+        return False
 
     # Wait until the node instance is suspended
     def wait_until_suspended(self, zone, instance_id, timeout):
-        self.get_instance_status(zone, instance_id, "SUSPENDED", timeout)
+        return self.get_instance_status(zone, instance_id, "SUSPENDED", timeout)
 
     # Wait until the node instance is running
     def wait_until_running(self, zone, instance_id, timeout):
-        self.get_instance_status(zone, instance_id, "RUNNING", timeout)
+        return self.get_instance_status(zone, instance_id, "RUNNING", timeout)
 
     # Wait until the node instance is stopped
     def wait_until_stopped(self, zone, instance_id, timeout):
-        self.get_instance_status(zone, instance_id, "TERMINATED", timeout)
+        return self.get_instance_status(zone, instance_id, "TERMINATED", timeout)
 
     # Wait until the node instance is terminated
     def wait_until_terminated(self, zone, instance_id, timeout):

--- a/kraken/post_actions/actions.py
+++ b/kraken/post_actions/actions.py
@@ -27,6 +27,8 @@ def run(kubeconfig_path, scenario, pre_action_output=""):
                 logging.info(scenario + " post action checks passed")
             else:
                 logging.info(scenario + " post action response did not match pre check output")
+                logging.info("Pre action output: " + str(pre_action_output) + "\n")
+                logging.info("Post action output: " + str(action_output))
                 return False
     elif scenario != "":
         # invoke custom bash script

--- a/kraken/shut_down/common_shut_down_func.py
+++ b/kraken/shut_down/common_shut_down_func.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+import sys
+import yaml
+import logging
+import time
+from multiprocessing.pool import ThreadPool
+import kraken.cerberus.setup as cerberus
+import kraken.kubernetes.client as kubecli
+import kraken.post_actions.actions as post_actions
+from kraken.node_actions.aws_node_scenarios import AWS
+from kraken.node_actions.openstack_node_scenarios import OPENSTACKCLOUD
+from kraken.node_actions.az_node_scenarios import Azure
+from kraken.node_actions.gcp_node_scenarios import GCP
+
+
+def multiprocess_nodes(cloud_object_function, nodes):
+    try:
+        # pool object with number of element
+
+        pool = ThreadPool(processes=len(nodes))
+        logging.info("nodes type " + str(type(nodes[0])))
+        if type(nodes[0]) is tuple:
+            node_id = []
+            node_info = []
+            for node in nodes:
+                node_id.append(node[0])
+                node_info.append(node[1])
+            logging.info("node id " + str(node_id))
+            logging.info("node info" + str(node_info))
+            pool.starmap(cloud_object_function, zip(node_info, node_id))
+
+        else:
+            logging.info("pool type" + str(type(nodes)))
+            pool.map(cloud_object_function, nodes)
+        pool.close()
+    except Exception as e:
+        logging.info("Error on pool multiprocessing: " + str(e))
+
+
+# Inject the cluster shut down scenario
+def cluster_shut_down(shut_down_config):
+    runs = shut_down_config["runs"]
+    shut_down_duration = shut_down_config["shut_down_duration"]
+    cloud_type = shut_down_config["cloud_type"]
+    timeout = shut_down_config["timeout"]
+    if cloud_type.lower() == "aws":
+        cloud_object = AWS()
+    elif cloud_type.lower() == "gcp":
+        cloud_object = GCP()
+    elif cloud_type.lower() == "openstack":
+        cloud_object = OPENSTACKCLOUD()
+    elif cloud_type.lower() in ["azure", "az"]:
+        cloud_object = Azure()
+    else:
+        logging.error("Cloud type " + cloud_type + " is not currently supported for cluster shut down")
+        sys.exit(1)
+
+    nodes = kubecli.list_nodes()
+    node_id = []
+    for node in nodes:
+        instance_id = cloud_object.get_instance_id(node)
+        node_id.append(instance_id)
+    logging.info("node id list " + str(node_id))
+    for _ in range(runs):
+        logging.info("Starting cluster_shut_down scenario injection")
+        stopping_nodes = set(node_id)
+        multiprocess_nodes(cloud_object.stop_instances, node_id)
+        stopped_nodes = stopping_nodes.copy()
+        while len(stopping_nodes) > 0:
+            for node in stopping_nodes:
+                if type(node) is tuple:
+                    node_status = cloud_object.wait_until_stopped(node[1], node[0], timeout)
+                else:
+                    node_status = cloud_object.wait_until_stopped(node, timeout)
+
+                # Only want to remove node from stopping list when fully stopped/no error
+                if node_status:
+                    stopped_nodes.remove(node)
+
+            stopping_nodes = stopped_nodes.copy()
+
+        logging.info("Shutting down the cluster for the specified duration: %s" % (shut_down_duration))
+        time.sleep(shut_down_duration)
+        logging.info("Restarting the nodes")
+        restarted_nodes = set(node_id)
+        multiprocess_nodes(cloud_object.start_instances, node_id)
+        logging.info("Wait for each node to be running again")
+        not_running_nodes = restarted_nodes.copy()
+        while len(not_running_nodes) > 0:
+            for node in not_running_nodes:
+                if type(node) is tuple:
+                    node_status = cloud_object.wait_until_running(node[1], node[0], timeout)
+                else:
+                    node_status = cloud_object.wait_until_running(node, timeout)
+                if node_status:
+                    restarted_nodes.remove(node)
+            not_running_nodes = restarted_nodes.copy()
+        logging.info("Waiting for 150s to allow cluster component initialization")
+        time.sleep(150)
+
+        logging.info("Successfully injected cluster_shut_down scenario!")
+
+
+def run(scenarios_list, config, wait_duration):
+    failed_post_scenarios = []
+    for shut_down_config in scenarios_list:
+        if len(shut_down_config) > 1:
+            pre_action_output = post_actions.run("", shut_down_config[1])
+        else:
+            pre_action_output = ""
+        with open(shut_down_config[0], "r") as f:
+            shut_down_config_yaml = yaml.full_load(f)
+            shut_down_config_scenario = shut_down_config_yaml["cluster_shut_down_scenario"]
+            cluster_shut_down(shut_down_config_scenario)
+            logging.info("Waiting for the specified duration: %s" % (wait_duration))
+            time.sleep(wait_duration)
+            failed_post_scenarios = post_actions.check_recovery(
+                "", shut_down_config, failed_post_scenarios, pre_action_output
+            )
+            cerberus.publish_kraken_status(config, failed_post_scenarios)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -14,6 +14,7 @@ import kraken.litmus.common_litmus as common_litmus
 import kraken.time_actions.common_time_functions as time_actions
 import kraken.performance_dashboards.setup as performance_dashboards
 import kraken.pod_scenarios.setup as pod_scenarios
+import kraken.shut_down.common_shut_down_func as shut_down
 import kraken.node_actions.run as nodeaction
 import kraken.kube_burner.client as kube_burner
 
@@ -133,6 +134,8 @@ def main(cfg):
                             litmus_namespaces = common_litmus.run(
                                 scenarios_list, config, litmus_namespaces, litmus_uninstall, wait_duration,
                             )
+                        elif scenario_type == "cluster_shut_down_scenarios":
+                            shut_down.run(scenarios_list, config, wait_duration)
 
             iteration += 1
             logging.info("")

--- a/scenarios/cluster_shut_down_scenario.yml
+++ b/scenarios/cluster_shut_down_scenario.yml
@@ -1,0 +1,5 @@
+cluster_shut_down_scenario:                          # Scenario to stop all the nodes for specified duration and restart the nodes
+  runs: 1                                            # Number of times to execute the cluster_shut_down scenario
+  shut_down_duration: 150                            # duration in seconds to shut down the cluster
+  cloud_type: aws                                    # cloud type on which Kubernetes/OpenShift runs
+  timeout: 60                                        # Number of seconds to wait for each node to be stopped or running

--- a/scenarios/post_action_shut_down.py
+++ b/scenarios/post_action_shut_down.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import subprocess
+import logging
+import time
+import yaml
+
+
+def run(cmd):
+    out = ""
+    try:
+        output = subprocess.Popen(
+            cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        )
+        (out, err) = output.communicate()
+    except Exception as e:
+        logging.info("Failed to run %s, error: %s" % (cmd, e))
+    return out
+
+
+# Get cluster operators and return yaml
+def get_cluster_operators():
+    operators_status = run("kubectl get co -o yaml")
+    status_yaml = yaml.load(operators_status, Loader=yaml.FullLoader)
+    return status_yaml
+
+
+# Monitor cluster operators
+def monitor_cluster_operator(cluster_operators):
+    failed_operators = []
+    for operator in cluster_operators["items"]:
+        # loop through the conditions in the status section to find the dedgraded condition
+        if "status" in operator.keys() and "conditions" in operator["status"].keys():
+            for status_cond in operator["status"]["conditions"]:
+                # if the degraded status is not false, add it to the failed operators to return
+                if status_cond["type"] == "Degraded" and status_cond["status"] != "False":
+                    failed_operators.append(operator["metadata"]["name"])
+                    break
+        else:
+            logging.info("Can't find status of " + operator["metadata"]["name"])
+            failed_operators.append(operator["metadata"]["name"])
+    # return False if there are failed operators else return True
+    return failed_operators
+
+
+wait_duration = 10
+timeout = 900
+counter = 0
+
+counter = 0
+co_yaml = get_cluster_operators()
+failed_operators = monitor_cluster_operator(co_yaml)
+while len(failed_operators) > 0:
+    time.sleep(wait_duration)
+    co_yaml = get_cluster_operators()
+    failed_operators = monitor_cluster_operator(co_yaml)
+    if counter >= timeout:
+        print("Cluster operators are still degraded after " + str(timeout) + "seconds")
+        print("Degraded operators " + str(failed_operators))
+        exit(1)
+    counter += wait_duration
+
+not_ready = run("oc get nodes --no-headers | grep 'NotReady' | wc -l").rstrip()
+while int(not_ready) > 0:
+    time.sleep(wait_duration)
+    not_ready = run("oc get nodes --no-headers | grep 'NotReady' | wc -l").rstrip()
+    if counter >= timeout:
+        print("Nodes are still not ready after " + str(timeout) + "seconds")
+        exit(1)
+    counter += wait_duration
+
+worker_nodes = run("oc get nodes --no-headers | grep worker | egrep -v NotReady | awk '{print $1}'").rstrip()
+print("Worker nodes list \n" + str(worker_nodes))
+master_nodes = run("oc get nodes --no-headers | grep master | egrep -v NotReady | awk '{print $1}'").rstrip()
+print("Master nodes list \n" + str(master_nodes))
+infra_nodes = run("oc get nodes --no-headers | grep infra | egrep -v NotReady | awk '{print $1}'").rstrip()
+print("Infra nodes list \n" + str(infra_nodes))


### PR DESCRIPTION
### Description
Adding cluster shut down on the current cloud providers. Tried to add more useful logging and consistency of the functions across all the clouds we support

This is an updated version of [PR](https://github.com/cloud-bulldozer/kraken/pull/25) 

The one thing I didn't add is a retry count of how many retries we want to have for waiting for the vm's to be stopped or running. We have a timeout for one attempt at the vm getting to the specified status. Not sure if it's worth adding in a total retries counter to fail eventually if the vm's/ec instances never get to the wanted status. Not sure how often we will hit that but could happen. 

### Fixes
https://github.com/cloud-bulldozer/kraken/issues/63
