### PR TITLE
Adding check if connection was properly set

### DIFF
--- a/run_kraken.py
+++ b/run_kraken.py
@@ -163,8 +163,13 @@ def main(cfg):
             if prometheus_url is None:
                 try:
                     connection_data = ocpcli.get_prometheus_api_connection_data()
-                    prometheus_url = connection_data.endpoint
-                    prometheus_bearer_token = connection_data.token
+                    if connection_data:
+                        prometheus_url = connection_data.endpoint
+                        prometheus_bearer_token = connection_data.token
+                    else: 
+                        # If can't make a connection, set alerts to false
+                        enable_alerts = False
+                        critical_alerts = False
                 except Exception:
                     logging.error("invalid distribution selected, running openshift scenarios against kubernetes cluster."
                                   "Please set 'kubernetes' in config.yaml krkn.platform and try again")
@@ -341,7 +346,7 @@ def main(cfg):
                             failed_post_scenarios, scenario_telemetries = network_chaos.run(scenarios_list, config, wait_duration, kubecli, telemetry_k8s)
 
                         # Check for critical alerts when enabled
-                        if enable_alerts and check_critical_alerts :
+                        if enable_alerts and check_critical_alerts:
                             logging.info("Checking for critical alerts firing post choas")
 
                             ##PROM


### PR DESCRIPTION
If prometheus is not able to be set properly, we dont want to check the alerts (critical or file). The distribution would still be openshift but could have issues like in the HCP configuration case 


```
+ python3.9 /tmp/kraken/run_kraken.py --config=/tmp/memory_hog_config.yaml -o /tmp/report.out
 _              _              
| | ___ __ __ _| | _____ _ __  
| |/ / '__/ _` | |/ / _ \ '_ \ 
|   <| | | (_| |   <  __/ | | |
|_|\_\_|  \__,_|_|\_\___|_| |_|
                               


2024-02-08 21:42:11,814 [INFO] Starting kraken
2024-02-08 21:42:11,821 [INFO] Initializing client to talk to the Kubernetes cluster
2024-02-08 21:42:11,821 [INFO] Generated a uuid for the run: ea06930a-1d82-4c2e-bc28-d51f87f77107
2024-02-08 21:42:12,173 [INFO] Fetching cluster info
2024-02-08 21:42:12,616 [ERROR] failed to create token for SA: prometheus-k8s on namespace: openshift-monitoring with error: (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict({'Audit-Id': '066455de-1d85-40e2-bbe5-9f74716e7bae', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload', 'X-Kubernetes-Pf-Flowschema-Uid': '05e59b10-a909-407e-a5c0-f8443390f5c1', 'X-Kubernetes-Pf-Prioritylevel-Uid': '44b5b6a9-2155-4b56-86f2-c86534b0f9f9', 'Date': 'Thu, 08 Feb 2024 21:42:12 GMT', 'Content-Length': '218'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"serviceaccounts \"prometheus-k8s\" not found","reason":"NotFound","details":{"name":"prometheus-k8s","kind":"serviceaccounts"},"code":404}


Traceback (most recent call last):
  File "/tmp/kraken/run_kraken.py", line 458, in <module>
    main(options.cfg)
  File "/tmp/kraken/run_kraken.py", line 163, in main
    prometheus_url = connection_data.endpoint
AttributeError: 'NoneType' object has no attribute 'endpoint'
```
