### PR TITLE
Expose setting the signal in the config

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,8 @@ kraken:
     kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
     port: 8081
-    publish_kraken_status: True
+    publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081
+    signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
     litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
     chaos_scenarios:                                       # List of policies/chaos scenarios to load

--- a/config/config_performance.yaml
+++ b/config/config_performance.yaml
@@ -2,6 +2,9 @@ kraken:
     distribution: openshift                                # Distribution can be kubernetes or openshift
     kubeconfig_path: /root/.kube/config                    # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
+    port: 8081
+    publish_kraken_status: True                            # Can be accessed at http://0.0.0.0:8081
+    signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
     litmus_version: v1.10.0                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
     chaos_scenarios:                                       # List of policies/chaos scenarios to load

--- a/docs/signal.md
+++ b/docs/signal.md
@@ -1,9 +1,12 @@
 ### Signaling to Kraken
-This functionality allows a user to be able to pause or stop the kraken run at any time no matter the number of iterations or dameon_mode set in the config
+This functionality allows a user to be able to pause or stop the kraken run at any time no matter the number of iterations or daemon_mode set in the config
 
 If publish_kraken_status is set to True in the config, kraken will start up a connection to a url at a certain port to decide if it should continue running
 
 By default it will get posted to http://0.0.0.0:8081/
+
+An example use case for this feature would be coordinating kraken runs based on the status of the service installation or load on the cluster
+
 
 
 #### States
@@ -19,11 +22,13 @@ There are 3 states in the kraken status
 
 #### Configuration
 
-In the config you need to set these 2 parameters to tell kraken which port to post the kraken run status to
+In the config you need to set these parameters to tell kraken which port to post the kraken run status to
 As well if you want to publish and stop running based on the kraken status or not
+The signal is set to `RUN` by default meaning it will continue to run the scenarios, it can set to `PAUSE` for Kraken to act as listener and wait until set to `RUN` before injecting chaos
 ```
     port: 8081
     publish_kraken_status: True
+    signal_state: RUN
 ```
 
 

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -44,6 +44,7 @@ def main(cfg):
         chaos_scenarios = config["kraken"].get("chaos_scenarios", [])
         publish_running_status = config["kraken"].get("publish_kraken_status", False)
         port = config["kraken"].get("port", "8081")
+        run_signal = config["kraken"].get("signal_state", "RUN")
         litmus_version = config["kraken"].get("litmus_version", "v1.9.1")
         litmus_uninstall = config["kraken"].get("litmus_uninstall", False)
         wait_duration = config["tunings"].get("wait_duration", 60)
@@ -83,13 +84,11 @@ def main(cfg):
             port = 8081
         address = ("0.0.0.0", port)
 
-        # Setting the first signal to RUN
         # If publish_running_status is False this should keep us going in our loop below
-        run_signal = "RUN"
         if publish_running_status:
             server_address = address[0]
             port = address[1]
-            logging.info("Publishing kraken go status at http://%s:%s" % (server_address, port))
+            logging.info("Publishing kraken status at http://%s:%s" % (server_address, port))
             server.start_server(address)
             publish_kraken_status(run_signal)
 

--- a/server.py
+++ b/server.py
@@ -32,7 +32,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.end_headers()
         with open("/tmp/kraken_status", "w+") as file:
-            file.write(str("STOP"))
+            file.write(str("RUN"))
 
     def set_stop(self):
         self.send_response(200)

--- a/set_stop_signal.py
+++ b/set_stop_signal.py
@@ -1,6 +1,6 @@
-import http
+import http.client as cli
 
-conn = http.client.HTTPConnection("0.0.0.0", "<port>")
+conn = cli.HTTPConnection("0.0.0.0", "<port>")
 
 conn.request("POST", "/STOP", {})
 


### PR DESCRIPTION
### Description
This commit enables users to start Kraken to act as listener by setting
the signal to PAUSE in the config to get the cluster to a desired test or
run any setup before injecting chaos by setting the signal to RUN. This
helps in cases where we have test cases that need to coordinate the chaos
at a desired time depending on the state of the cluster/test run.


