### PR TITLE
adding litmus logging

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,11 +20,11 @@ kraken:
         -   time_scenarios:                                # List of chaos time scenarios to load
             - scenarios/time_scenarios_example.yml
         -   litmus_scenarios:                              # List of litmus scenarios to load
-            - - https://raw.githubusercontent.com/cloud-bulldozer/kraken/master/scenarios/templates/litmus-rbac.yaml
+            - - scenarios/templates/litmus-rbac.yaml
               - scenarios/node_cpu_hog_engine.yaml
-            - - https://raw.githubusercontent.com/cloud-bulldozer/kraken/master/scenarios/templates/litmus-rbac.yaml
+            - - scenarios/templates/litmus-rbac.yaml
               - scenarios/node_mem_engine.yaml
-            - - https://raw.githubusercontent.com/cloud-bulldozer/kraken/master/scenarios/templates/litmus-rbac.yaml
+            - - scenarios/templates/litmus-rbac.yaml
               - scenarios/node_io_engine.yaml
         -   cluster_shut_down_scenarios:
             - - scenarios/cluster_shut_down_scenario.yml

--- a/kraken/invoke/command.py
+++ b/kraken/invoke/command.py
@@ -1,15 +1,14 @@
 import subprocess
 import logging
-import sys
 
 
 # Invokes a given command and returns the stdout
 def invoke(command, timeout=None):
+    output = ""
     try:
         output = subprocess.check_output(command, shell=True, universal_newlines=True, timeout=timeout)
     except Exception as e:
         logging.error("Failed to run %s, error: %s" % (command, e))
-        sys.exit(1)
     return output
 
 

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -142,6 +142,10 @@ def main(cfg):
                         elif scenario_type == "litmus_scenarios":
                             logging.info("Running litmus scenarios")
                             if not litmus_installed:
+                                # Will always uninstall first
+                                common_litmus.delete_chaos(litmus_namespace)
+                                common_litmus.delete_chaos_experiments(litmus_namespace)
+                                common_litmus.uninstall_litmus(litmus_version, litmus_namespace)
                                 common_litmus.install_litmus(litmus_version, litmus_namespace)
                                 common_litmus.deploy_all_experiments(litmus_version, litmus_namespace)
                                 litmus_installed = True
@@ -198,8 +202,8 @@ def main(cfg):
 
         if litmus_uninstall and litmus_installed:
             common_litmus.delete_chaos(litmus_namespace)
-            common_litmus.delete_experiments(litmus_namespace)
-            common_litmus.uninstall_litmus(litmus_version)
+            common_litmus.delete_chaos_experiments(litmus_namespace)
+            common_litmus.uninstall_litmus(litmus_version, litmus_namespace)
 
         if failed_post_scenarios:
             logging.error("Post scenarios are still failing at the end of all iterations")


### PR DESCRIPTION
### Description
Based on changes from https://github.com/cloud-bulldozer/kraken/pull/148; will need to rebase once that's merged

Some new changes to print the expected status the engine is waiting for 
```
2021-09-07 15:27:07,788 [INFO] Waiting for node-cpu-hog to be running
2021-09-07 15:27:18,177 [INFO] Waiting for node-cpu-hog to be completed
2021-09-07 15:30:17,787 [INFO] Chaos scenario:node-cpu-hog failed with error: Checking the status of nodes
2021-09-07 15:30:17,790 [INFO] See 'kubectl get chaosresult nginx-chaos-node-cpu-hog -n litmus -o yaml' for full results
2021-09-07 15:30:17,790 [INFO] Scenario: scenarios/node_cpu_hog_engine.yaml was not successfully injected, please check
```

Uninstalls litmus and deletes all litmus objects at beginning of run to have a fresh start 


### Fixes
https://github.com/cloud-bulldozer/kraken/issues/145