### PR TITLE
Time spacing fix

### DIFF
--- a/kraken/time_actions/common_time_functions.py
+++ b/kraken/time_actions/common_time_functions.py
@@ -78,7 +78,9 @@ def skew_time(scenario):
 # From kubectl/oc command get time output
 def parse_string_date(obj_datetime):
     try:
-        date_line = re.search(r"[a-zA-Z0-9_() .]*\w{3} \w{3} \d{2} \d{2}:\d{2}:\d{2} \w{3} " r"\d{4}\W*", obj_datetime)
+        date_line = re.search(
+            r"[a-zA-Z0-9_() .]*\w{3}\s{1,}\w{3}\s{1,}\d{2}\s{1,}\d{2}:\d{2}:\d{2}\s{1,}\w{3} " r"\d{4}\W*", obj_datetime
+        )
         return date_line.group().strip()
     except Exception:
         return ""


### PR DESCRIPTION
### Description
This fix should match on one or more spaces when checking the time/date has returned to the correct time 

I was not able to get the response to show the error that we had seen before but it should work
Format of date when error occured (2 spaces between Sep and 1) 
`Wed Sep  1 13:27:07 UTC 2021`


### Fixes
https://github.com/cloud-bulldozer/kraken/issues/146