### PR TITLE
Allow critical alerts check when enable_alerts is disabled

### DIFF
--- a/run_kraken.py
+++ b/run_kraken.py
@@ -184,7 +184,7 @@ def main(cfg):
         telemetry_ocp = KrknTelemetryOpenshift(safe_logger, ocpcli)
         telemetry_elastic = KrknElastic(safe_logger,elastic_url)
 
-        if enable_alerts:
+        if enable_alerts or check_critical_alerts:
             prometheus = KrknPrometheus(prometheus_url, prometheus_bearer_token)
 
         logging.info("Server URL: %s" % kubecli.get_host())
@@ -347,7 +347,7 @@ def main(cfg):
                             failed_post_scenarios, scenario_telemetries = network_chaos.run(scenarios_list, config, wait_duration, kubecli, telemetry_k8s)
 
                         # Check for critical alerts when enabled
-                        if enable_alerts and check_critical_alerts:
+                        if check_critical_alerts:
                             logging.info("Checking for critical alerts firing post choas")
 
                             ##PROM


### PR DESCRIPTION
This covers use case where user wants to just check for critical alerts post chaos without having to enable the alerts evaluation feature which evaluates prom queries specified in an alerts file.