### PR TITLE
Fixes the critical alerts exception with the start_time > end_time

### DIFF
--- a/run_kraken.py
+++ b/run_kraken.py
@@ -203,6 +203,7 @@ def main(cfg):
 
         # Capture the start time
         start_time = int(time.time())
+
         chaos_telemetry = ChaosRunTelemetry()
         chaos_telemetry.run_uuid = run_uuid
         # Loop to run the chaos starts here
@@ -345,7 +346,13 @@ def main(cfg):
 
                             ##PROM
                             query = r"""ALERTS{severity="critical"}"""
-                            critical_alerts = prometheus.process_prom_query_in_range(query, datetime.datetime.fromtimestamp(start_time))
+                            end_time = datetime.datetime.now()
+                            critical_alerts = prometheus.process_prom_query_in_range(
+                                query,
+                                start_time = datetime.datetime.fromtimestamp(start_time),
+                                end_time = end_time
+
+                            )
                             critical_alerts_count = len(critical_alerts)
                             if critical_alerts_count > 0:
                                 logging.error("Critical alerts are firing: %s", critical_alerts)


### PR DESCRIPTION
If datetime.now() is defined as default parameter value, the date is calculated at the moment the intepreter defines the function and not when the function is called (as I thought), that's the reason why the start_time is considered greater than the end_time by the prometheus API as explained [here](https://stackoverflow.com/questions/62399546/python-datetime-now-as-a-default-function-parameter-return-same-value-in-diffe).
This change fixes the issue.

This has been enforced also on the [krkn-lib side](https://github.com/redhat-chaos/krkn-lib/pull/87), but this fix will solve the problem immediately without the need of updating to the next version.