### PR TITLE
Bump cryptography version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ zope.interface==5.4.0
 
 git+https://github.com/krkn-chaos/arcaflow-plugin-kill-pod.git
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
-cryptography>=42.0.2 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=42.0.4 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
This is need to fix the security vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2024-26130.
Note: Reported by FOSSA.