### PR TITLE
Do not fail GCP auth when GOOGLE_APPLICATION_CREDENTIALS is not found

### DIFF
--- a/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
@@ -14,13 +14,15 @@ from krkn_lib.k8s import KrknKubernetes
 
 class GCP:
     def __init__(self):
-        try:
+        if "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
             gapp_creds = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
             with open(gapp_creds, "r") as f:
                 f_str = f.read()
                 self.project = json.loads(f_str)["project_id"]
             # self.project = runcommand.invoke("gcloud config get-value project").split("/n")[0].strip()
             logging.info("project " + str(self.project) + "!")
+
+        try:
             credentials = GoogleCredentials.get_application_default()
             self.client = discovery.build(
                 "compute", "v1", credentials=credentials, cache_discovery=False

--- a/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
@@ -19,7 +19,6 @@ class GCP:
             with open(gapp_creds, "r") as f:
                 f_str = f.read()
                 self.project = json.loads(f_str)["project_id"]
-            # self.project = runcommand.invoke("gcloud config get-value project").split("/n")[0].strip()
             logging.info("project " + str(self.project) + "!")
 
         try:


### PR DESCRIPTION
Auth could have been set up using the Google Cloud CLI:

- `gcloud init`
- `gcloud auth application-default login`