### PR TITLE
Add /usr/local/bin to the path for krkn images

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -5,6 +5,7 @@ FROM mcr.microsoft.com/azure-cli:latest as azure-cli
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
 ENV KUBECONFIG /root/.kube/config
+ENV PATH=$PATH:/usr/local/bin
 
 # Copy azure client binary from azure-cli image
 COPY --from=azure-cli /usr/local/bin/az /usr/bin/az

--- a/containers/Dockerfile-ppc64le
+++ b/containers/Dockerfile-ppc64le
@@ -7,6 +7,7 @@ FROM mcr.microsoft.com/azure-cli:latest as azure-cli
 LABEL org.opencontainers.image.authors="Red Hat OpenShift Chaos Engineering"
 
 ENV KUBECONFIG /root/.kube/config
+ENV PATH=$PATH:/usr/local/bin
 
 # Copy azure client binary from azure-cli image
 COPY --from=azure-cli /usr/local/bin/az /usr/bin/az


### PR DESCRIPTION
This is needed to ensure oc and kubectl binaries under /usr/local/bin are accessible.