### PR TITLE
Ignore validation for network policy creation

### DIFF
--- a/kraken/application_outage/actions.py
+++ b/kraken/application_outage/actions.py
@@ -38,7 +38,9 @@ spec:
                     f.write(rendered_spec)
                 # Block the traffic by creating network policy
                 logging.info("Creating the network policy")
-                runcommand.invoke("kubectl create -f %s -n %s" % ("kraken_network_policy.yaml", namespace))
+                runcommand.invoke(
+                    "kubectl create -f %s -n %s --validate=false" % ("kraken_network_policy.yaml", namespace)
+                )
 
                 # wait for the specified duration
                 logging.info("Waiting for the specified duration in the config: %s" % (duration))


### PR DESCRIPTION
### Description
This commit helps the cases where targeting application pods in a
namespace using pod-selector to create an outage fails because of
not being able to validate the selector.

Error message for reference:
error validating data: ValidationError(NetworkPolicy.spec.podSelector):
unknown field "app=foo" in io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector

