### PR TITLE
Remove container status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Krkn aka Kraken
-[![Docker Repository on Quay](https://quay.io/repository/krkn-chaos/krkn/status "Docker Repository on Quay")](https://quay.io/repository/krkn-chaos/krkn?tab=tags&tag=latest)
 ![Workflow-Status](https://github.com/krkn-chaos/krkn/actions/workflows/docker-image.yml/badge.svg)
 
 ![Krkn logo](media/logo.png)


### PR DESCRIPTION
Quay is no longer exposing it correctly: https://quay.io/repository/krkn-chaos/krkn/status