### PR TITLE
Convert thresholds to float

### DIFF
--- a/krkn/chaos_recommender/analysis.py
+++ b/krkn/chaos_recommender/analysis.py
@@ -29,9 +29,9 @@ def calculate_zscores(data):
 
 
 def identify_outliers(data, threshold):
-    outliers_cpu = data[data["CPU"] > threshold]["Service"].tolist()
-    outliers_memory = data[data["Memory"] > threshold]["Service"].tolist()
-    outliers_network = data[data["Network"] > threshold]["Service"].tolist()
+    outliers_cpu = data[data["CPU"] > float(threshold)]["Service"].tolist()
+    outliers_memory = data[data["Memory"] > float(threshold)]["Service"].tolist()
+    outliers_network = data[data["Network"] > float(threshold)]["Service"].tolist()
 
     return outliers_cpu, outliers_memory, outliers_network
 
@@ -39,13 +39,13 @@ def identify_outliers(data, threshold):
 def get_services_above_heatmap_threshold(dataframe, cpu_threshold, mem_threshold):
     # Filter the DataFrame based on CPU_HEATMAP and MEM_HEATMAP thresholds
     filtered_df = dataframe[
-        ((dataframe["CPU"] / dataframe["CPU_LIMITS"]) > cpu_threshold)
+        ((dataframe["CPU"] / dataframe["CPU_LIMITS"]) > float(cpu_threshold))
     ]
     # Get the lists of services
     cpu_services = filtered_df["service"].tolist()
 
     filtered_df = dataframe[
-        ((dataframe["MEM"] / dataframe["MEM_LIMITS"]) > mem_threshold)
+        ((dataframe["MEM"] / dataframe["MEM_LIMITS"]) > float(mem_threshold))
     ]
     mem_services = filtered_df["service"].tolist()
 

--- a/utils/chaos_recommender/chaos_recommender.py
+++ b/utils/chaos_recommender/chaos_recommender.py
@@ -112,12 +112,12 @@ def parse_arguments(parser):
         default=[],
         help="Memory related chaos tests (space separated list)",
     )
-    parser.add_argument("--threshold", action="store", default="", help="Threshold")
+    parser.add_argument("--threshold", action="store", help="Threshold")
     parser.add_argument(
-        "--cpu-threshold", action="store", default="", help="CPU threshold"
+        "--cpu-threshold", action="store", help="CPU threshold"
     )
     parser.add_argument(
-        "--mem-threshold", action="store", default="", help="Memory threshold"
+        "--mem-threshold", action="store", help="Memory threshold"
     )
 
     return parser.parse_args()
@@ -141,9 +141,9 @@ def read_configuration(config_file_path):
     prometheus_endpoint = config.get("prometheus_endpoint")
     auth_token = config.get("auth_token")
     scrape_duration = get_yaml_item_value(config, "scrape_duration", "10m")
-    threshold = get_yaml_item_value(config, "threshold", ".7")
-    heatmap_cpu_threshold = get_yaml_item_value(config, "cpu_threshold", ".5")
-    heatmap_mem_threshold = get_yaml_item_value(config, "mem_threshold", ".3")
+    threshold = get_yaml_item_value(config, "threshold")
+    heatmap_cpu_threshold = get_yaml_item_value(config, "cpu_threshold")
+    heatmap_mem_threshold = get_yaml_item_value(config, "mem_threshold")
     output_file = config.get("json_output_file", False)
     if output_file is True:
         output_path = config.get("json_output_folder_path")


### PR DESCRIPTION
This is needed to avoid issues due to comparing two different data types: TypeError: Invalid comparison between dtype=float64 and str. This commit also avoids setting defaults for the thresholds to make it mandatory for the users to define them as it plays a key role in determining the outliers.