### PR TITLE
Porting of the arcaflow scenarios to engine v0.9.0 (syntax version 0.2.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 PyYAML>=5.1
 aliyun-python-sdk-core==2.13.36
 aliyun-python-sdk-ecs==4.24.25
-arcaflow >= 0.8.0
+arcaflow >= 0.9.0
 arcaflow-plugin-sdk >= 0.10.0
 azure-identity
 azure-keyvault

--- a/scenarios/arcaflow/cpu-hog/config.yaml
+++ b/scenarios/arcaflow/cpu-hog/config.yaml
@@ -1,7 +1,11 @@
----
-deployer:
-  connection: {}
-  type: kubernetes
+deployers:
+  image:
+    deployer_name: kubernetes
+    connection:
+      cacert: ''
+      cert: ''
+      host: ''
+      key: ''
 log:
   level: debug
 logged_outputs:

--- a/scenarios/arcaflow/cpu-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/cpu-hog/sub-workflow.yaml
@@ -1,4 +1,4 @@
-version: v0.1.0
+version: v0.2.0
 input:
   root: RootObject
   objects:
@@ -61,11 +61,15 @@ input:
 
 steps:
   kubeconfig:
-    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.2.0
+    plugin:
+      src: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.2.0
+      deployment_type: image
     input:
       kubeconfig: !expr $.input.kubeconfig
   stressng:
-    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.5.0
+    plugin:
+      src: quay.io/arcalot/arcaflow-plugin-stressng:0.5.0
+      deployment_type: image
     step: workload
     input:
       cleanup: "true"
@@ -77,8 +81,8 @@ steps:
             cpu_method: !expr $.input.cpu_method
             cpu_load: !expr $.input.cpu_load_percentage
     deploy:
-      type: kubernetes
       connection: !expr $.steps.kubeconfig.outputs.success.connection
+      deployer_name: kubernetes
       pod:
         metadata:
           namespace: !expr $.input.namespace

--- a/scenarios/arcaflow/cpu-hog/workflow.yaml
+++ b/scenarios/arcaflow/cpu-hog/workflow.yaml
@@ -1,4 +1,4 @@
-version: v0.1.0
+version: v0.2.0
 input:
   root: RootObject
   objects:

--- a/scenarios/arcaflow/io-hog/config.yaml
+++ b/scenarios/arcaflow/io-hog/config.yaml
@@ -1,6 +1,11 @@
-deployer:
-  connection: {}
-  type: kubernetes
+deployers:
+  image:
+    deployer_name: kubernetes
+    connection:
+      cacert: ''
+      cert: ''
+      host: ''
+      key: ''
 log:
   level: debug
 logged_outputs:

--- a/scenarios/arcaflow/io-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/io-hog/sub-workflow.yaml
@@ -1,4 +1,4 @@
-version: v0.1.0
+version: v0.2.0
 input:
   root: RootObject
   objects:
@@ -74,7 +74,7 @@ input:
                          the node storage only hosPath mode is currently supported
           type:
             type_id: object
-            id: k8s_volume
+            id: Volume
             properties:
               name:
                 display:
@@ -96,11 +96,15 @@ input:
 
 steps:
   kubeconfig:
-    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.2.0
+    plugin:
+      src: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.2.0
+      deployment_type: image
     input:
       kubeconfig: !expr $.input.kubeconfig
   stressng:
-    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.5.0
+    plugin:
+      src: quay.io/arcalot/arcaflow-plugin-stressng:0.5.0
+      deployment_type: image
     step: workload
     input:
       cleanup: "true"
@@ -114,7 +118,7 @@ steps:
             hdd_write_size: !expr $.input.io_block_size
 
     deploy:
-      type: kubernetes
+      deployer_name: kubernetes
       connection: !expr $.steps.kubeconfig.outputs.success.connection
       pod:
         metadata:

--- a/scenarios/arcaflow/io-hog/workflow.yaml
+++ b/scenarios/arcaflow/io-hog/workflow.yaml
@@ -1,4 +1,4 @@
-version: v0.1.0
+version: v0.2.0
 input:
   root: RootObject
   objects:
@@ -81,7 +81,7 @@ input:
                       the node storage only hosPath mode is currently supported
                   type:
                     type_id: object
-                    id: k8s_volume
+                    id: Volume
                     properties:
                       name:
                         display:

--- a/scenarios/arcaflow/memory-hog/config.yaml
+++ b/scenarios/arcaflow/memory-hog/config.yaml
@@ -1,7 +1,11 @@
----
-deployer:
-  connection: {}
-  type: kubernetes
+deployers:
+  image:
+    deployer_name: kubernetes
+    connection:
+      cacert: ''
+      cert: ''
+      host: ''
+      key: ''
 log:
   level: debug
 logged_outputs:

--- a/scenarios/arcaflow/memory-hog/sub-workflow.yaml
+++ b/scenarios/arcaflow/memory-hog/sub-workflow.yaml
@@ -1,4 +1,4 @@
-version: v0.1.0
+version: v0.2.0
 input:
   root: RootObject
   objects:
@@ -53,11 +53,15 @@ input:
 
 steps:
   kubeconfig:
-    plugin: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.2.0
+    plugin:
+      src: quay.io/arcalot/arcaflow-plugin-kubeconfig:0.2.0
+      deployment_type: image
     input:
       kubeconfig: !expr $.input.kubeconfig
   stressng:
-    plugin: quay.io/arcalot/arcaflow-plugin-stressng:0.5.0
+    plugin:
+      src: quay.io/arcalot/arcaflow-plugin-stressng:0.5.0
+      deployment_type: image
     step: workload
     input:
       cleanup: "true"
@@ -68,7 +72,7 @@ steps:
             vm: !expr $.input.vm_workers
             vm_bytes: !expr $.input.vm_bytes
     deploy:
-      type: kubernetes
+      deployer_name: kubernetes
       connection: !expr $.steps.kubeconfig.outputs.success.connection
       pod:
         metadata:

--- a/scenarios/arcaflow/memory-hog/workflow.yaml
+++ b/scenarios/arcaflow/memory-hog/workflow.yaml
@@ -1,4 +1,4 @@
-version: v0.1.0
+version: v0.2.0
 input:
   root: RootObject
   objects:


### PR DESCRIPTION
Porting of the current hog scenarios to the new engine syntax. This version of the engine introduces several enhancement regarding multiple deployers and parallelism, but there are breaking changes in the workflow syntax.