### PR TITLE
Node timing

### DIFF
--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -99,13 +99,13 @@ class AbstractScenarioPlugin(ABC):
                 int(scenario_telemetry.start_timestamp),
                 int(scenario_telemetry.end_timestamp),
             )
-            utils.populate_cluster_events(
-                scenario_telemetry,
-                parsed_scenario_config,
-                telemetry.get_lib_kubernetes(),
-                int(scenario_telemetry.start_timestamp),
-                int(scenario_telemetry.end_timestamp),
-            )
+            # utils.populate_cluster_events(
+            #     scenario_telemetry,
+            #     parsed_scenario_config,
+            #     telemetry.get_lib_kubernetes(),
+            #     int(scenario_telemetry.start_timestamp),
+            #     int(scenario_telemetry.end_timestamp),
+            # )
 
             if scenario_telemetry.exit_status != 0:
                 failed_scenarios.append(scenario_config)

--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -99,13 +99,13 @@ class AbstractScenarioPlugin(ABC):
                 int(scenario_telemetry.start_timestamp),
                 int(scenario_telemetry.end_timestamp),
             )
-            # utils.populate_cluster_events(
-            #     scenario_telemetry,
-            #     parsed_scenario_config,
-            #     telemetry.get_lib_kubernetes(),
-            #     int(scenario_telemetry.start_timestamp),
-            #     int(scenario_telemetry.end_timestamp),
-            # )
+            utils.populate_cluster_events(
+                scenario_telemetry,
+                parsed_scenario_config,
+                telemetry.get_lib_kubernetes(),
+                int(scenario_telemetry.start_timestamp),
+                int(scenario_telemetry.end_timestamp),
+            )
 
             if scenario_telemetry.exit_status != 0:
                 failed_scenarios.append(scenario_config)

--- a/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
@@ -14,15 +14,15 @@ class abstract_node_scenarios:
         self.kubecli = kubecli
 
     # Node scenario to start the node
-    def node_start_scenario(self, instance_kill_count, node, timeout):
+    def node_start_scenario(self, instance_kill_count, node, timeout, affected_node):
         pass
 
     # Node scenario to stop the node
-    def node_stop_scenario(self, instance_kill_count, node, timeout):
+    def node_stop_scenario(self, instance_kill_count, node, timeout, affected_node):
         pass
 
     # Node scenario to stop and then start the node
-    def node_stop_start_scenario(self, instance_kill_count, node, timeout, duration):
+    def node_stop_start_scenario(self, instance_kill_count, node, timeout, duration, affected_node):
         logging.info("Starting node_stop_start_scenario injection")
         self.node_stop_scenario(instance_kill_count, node, timeout)
         logging.info("Waiting for %s seconds before starting the node" % (duration))
@@ -30,7 +30,7 @@ class abstract_node_scenarios:
         self.node_start_scenario(instance_kill_count, node, timeout)
         logging.info("node_stop_start_scenario has been successfully injected!")
 
-    def helper_node_stop_start_scenario(self, instance_kill_count, node, timeout):
+    def helper_node_stop_start_scenario(self, instance_kill_count, node, timeout, affected_node):
         logging.info("Starting helper_node_stop_start_scenario injection")
         self.helper_node_stop_scenario(instance_kill_count, node, timeout)
         self.helper_node_start_scenario(instance_kill_count, node, timeout)
@@ -51,15 +51,15 @@ class abstract_node_scenarios:
             logging.error("node_disk_detach_attach_scenario failed!")
 
     # Node scenario to terminate the node
-    def node_termination_scenario(self, instance_kill_count, node, timeout):
+    def node_termination_scenario(self, instance_kill_count, node, timeout, affected_node):
         pass
 
     # Node scenario to reboot the node
-    def node_reboot_scenario(self, instance_kill_count, node, timeout):
+    def node_reboot_scenario(self, instance_kill_count, node, timeout, affected_node):
         pass
 
     # Node scenario to stop the kubelet
-    def stop_kubelet_scenario(self, instance_kill_count, node, timeout):
+    def stop_kubelet_scenario(self, instance_kill_count, node, timeout, affected_node):
         for _ in range(instance_kill_count):
             try:
                 logging.info("Starting stop_kubelet_scenario injection")
@@ -67,7 +67,8 @@ class abstract_node_scenarios:
                 runcommand.run(
                     "oc debug node/" + node + " -- chroot /host systemctl stop kubelet"
                 )
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
+                
                 logging.info("The kubelet of the node %s has been stopped" % (node))
                 logging.info("stop_kubelet_scenario has been successfuly injected!")
             except Exception as e:
@@ -79,14 +80,14 @@ class abstract_node_scenarios:
                 raise e
 
     # Node scenario to stop and start the kubelet
-    def stop_start_kubelet_scenario(self, instance_kill_count, node, timeout):
+    def stop_start_kubelet_scenario(self, instance_kill_count, node, timeout, affected_node):
         logging.info("Starting stop_start_kubelet_scenario injection")
-        self.stop_kubelet_scenario(instance_kill_count, node, timeout)
-        self.node_reboot_scenario(instance_kill_count, node, timeout)
+        self.stop_kubelet_scenario(instance_kill_count, node, timeout, affected_node)
+        self.node_reboot_scenario(instance_kill_count, node, timeout, affected_node)
         logging.info("stop_start_kubelet_scenario has been successfully injected!")
 
     # Node scenario to restart the kubelet
-    def restart_kubelet_scenario(self, instance_kill_count, node, timeout):
+    def restart_kubelet_scenario(self, instance_kill_count, node, timeout, affected_node):
         for _ in range(instance_kill_count):
             try:
                 logging.info("Starting restart_kubelet_scenario injection")
@@ -96,8 +97,8 @@ class abstract_node_scenarios:
                     + node
                     + " -- chroot /host systemctl restart kubelet &"
                 )
-                nodeaction.wait_for_not_ready_status(node, timeout, self.kubecli)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_not_ready_status(node, timeout, self.kubecli, affected_node)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info("The kubelet of the node %s has been restarted" % (node))
                 logging.info("restart_kubelet_scenario has been successfuly injected!")
             except Exception as e:
@@ -109,7 +110,7 @@ class abstract_node_scenarios:
                 raise e
 
     # Node scenario to crash the node
-    def node_crash_scenario(self, instance_kill_count, node, timeout):
+    def node_crash_scenario(self, instance_kill_count, node, timeout, affected_node):
         for _ in range(instance_kill_count):
             try:
                 logging.info("Starting node_crash_scenario injection")

--- a/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
@@ -30,6 +30,8 @@ class abstract_node_scenarios:
         logging.info("Waiting for %s seconds before starting the node" % (duration))
         time.sleep(duration)
         self.node_start_scenario(instance_kill_count, node, timeout)
+
+        logging.info('affected nodes ' + str(self.affected_nodes_status.affected_nodes))
         self.affected_nodes_status.merge_affected_nodes()
         logging.info("node_stop_start_scenario has been successfully injected!")
 

--- a/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
@@ -30,8 +30,6 @@ class abstract_node_scenarios:
         logging.info("Waiting for %s seconds before starting the node" % (duration))
         time.sleep(duration)
         self.node_start_scenario(instance_kill_count, node, timeout)
-
-        logging.info('affected nodes ' + str(self.affected_nodes_status.affected_nodes))
         self.affected_nodes_status.merge_affected_nodes()
         logging.info("node_stop_start_scenario has been successfully injected!")
 

--- a/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
@@ -4,33 +4,39 @@ import time
 import krkn.invoke.command as runcommand
 import krkn.scenario_plugins.node_actions.common_node_functions as nodeaction
 from krkn_lib.k8s import KrknKubernetes
-
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
 
 # krkn_lib
 class abstract_node_scenarios:
     kubecli: KrknKubernetes
+    affected_nodes_status: AffectedNodeStatus
 
-    def __init__(self, kubecli: KrknKubernetes):
+    def __init__(self, kubecli: KrknKubernetes, affected_nodes_status: AffectedNodeStatus):
         self.kubecli = kubecli
+        self.affected_nodes_status = affected_nodes_status
+
+    def add_affected_node(self, affected_node: AffectedNode):
+        self.affected_node_status.affected_nodes.append(affected_node)
 
     # Node scenario to start the node
-    def node_start_scenario(self, instance_kill_count, node, timeout, affected_node):
+    def node_start_scenario(self, instance_kill_count, node, timeout):
         pass
 
     # Node scenario to stop the node
-    def node_stop_scenario(self, instance_kill_count, node, timeout, affected_node):
+    def node_stop_scenario(self, instance_kill_count, node, timeout):
         pass
 
     # Node scenario to stop and then start the node
-    def node_stop_start_scenario(self, instance_kill_count, node, timeout, duration, affected_node):
+    def node_stop_start_scenario(self, instance_kill_count, node, timeout, duration):
         logging.info("Starting node_stop_start_scenario injection")
         self.node_stop_scenario(instance_kill_count, node, timeout)
         logging.info("Waiting for %s seconds before starting the node" % (duration))
         time.sleep(duration)
         self.node_start_scenario(instance_kill_count, node, timeout)
+        self.affected_nodes_status.merge_affected_nodes()
         logging.info("node_stop_start_scenario has been successfully injected!")
 
-    def helper_node_stop_start_scenario(self, instance_kill_count, node, timeout, affected_node):
+    def helper_node_stop_start_scenario(self, instance_kill_count, node, timeout):
         logging.info("Starting helper_node_stop_start_scenario injection")
         self.helper_node_stop_scenario(instance_kill_count, node, timeout)
         self.helper_node_start_scenario(instance_kill_count, node, timeout)
@@ -51,16 +57,17 @@ class abstract_node_scenarios:
             logging.error("node_disk_detach_attach_scenario failed!")
 
     # Node scenario to terminate the node
-    def node_termination_scenario(self, instance_kill_count, node, timeout, affected_node):
+    def node_termination_scenario(self, instance_kill_count, node, timeout):
         pass
 
     # Node scenario to reboot the node
-    def node_reboot_scenario(self, instance_kill_count, node, timeout, affected_node):
+    def node_reboot_scenario(self, instance_kill_count, node, timeout):
         pass
 
     # Node scenario to stop the kubelet
-    def stop_kubelet_scenario(self, instance_kill_count, node, timeout, affected_node):
+    def stop_kubelet_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting stop_kubelet_scenario injection")
                 logging.info("Stopping the kubelet of the node %s" % (node))
@@ -78,17 +85,20 @@ class abstract_node_scenarios:
                 )
                 logging.error("stop_kubelet_scenario injection failed!")
                 raise e
+            self.add_affected_node(affected_node)
 
     # Node scenario to stop and start the kubelet
-    def stop_start_kubelet_scenario(self, instance_kill_count, node, timeout, affected_node):
+    def stop_start_kubelet_scenario(self, instance_kill_count, node, timeout):
         logging.info("Starting stop_start_kubelet_scenario injection")
-        self.stop_kubelet_scenario(instance_kill_count, node, timeout, affected_node)
-        self.node_reboot_scenario(instance_kill_count, node, timeout, affected_node)
+        self.stop_kubelet_scenario(instance_kill_count, node, timeout)
+        self.node_reboot_scenario(instance_kill_count, node, timeout)
+        self.affected_nodes_status.merge_affected_nodes()
         logging.info("stop_start_kubelet_scenario has been successfully injected!")
 
     # Node scenario to restart the kubelet
-    def restart_kubelet_scenario(self, instance_kill_count, node, timeout, affected_node):
+    def restart_kubelet_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting restart_kubelet_scenario injection")
                 logging.info("Restarting the kubelet of the node %s" % (node))
@@ -98,7 +108,7 @@ class abstract_node_scenarios:
                     + " -- chroot /host systemctl restart kubelet &"
                 )
                 nodeaction.wait_for_not_ready_status(node, timeout, self.kubecli, affected_node)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli,affected_node)
                 logging.info("The kubelet of the node %s has been restarted" % (node))
                 logging.info("restart_kubelet_scenario has been successfuly injected!")
             except Exception as e:
@@ -108,9 +118,10 @@ class abstract_node_scenarios:
                 )
                 logging.error("restart_kubelet_scenario injection failed!")
                 raise e
+            self.add_affected_node(affected_node)
 
     # Node scenario to crash the node
-    def node_crash_scenario(self, instance_kill_count, node, timeout, affected_node):
+    def node_crash_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
             try:
                 logging.info("Starting node_crash_scenario injection")

--- a/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
@@ -15,9 +15,6 @@ class abstract_node_scenarios:
         self.kubecli = kubecli
         self.affected_nodes_status = affected_nodes_status
 
-    def add_affected_node(self, affected_node: AffectedNode):
-        self.affected_node_status.affected_nodes.append(affected_node)
-
     # Node scenario to start the node
     def node_start_scenario(self, instance_kill_count, node, timeout):
         pass

--- a/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
@@ -18,7 +18,7 @@ from krkn.scenario_plugins.node_actions.abstract_node_scenarios import (
     abstract_node_scenarios,
 )
 from krkn_lib.k8s import KrknKubernetes
-
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
 
 class Alibaba:
     def __init__(self):
@@ -215,8 +215,10 @@ class Alibaba:
 
 # krkn_lib
 class alibaba_node_scenarios(abstract_node_scenarios):
-    def __init__(self, kubecli: KrknKubernetes):
+    def __init__(self, kubecli: KrknKubernetes, affected_nodes_status: AffectedNodeStatus):
+        super().__init__(kubecli, affected_nodes_status)
         self.alibaba = Alibaba()
+        
 
     # Node scenario to start the node
     def node_start_scenario(self, instance_kill_count, node, timeout):

--- a/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
@@ -161,8 +161,9 @@ class Alibaba:
             return None
 
     # Wait until the node instance is running
-    def wait_until_running(self, instance_id, timeout):
+    def wait_until_running(self, instance_id, timeout, affected_node):
         time_counter = 0
+        start_time = time.time()
         status = self.get_vm_status(instance_id)
         while status != "Running":
             status = self.get_vm_status(instance_id)
@@ -174,11 +175,15 @@ class Alibaba:
             if time_counter >= timeout:
                 logging.info("ECS %s is still not ready in allotted time" % instance_id)
                 return False
+        end_time = time.time()
+        if affected_node:
+            affected_node.set_affected_node_status("running", end_time - start_time)
         return True
 
     # Wait until the node instance is stopped
-    def wait_until_stopped(self, instance_id, timeout):
+    def wait_until_stopped(self, instance_id, timeout, affected_node):
         time_counter = 0
+        start_time = time.time()
         status = self.get_vm_status(instance_id)
         while status != "Stopped":
             status = self.get_vm_status(instance_id)
@@ -192,10 +197,14 @@ class Alibaba:
                     "Vm %s is still not stopped in allotted time" % instance_id
                 )
                 return False
+        end_time = time.time()
+        if affected_node:
+            affected_node.set_affected_node_status("running", end_time - start_time)
         return True
 
     # Wait until the node instance is terminated
-    def wait_until_released(self, instance_id, timeout):
+    def wait_until_released(self, instance_id, timeout, affected_node):
+        start_time = time.time()
         statuses = self.get_vm_status(instance_id)
         time_counter = 0
         while statuses and statuses != "Released":
@@ -210,6 +219,9 @@ class Alibaba:
                 return False
 
         logging.info("ECS %s is released" % instance_id)
+        end_time = time.time()
+        if affected_node:
+            affected_node.set_affected_node_status("terminated", end_time - start_time)
         return True
 
 
@@ -223,6 +235,7 @@ class alibaba_node_scenarios(abstract_node_scenarios):
     # Node scenario to start the node
     def node_start_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_start_scenario injection")
                 vm_id = self.alibaba.get_instance_id(node)
@@ -230,8 +243,8 @@ class alibaba_node_scenarios(abstract_node_scenarios):
                     "Starting the node %s with instance ID: %s " % (node, vm_id)
                 )
                 self.alibaba.start_instances(vm_id)
-                self.alibaba.wait_until_running(vm_id, timeout)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                self.alibaba.wait_until_running(vm_id, timeout, affected_node)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info("Node with instance ID: %s is in running state" % node)
                 logging.info("node_start_scenario has been successfully injected!")
             except Exception as e:
@@ -241,10 +254,12 @@ class alibaba_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_start_scenario injection failed!")
                 raise e
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_stop_scenario injection")
                 vm_id = self.alibaba.get_instance_id(node)
@@ -252,9 +267,9 @@ class alibaba_node_scenarios(abstract_node_scenarios):
                     "Stopping the node %s with instance ID: %s " % (node, vm_id)
                 )
                 self.alibaba.stop_instances(vm_id)
-                self.alibaba.wait_until_stopped(vm_id, timeout)
+                self.alibaba.wait_until_stopped(vm_id, timeout, affected_node)
                 logging.info("Node with instance ID: %s is in stopped state" % vm_id)
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
             except Exception as e:
                 logging.error(
                     "Failed to stop node instance. Encountered following exception: %s. "
@@ -262,23 +277,25 @@ class alibaba_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_stop_scenario injection failed!")
                 raise e
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Might need to stop and then release the instance
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info(
                     "Starting node_termination_scenario injection by first stopping instance"
                 )
                 vm_id = self.alibaba.get_instance_id(node)
                 self.alibaba.stop_instances(vm_id)
-                self.alibaba.wait_until_stopped(vm_id, timeout)
+                self.alibaba.wait_until_stopped(vm_id, timeout, affected_node)
                 logging.info(
                     "Releasing the node %s with instance ID: %s " % (node, vm_id)
                 )
                 self.alibaba.release_instance(vm_id)
-                self.alibaba.wait_until_released(vm_id, timeout)
+                self.alibaba.wait_until_released(vm_id, timeout, affected_node)
                 logging.info("Node with instance ID: %s has been released" % node)
                 logging.info(
                     "node_termination_scenario has been successfully injected!"
@@ -290,17 +307,19 @@ class alibaba_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_termination_scenario injection failed!")
                 raise e
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to reboot the node
     def node_reboot_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_reboot_scenario injection")
                 instance_id = self.alibaba.get_instance_id(node)
                 logging.info("Rebooting the node with instance ID: %s " % (instance_id))
                 self.alibaba.reboot_instances(instance_id)
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info(
                     "Node with instance ID: %s has been rebooted" % (instance_id)
                 )
@@ -312,3 +331,4 @@ class alibaba_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_reboot_scenario injection failed!")
                 raise e
+            self.affected_nodes_status.affected_nodes.append(affected_node)

--- a/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
@@ -82,7 +82,8 @@ class AWS:
             start_time = time.time()
             self.boto_instance.wait_until_running(InstanceIds=[instance_id])
             end_time = time.time()
-            affected_node.set_effected_node_status("running", end_time - start_time)
+            if affected_node:
+                affected_node.set_effected_node_status("running", end_time - start_time)
             return True
         except Exception as e:
             logging.error(
@@ -97,7 +98,8 @@ class AWS:
             start_time = time.time()
             self.boto_instance.wait_until_stopped(InstanceIds=[instance_id])
             end_time = time.time()
-            affected_node.set_effected_node_status("stopped", end_time - start_time)
+            if affected_node:
+                affected_node.set_effected_node_status("stopped", end_time - start_time)
             return True
         except Exception as e:
             logging.error(
@@ -112,7 +114,8 @@ class AWS:
             start_time = time.time()
             self.boto_instance.wait_until_terminated(InstanceIds=[instance_id])
             end_time = time.time()
-            affected_node.set_effected_node_status("terminated", end_time - start_time)
+            if affected_node:
+                affected_node.set_effected_node_status("terminated", end_time - start_time)
             return True
         except Exception as e:
             logging.error(

--- a/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
@@ -7,7 +7,7 @@ from krkn.scenario_plugins.node_actions.abstract_node_scenarios import (
     abstract_node_scenarios,
 )
 from krkn_lib.k8s import KrknKubernetes
-
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
 
 class AWS:
     def __init__(self):
@@ -249,8 +249,8 @@ class AWS:
 
 # krkn_lib
 class aws_node_scenarios(abstract_node_scenarios):
-    def __init__(self, kubecli: KrknKubernetes):
-        super().__init__(kubecli)
+    def __init__(self, kubecli: KrknKubernetes, affected_nodes_status: AffectedNodeStatus):
+        super().__init__(kubecli, affected_nodes_status)
         self.aws = AWS()
 
     # Node scenario to start the node
@@ -343,8 +343,8 @@ class aws_node_scenarios(abstract_node_scenarios):
                     "Rebooting the node %s with instance ID: %s " % (node, instance_id)
                 )
                 self.aws.reboot_instances(instance_id)
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                affected_node = nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
+                affected_node = nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
                 logging.info(
                     "Node with instance ID: %s has been rebooted" % (instance_id)
                 )

--- a/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
@@ -77,9 +77,12 @@ class AWS:
     # until a successful state is reached. An error is returned after 40 failed checks
     # Setting timeout for consistency with other cloud functions
     # Wait until the node instance is running
-    def wait_until_running(self, instance_id, timeout=600):
+    def wait_until_running(self, instance_id, timeout=600, affected_node=None):
         try:
+            start_time = time.time()
             self.boto_instance.wait_until_running(InstanceIds=[instance_id])
+            end_time = time.time()
+            affected_node.set_effected_node_status("running", end_time - start_time)
             return True
         except Exception as e:
             logging.error(
@@ -89,9 +92,12 @@ class AWS:
             return False
 
     # Wait until the node instance is stopped
-    def wait_until_stopped(self, instance_id, timeout=600):
+    def wait_until_stopped(self, instance_id, timeout=600, affected_node= None):
         try:
+            start_time = time.time()
             self.boto_instance.wait_until_stopped(InstanceIds=[instance_id])
+            end_time = time.time()
+            affected_node.set_effected_node_status("stopped", end_time - start_time)
             return True
         except Exception as e:
             logging.error(
@@ -101,9 +107,12 @@ class AWS:
             return False
 
     # Wait until the node instance is terminated
-    def wait_until_terminated(self, instance_id, timeout=600):
+    def wait_until_terminated(self, instance_id, timeout=600, affected_node= None):
         try:
+            start_time = time.time()
             self.boto_instance.wait_until_terminated(InstanceIds=[instance_id])
+            end_time = time.time()
+            affected_node.set_effected_node_status("terminated", end_time - start_time)
             return True
         except Exception as e:
             logging.error(
@@ -256,6 +265,7 @@ class aws_node_scenarios(abstract_node_scenarios):
     # Node scenario to start the node
     def node_start_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_start_scenario injection")
                 instance_id = self.aws.get_instance_id(node)
@@ -263,8 +273,8 @@ class aws_node_scenarios(abstract_node_scenarios):
                     "Starting the node %s with instance ID: %s " % (node, instance_id)
                 )
                 self.aws.start_instances(instance_id)
-                self.aws.wait_until_running(instance_id)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                self.aws.wait_until_running(instance_id, affected_node=affected_node)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info(
                     "Node with instance ID: %s is in running state" % (instance_id)
                 )
@@ -277,10 +287,12 @@ class aws_node_scenarios(abstract_node_scenarios):
                 logging.error("node_start_scenario injection failed!")
 
                 raise RuntimeError()
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_stop_scenario injection")
                 instance_id = self.aws.get_instance_id(node)
@@ -288,11 +300,11 @@ class aws_node_scenarios(abstract_node_scenarios):
                     "Stopping the node %s with instance ID: %s " % (node, instance_id)
                 )
                 self.aws.stop_instances(instance_id)
-                self.aws.wait_until_stopped(instance_id)
+                self.aws.wait_until_stopped(instance_id, affected_node=affected_node)
                 logging.info(
                     "Node with instance ID: %s is in stopped state" % (instance_id)
                 )
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node=affected_node)
             except Exception as e:
                 logging.error(
                     "Failed to stop node instance. Encountered following exception: %s. "
@@ -301,10 +313,12 @@ class aws_node_scenarios(abstract_node_scenarios):
                 logging.error("node_stop_scenario injection failed!")
 
                 raise RuntimeError()
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_termination_scenario injection")
                 instance_id = self.aws.get_instance_id(node)
@@ -313,7 +327,7 @@ class aws_node_scenarios(abstract_node_scenarios):
                     % (node, instance_id)
                 )
                 self.aws.terminate_instances(instance_id)
-                self.aws.wait_until_terminated(instance_id)
+                self.aws.wait_until_terminated(instance_id, affected_node=affected_node)
                 for _ in range(timeout):
                     if node not in self.kubecli.list_nodes():
                         break
@@ -332,10 +346,12 @@ class aws_node_scenarios(abstract_node_scenarios):
                 logging.error("node_termination_scenario injection failed!")
 
                 raise RuntimeError()
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to reboot the node
     def node_reboot_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_reboot_scenario injection" + str(node))
                 instance_id = self.aws.get_instance_id(node)
@@ -343,8 +359,8 @@ class aws_node_scenarios(abstract_node_scenarios):
                     "Rebooting the node %s with instance ID: %s " % (node, instance_id)
                 )
                 self.aws.reboot_instances(instance_id)
-                affected_node = nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
-                affected_node = nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info(
                     "Node with instance ID: %s has been rebooted" % (instance_id)
                 )
@@ -357,6 +373,7 @@ class aws_node_scenarios(abstract_node_scenarios):
                 logging.error("node_reboot_scenario injection failed!")
 
                 raise RuntimeError()
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Get volume attachment info
     def get_disk_attachment_info(self, instance_kill_count, node):

--- a/krkn/scenario_plugins/node_actions/az_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/az_node_scenarios.py
@@ -176,7 +176,7 @@ class azure_node_scenarios(abstract_node_scenarios):
                 logging.error("node_start_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
@@ -201,7 +201,7 @@ class azure_node_scenarios(abstract_node_scenarios):
                 logging.error("node_stop_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
@@ -234,7 +234,7 @@ class azure_node_scenarios(abstract_node_scenarios):
                 logging.error("node_termination_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
 
     # Node scenario to reboot the node
@@ -263,4 +263,4 @@ class azure_node_scenarios(abstract_node_scenarios):
                 logging.error("node_reboot_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)

--- a/krkn/scenario_plugins/node_actions/az_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/az_node_scenarios.py
@@ -106,7 +106,8 @@ class Azure:
                 logging.info("Vm %s is still not ready in allotted time" % vm_name)
                 return False
         end_time = time.time()
-        affected_node.set_affected_node_status("running", end_time - start_time)
+        if affected_node:
+            affected_node.set_affected_node_status("running", end_time - start_time)
         return True
 
     # Wait until the node instance is stopped
@@ -123,7 +124,8 @@ class Azure:
                 logging.info("Vm %s is still not stopped in allotted time" % vm_name)
                 return False
         end_time = time.time()
-        affected_node.set_affected_node_status("stopped", end_time - start_time)
+        if affected_node:
+            affected_node.set_affected_node_status("stopped", end_time - start_time)
         return True
 
     # Wait until the node instance is terminated
@@ -148,7 +150,8 @@ class Azure:
             except Exception:
                 logging.info("Vm %s is terminated" % vm_name)
                 end_time = time.time()
-                affected_node.set_affected_node_status("terminated", end_time - start_time)
+                if affected_node:
+                    affected_node.set_affected_node_status("terminated", end_time - start_time)
                 return True
 
 

--- a/krkn/scenario_plugins/node_actions/az_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/az_node_scenarios.py
@@ -93,8 +93,9 @@ class Azure:
         return status
 
     # Wait until the node instance is running
-    def wait_until_running(self, resource_group, vm_name, timeout):
+    def wait_until_running(self, resource_group, vm_name, timeout, affected_node):
         time_counter = 0
+        start_time = time.time()
         status = self.get_vm_status(resource_group, vm_name)
         while status and status.code != "PowerState/running":
             status = self.get_vm_status(resource_group, vm_name)
@@ -104,11 +105,14 @@ class Azure:
             if time_counter >= timeout:
                 logging.info("Vm %s is still not ready in allotted time" % vm_name)
                 return False
+        end_time = time.time()
+        affected_node.set_affected_node_status("running", end_time - start_time)
         return True
 
     # Wait until the node instance is stopped
-    def wait_until_stopped(self, resource_group, vm_name, timeout):
+    def wait_until_stopped(self, resource_group, vm_name, timeout, affected_node):
         time_counter = 0
+        start_time = time.time()
         status = self.get_vm_status(resource_group, vm_name)
         while status and status.code != "PowerState/stopped":
             status = self.get_vm_status(resource_group, vm_name)
@@ -118,10 +122,13 @@ class Azure:
             if time_counter >= timeout:
                 logging.info("Vm %s is still not stopped in allotted time" % vm_name)
                 return False
+        end_time = time.time()
+        affected_node.set_affected_node_status("stopped", end_time - start_time)
         return True
 
     # Wait until the node instance is terminated
-    def wait_until_terminated(self, resource_group, vm_name, timeout):
+    def wait_until_terminated(self, resource_group, vm_name, timeout, affected_node):
+        start_time = time.time()
         statuses = self.compute_client.virtual_machines.instance_view(
             resource_group, vm_name
         ).statuses[0]
@@ -140,6 +147,8 @@ class Azure:
                     return False
             except Exception:
                 logging.info("Vm %s is terminated" % vm_name)
+                end_time = time.time()
+                affected_node.set_affected_node_status("terminated", end_time - start_time)
                 return True
 
 
@@ -164,7 +173,7 @@ class azure_node_scenarios(abstract_node_scenarios):
                     % (vm_name, resource_group)
                 )
                 self.azure.start_instances(resource_group, vm_name)
-                self.azure.wait_until_running(resource_group, vm_name, timeout)
+                self.azure.wait_until_running(resource_group, vm_name, timeout, affected_node=affected_node)
                 nodeaction.wait_for_ready_status(vm_name, timeout, self.kubecli, affected_node)
                 logging.info("Node with instance ID: %s is in running state" % node)
                 logging.info("node_start_scenario has been successfully injected!")
@@ -190,7 +199,7 @@ class azure_node_scenarios(abstract_node_scenarios):
                     % (vm_name, resource_group)
                 )
                 self.azure.stop_instances(resource_group, vm_name)
-                self.azure.wait_until_stopped(resource_group, vm_name, timeout)
+                self.azure.wait_until_stopped(resource_group, vm_name, timeout, affected_node=affected_node)
                 logging.info("Node with instance ID: %s is in stopped state" % vm_name)
                 nodeaction.wait_for_unknown_status(vm_name, timeout, self.kubecli, affected_node)
             except Exception as e:
@@ -206,6 +215,7 @@ class azure_node_scenarios(abstract_node_scenarios):
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_termination_scenario injection")
                 affected_node = AffectedNode(node)
@@ -215,7 +225,7 @@ class azure_node_scenarios(abstract_node_scenarios):
                     % (vm_name, resource_group)
                 )
                 self.azure.terminate_instances(resource_group, vm_name)
-                self.azure.wait_until_terminated(resource_group, vm_name, timeout)
+                self.azure.wait_until_terminated(resource_group, vm_name, timeout, affected_node)
                 for _ in range(timeout):
                     if vm_name not in self.kubecli.list_nodes():
                         break

--- a/krkn/scenario_plugins/node_actions/az_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/az_node_scenarios.py
@@ -8,7 +8,7 @@ from krkn.scenario_plugins.node_actions.abstract_node_scenarios import (
 from azure.mgmt.compute import ComputeManagementClient
 from azure.identity import DefaultAzureCredential
 from krkn_lib.k8s import KrknKubernetes
-
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
 
 class Azure:
     def __init__(self):
@@ -18,8 +18,11 @@ class Azure:
         logging.info("credential " + str(credentials))
         # az_account = runcommand.invoke("az account list -o yaml")
         # az_account_yaml = yaml.safe_load(az_account, Loader=yaml.FullLoader)
+        logger = logging.getLogger("azure")
+        logger.setLevel(logging.WARNING)
         subscription_id = os.getenv("AZURE_SUBSCRIPTION_ID")
-        self.compute_client = ComputeManagementClient(credentials, subscription_id)
+        self.compute_client = ComputeManagementClient(credentials, subscription_id,logging=logger)
+        
 
     # Get the instance ID of the node
     def get_instance_id(self, node_name):
@@ -142,24 +145,27 @@ class Azure:
 
 # krkn_lib
 class azure_node_scenarios(abstract_node_scenarios):
-    def __init__(self, kubecli: KrknKubernetes):
-        super().__init__(kubecli)
+    def __init__(self, kubecli: KrknKubernetes, affected_nodes_status: AffectedNodeStatus):
+        super().__init__(kubecli, affected_nodes_status)
         logging.info("init in azure")
         self.azure = Azure()
+        
 
     # Node scenario to start the node
     def node_start_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_start_scenario injection")
                 vm_name, resource_group = self.azure.get_instance_id(node)
+                
                 logging.info(
                     "Starting the node %s with instance ID: %s "
                     % (vm_name, resource_group)
                 )
                 self.azure.start_instances(resource_group, vm_name)
                 self.azure.wait_until_running(resource_group, vm_name, timeout)
-                nodeaction.wait_for_ready_status(vm_name, timeout, self.kubecli)
+                nodeaction.wait_for_ready_status(vm_name, timeout, self.kubecli, affected_node)
                 logging.info("Node with instance ID: %s is in running state" % node)
                 logging.info("node_start_scenario has been successfully injected!")
             except Exception as e:
@@ -170,10 +176,12 @@ class azure_node_scenarios(abstract_node_scenarios):
                 logging.error("node_start_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_stop_scenario injection")
                 vm_name, resource_group = self.azure.get_instance_id(node)
@@ -184,7 +192,7 @@ class azure_node_scenarios(abstract_node_scenarios):
                 self.azure.stop_instances(resource_group, vm_name)
                 self.azure.wait_until_stopped(resource_group, vm_name, timeout)
                 logging.info("Node with instance ID: %s is in stopped state" % vm_name)
-                nodeaction.wait_for_unknown_status(vm_name, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(vm_name, timeout, self.kubecli, affected_node)
             except Exception as e:
                 logging.error(
                     "Failed to stop node instance. Encountered following exception: %s. "
@@ -193,12 +201,14 @@ class azure_node_scenarios(abstract_node_scenarios):
                 logging.error("node_stop_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)
 
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
             try:
                 logging.info("Starting node_termination_scenario injection")
+                affected_node = AffectedNode(node)
                 vm_name, resource_group = self.azure.get_instance_id(node)
                 logging.info(
                     "Terminating the node %s with instance ID: %s "
@@ -224,10 +234,13 @@ class azure_node_scenarios(abstract_node_scenarios):
                 logging.error("node_termination_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)
+
 
     # Node scenario to reboot the node
     def node_reboot_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_reboot_scenario injection")
                 vm_name, resource_group = self.azure.get_instance_id(node)
@@ -235,9 +248,11 @@ class azure_node_scenarios(abstract_node_scenarios):
                     "Rebooting the node %s with instance ID: %s "
                     % (vm_name, resource_group)
                 )
+                
                 self.azure.reboot_instances(resource_group, vm_name)
-                nodeaction.wait_for_unknown_status(vm_name, timeout, self.kubecli)
-                nodeaction.wait_for_ready_status(vm_name, timeout, self.kubecli)
+
+                nodeaction.wait_for_ready_status(vm_name, timeout, self.kubecli, affected_node)
+
                 logging.info("Node with instance ID: %s has been rebooted" % (vm_name))
                 logging.info("node_reboot_scenario has been successfully injected!")
             except Exception as e:
@@ -248,3 +263,4 @@ class azure_node_scenarios(abstract_node_scenarios):
                 logging.error("node_reboot_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)

--- a/krkn/scenario_plugins/node_actions/bm_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/bm_node_scenarios.py
@@ -9,7 +9,7 @@ import pyipmi.interfaces
 import time
 import traceback
 from krkn_lib.k8s import KrknKubernetes
-
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
 
 class BM:
     def __init__(self, bm_info, user, passwd):
@@ -127,8 +127,8 @@ class BM:
 
 # krkn_lib
 class bm_node_scenarios(abstract_node_scenarios):
-    def __init__(self, bm_info, user, passwd, kubecli: KrknKubernetes):
-        super().__init__(kubecli)
+    def __init__(self, bm_info, user, passwd, kubecli: KrknKubernetes,affected_nodes_status: AffectedNodeStatus):
+        super().__init__(kubecli, affected_nodes_status)
         self.bm = BM(bm_info, user, passwd)
 
     # Node scenario to start the node

--- a/krkn/scenario_plugins/node_actions/bm_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/bm_node_scenarios.py
@@ -159,6 +159,7 @@ class bm_node_scenarios(abstract_node_scenarios):
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_stop_scenario injection")
                 bmc_addr = self.bm.get_bmc_addr(node)
@@ -166,11 +167,11 @@ class bm_node_scenarios(abstract_node_scenarios):
                     "Stopping the node %s with bmc address: %s " % (node, bmc_addr)
                 )
                 self.bm.stop_instances(bmc_addr, node)
-                self.bm.wait_until_stopped(bmc_addr, node)
+                self.bm.wait_until_stopped(bmc_addr, node, affected_node)
                 logging.info(
                     "Node with bmc address: %s is in stopped state" % (bmc_addr)
                 )
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
             except Exception as e:
                 logging.error(
                     "Failed to stop node instance. Encountered following exception: %s. "
@@ -179,6 +180,7 @@ class bm_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_stop_scenario injection failed!")
                 raise e
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
@@ -187,6 +189,7 @@ class bm_node_scenarios(abstract_node_scenarios):
     # Node scenario to reboot the node
     def node_reboot_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_reboot_scenario injection")
                 bmc_addr = self.bm.get_bmc_addr(node)
@@ -195,8 +198,8 @@ class bm_node_scenarios(abstract_node_scenarios):
                     "Rebooting the node %s with bmc address: %s " % (node, bmc_addr)
                 )
                 self.bm.reboot_instances(bmc_addr, node)
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info("Node with bmc address: %s has been rebooted" % (bmc_addr))
                 logging.info("node_reboot_scenario has been successfuly injected!")
             except Exception as e:
@@ -208,3 +211,4 @@ class bm_node_scenarios(abstract_node_scenarios):
                 traceback.print_exc()
                 logging.error("node_reboot_scenario injection failed!")
                 raise e
+            self.affected_nodes_status.affected_nodes.append(affected_node)

--- a/krkn/scenario_plugins/node_actions/common_node_functions.py
+++ b/krkn/scenario_plugins/node_actions/common_node_functions.py
@@ -1,7 +1,9 @@
+import datetime
 import time
 import random
 import logging
 import paramiko
+from krkn_lib.models.k8s import AffectedNode
 import krkn.invoke.command as runcommand
 from krkn_lib.k8s import KrknKubernetes
 
@@ -43,20 +45,24 @@ def get_node(label_selector, instance_kill_count, kubecli: KrknKubernetes):
 
 # krkn_lib
 # Wait until the node status becomes Ready
-def wait_for_ready_status(node, timeout, kubecli: KrknKubernetes):
-    kubecli.watch_node_status(node, "True", timeout)
+def wait_for_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node: AffectedNode ):
+    ready_time =  kubecli.watch_node_status(node, "True", timeout)
+    affected_node.set_not_ready_time(ready_time)
+   
 
 
 # krkn_lib
 # Wait until the node status becomes Not Ready
-def wait_for_not_ready_status(node, timeout, kubecli: KrknKubernetes):
-    kubecli.watch_node_status(node, "False", timeout)
-
+def wait_for_not_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node: AffectedNode):
+    not_ready_time = kubecli.watch_node_status(node, "False", timeout)
+    affected_node.set_not_ready_time(not_ready_time)
+    
 
 # krkn_lib
 # Wait until the node status becomes Unknown
-def wait_for_unknown_status(node, timeout, kubecli: KrknKubernetes):
-    kubecli.watch_node_status(node, "Unknown", timeout)
+def wait_for_unknown_status(node, timeout, kubecli: KrknKubernetes, affected_node: AffectedNode):
+    unknown_time = kubecli.watch_node_status(node, "Unknown", timeout)
+    affected_node.set_unknown_time(unknown_time)
 
 
 # Get the ip of the cluster node

--- a/krkn/scenario_plugins/node_actions/common_node_functions.py
+++ b/krkn/scenario_plugins/node_actions/common_node_functions.py
@@ -6,6 +6,8 @@ import paramiko
 from krkn_lib.models.k8s import AffectedNode
 import krkn.invoke.command as runcommand
 from krkn_lib.k8s import KrknKubernetes
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
+from krkn_lib.models.k8s import AffectedNode
 
 node_general = False
 
@@ -42,27 +44,25 @@ def get_node(label_selector, instance_kill_count, kubecli: KrknKubernetes):
         nodes.remove(node_to_add)
     return nodes_to_return
 
-
 # krkn_lib
 # Wait until the node status becomes Ready
-def wait_for_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node: AffectedNode ):
-    ready_time =  kubecli.watch_node_status(node, "True", timeout)
-    affected_node.set_not_ready_time(ready_time)
+def wait_for_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node ):
+    affected_node =  kubecli.watch_node_status(node, "True", timeout, affected_node)
+    return affected_node
    
-
 
 # krkn_lib
 # Wait until the node status becomes Not Ready
-def wait_for_not_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node: AffectedNode):
-    not_ready_time = kubecli.watch_node_status(node, "False", timeout)
-    affected_node.set_not_ready_time(not_ready_time)
+def wait_for_not_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node):
+    affected_node = kubecli.watch_node_status(node, "False", timeout, affected_node)
+    return affected_node
     
 
 # krkn_lib
 # Wait until the node status becomes Unknown
-def wait_for_unknown_status(node, timeout, kubecli: KrknKubernetes, affected_node: AffectedNode):
-    unknown_time = kubecli.watch_node_status(node, "Unknown", timeout)
-    affected_node.set_unknown_time(unknown_time)
+def wait_for_unknown_status(node, timeout, kubecli: KrknKubernetes, affected_node):
+    affected_node = kubecli.watch_node_status(node, "Unknown", timeout, affected_node)
+    return affected_node
 
 
 # Get the ip of the cluster node

--- a/krkn/scenario_plugins/node_actions/common_node_functions.py
+++ b/krkn/scenario_plugins/node_actions/common_node_functions.py
@@ -46,21 +46,21 @@ def get_node(label_selector, instance_kill_count, kubecli: KrknKubernetes):
 
 # krkn_lib
 # Wait until the node status becomes Ready
-def wait_for_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node ):
+def wait_for_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node: AffectedNode = None):
     affected_node =  kubecli.watch_node_status(node, "True", timeout, affected_node)
     return affected_node
    
 
 # krkn_lib
 # Wait until the node status becomes Not Ready
-def wait_for_not_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node):
+def wait_for_not_ready_status(node, timeout, kubecli: KrknKubernetes, affected_node: AffectedNode = None):
     affected_node = kubecli.watch_node_status(node, "False", timeout, affected_node)
     return affected_node
     
 
 # krkn_lib
 # Wait until the node status becomes Unknown
-def wait_for_unknown_status(node, timeout, kubecli: KrknKubernetes, affected_node):
+def wait_for_unknown_status(node, timeout, kubecli: KrknKubernetes, affected_node: AffectedNode = None):
     affected_node = kubecli.watch_node_status(node, "Unknown", timeout, affected_node)
     return affected_node
 

--- a/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
@@ -65,7 +65,7 @@ class docker_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_start_scenario injection failed!")
                 raise e
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
@@ -89,7 +89,7 @@ class docker_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_stop_scenario injection failed!")
                 raise e
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
@@ -139,4 +139,4 @@ class docker_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_reboot_scenario injection failed!")
                 raise e
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)

--- a/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
@@ -127,7 +127,7 @@ class docker_node_scenarios(abstract_node_scenarios):
                 )
                 self.docker.reboot_instances(node)
                 nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info(
                     "Node with container ID: %s has been rebooted" % (container_id)
                 )

--- a/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
@@ -5,7 +5,7 @@ from krkn.scenario_plugins.node_actions.abstract_node_scenarios import (
 import logging
 import docker
 from krkn_lib.k8s import KrknKubernetes
-
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
 
 class Docker:
     def __init__(self):
@@ -38,13 +38,14 @@ class Docker:
 
 
 class docker_node_scenarios(abstract_node_scenarios):
-    def __init__(self, kubecli: KrknKubernetes):
-        super().__init__(kubecli)
+    def __init__(self, kubecli: KrknKubernetes, affected_nodes_status: AffectedNodeStatus):
+        super().__init__(kubecli, affected_nodes_status)
         self.docker = Docker()
 
     # Node scenario to start the node
     def node_start_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_start_scenario injection")
                 container_id = self.docker.get_container_id(node)
@@ -52,7 +53,7 @@ class docker_node_scenarios(abstract_node_scenarios):
                     "Starting the node %s with container ID: %s " % (node, container_id)
                 )
                 self.docker.start_instances(node)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info(
                     "Node with container ID: %s is in running state" % (container_id)
                 )
@@ -64,10 +65,12 @@ class docker_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_start_scenario injection failed!")
                 raise e
+            self.add_affected_node(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_stop_scenario injection")
                 container_id = self.docker.get_container_id(node)
@@ -78,7 +81,7 @@ class docker_node_scenarios(abstract_node_scenarios):
                 logging.info(
                     "Node with container ID: %s is in stopped state" % (container_id)
                 )
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
             except Exception as e:
                 logging.error(
                     "Failed to stop node instance. Encountered following exception: %s. "
@@ -86,6 +89,7 @@ class docker_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_stop_scenario injection failed!")
                 raise e
+            self.add_affected_node(affected_node)
 
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
@@ -113,6 +117,7 @@ class docker_node_scenarios(abstract_node_scenarios):
     # Node scenario to reboot the node
     def node_reboot_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_reboot_scenario injection")
                 container_id = self.docker.get_container_id(node)
@@ -121,7 +126,7 @@ class docker_node_scenarios(abstract_node_scenarios):
                     % (node, container_id)
                 )
                 self.docker.reboot_instances(node)
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
                 nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
                 logging.info(
                     "Node with container ID: %s has been rebooted" % (container_id)
@@ -134,3 +139,4 @@ class docker_node_scenarios(abstract_node_scenarios):
                 )
                 logging.error("node_reboot_scenario injection failed!")
                 raise e
+            self.add_affected_node(affected_node)

--- a/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
@@ -154,13 +154,11 @@ class GCP:
             raise RuntimeError()
 
     # Get instance status
-    def get_instance_status(self, instance_id, expected_status, timeout, affected_node):
+    def get_instance_status(self, instance_id, expected_status, timeout):
         # states: PROVISIONING, STAGING, RUNNING, STOPPING, SUSPENDING, SUSPENDED, REPAIRING,
         # and TERMINATED.
         i = 0
         sleeper = 5
-        start_time = time.time()
-        stopped_status = False
         while i <= timeout:
             try:
                 request = compute_v1.GetInstanceRequest(
@@ -169,8 +167,6 @@ class GCP:
                     zone=self.get_node_instance_zone(instance_id),
                 )
                 instance_status = self.instance_client.get(request=request).status
-                if instance_status.lower() == "stopping": 
-                    stopped_status = True
                 logging.info("Status of instance " + str(instance_id) + ": " + instance_status)
             except Exception as e:
                 logging.error(
@@ -180,12 +176,7 @@ class GCP:
                 raise RuntimeError()
 
             if instance_status == expected_status:
-                logging.info('status matches, end' + str(expected_status) + str(instance_status))
-                end_time = time.time()
-                if stopped_status: 
-                    expected_status = "stopped"
-                affected_node.set_affected_node_status(expected_status, end_time - start_time)
-                logging.info("affected node " + str(affected_node.to_json()))
+                logging.info('status matches, end' + str(expected_status) + str(instance_status))                
                 return True
             time.sleep(sleeper)
             i += sleeper
@@ -201,16 +192,31 @@ class GCP:
 
     # Wait until the node instance is running
     def wait_until_running(self, instance_id, timeout, affected_node):
-        return self.get_instance_status(instance_id, "RUNNING", timeout, affected_node)
+        start_time = time.time()
+        instance_status = self.get_instance_status(instance_id, "RUNNING", timeout)
+        end_time = time.time()
+        if affected_node:
+            affected_node.set_affected_node_status("running", end_time - start_time)
+        return instance_status
 
     # Wait until the node instance is stopped
     def wait_until_stopped(self, instance_id, timeout, affected_node):
         # In GCP, the next state after STOPPING is TERMINATED
-        return self.get_instance_status(instance_id, "TERMINATED", timeout, affected_node)
+        start_time = time.time()
+        instance_status = self.get_instance_status(instance_id, "TERMINATED", timeout)
+        end_time = time.time()
+        if affected_node:
+            affected_node.set_affected_node_status("stopped", end_time - start_time)
+        return instance_status
 
     # Wait until the node instance is terminated
     def wait_until_terminated(self, instance_id, timeout, affected_node):
-        return self.get_instance_status(instance_id, "TERMINATED", timeout, affected_node)
+        start_time = time.time()
+        instance_status =  self.get_instance_status(instance_id, "TERMINATED", timeout)
+        end_time = time.time()
+        if affected_node:
+            affected_node.set_affected_node_status("terminated", end_time - start_time)
+        return instance_status
 
 
 # krkn_lib

--- a/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
@@ -209,6 +209,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
     def __init__(self, kubecli: KrknKubernetes, affected_nodes_status: AffectedNodeStatus):
         super().__init__(kubecli, affected_nodes_status)
         self.gcp = GCP()
+        print("selfkeys" + str(vars(self)))
 
     # Node scenario to start the node
     def node_start_scenario(self, instance_kill_count, node, timeout):
@@ -236,7 +237,8 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_start_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+            
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
@@ -263,7 +265,8 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_stop_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
@@ -323,4 +326,4 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_reboot_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)

--- a/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
@@ -154,11 +154,13 @@ class GCP:
             raise RuntimeError()
 
     # Get instance status
-    def get_instance_status(self, instance_id, expected_status, timeout):
+    def get_instance_status(self, instance_id, expected_status, timeout, affected_node):
         # states: PROVISIONING, STAGING, RUNNING, STOPPING, SUSPENDING, SUSPENDED, REPAIRING,
         # and TERMINATED.
         i = 0
         sleeper = 5
+        start_time = time.time()
+        stopped_status = False
         while i <= timeout:
             try:
                 request = compute_v1.GetInstanceRequest(
@@ -167,16 +169,23 @@ class GCP:
                     zone=self.get_node_instance_zone(instance_id),
                 )
                 instance_status = self.instance_client.get(request=request).status
+                if instance_status.lower() == "stopping": 
+                    stopped_status = True
                 logging.info("Status of instance " + str(instance_id) + ": " + instance_status)
             except Exception as e:
                 logging.error(
                     "Failed to get status of instance %s. Encountered following "
                     "exception: %s." % (instance_id, e)
                 )
-
                 raise RuntimeError()
 
             if instance_status == expected_status:
+                logging.info('status matches, end' + str(expected_status) + str(instance_status))
+                end_time = time.time()
+                if stopped_status: 
+                    expected_status = "stopped"
+                affected_node.set_affected_node_status(expected_status, end_time - start_time)
+                logging.info("affected node " + str(affected_node.to_json()))
                 return True
             time.sleep(sleeper)
             i += sleeper
@@ -191,17 +200,17 @@ class GCP:
         return self.get_instance_status(instance_id, "SUSPENDED", timeout)
 
     # Wait until the node instance is running
-    def wait_until_running(self, instance_id, timeout):
-        return self.get_instance_status(instance_id, "RUNNING", timeout)
+    def wait_until_running(self, instance_id, timeout, affected_node):
+        return self.get_instance_status(instance_id, "RUNNING", timeout, affected_node)
 
     # Wait until the node instance is stopped
-    def wait_until_stopped(self, instance_id, timeout):
+    def wait_until_stopped(self, instance_id, timeout, affected_node):
         # In GCP, the next state after STOPPING is TERMINATED
-        return self.get_instance_status(instance_id, "TERMINATED", timeout)
+        return self.get_instance_status(instance_id, "TERMINATED", timeout, affected_node)
 
     # Wait until the node instance is terminated
-    def wait_until_terminated(self, instance_id, timeout):
-        return self.get_instance_status(instance_id, "TERMINATED", timeout)
+    def wait_until_terminated(self, instance_id, timeout, affected_node):
+        return self.get_instance_status(instance_id, "TERMINATED", timeout, affected_node)
 
 
 # krkn_lib
@@ -223,7 +232,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                     "Starting the node %s with instance ID: %s " % (node, instance_id)
                 )
                 self.gcp.start_instances(instance_id)
-                self.gcp.wait_until_running(instance_id, timeout)
+                self.gcp.wait_until_running(instance_id, timeout, affected_node)
                 nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info(
                     "Node with instance ID: %s is in running state" % instance_id
@@ -237,7 +246,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_start_scenario injection failed!")
 
                 raise RuntimeError()
-            
+            logging.info("started affected node" + str(affected_node.to_json()))
             self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to stop the node
@@ -252,7 +261,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                     "Stopping the node %s with instance ID: %s " % (node, instance_id)
                 )
                 self.gcp.stop_instances(instance_id)
-                self.gcp.wait_until_stopped(instance_id, timeout)
+                self.gcp.wait_until_stopped(instance_id, timeout, affected_node=affected_node)
                 logging.info(
                     "Node with instance ID: %s is in stopped state" % instance_id
                 )
@@ -265,12 +274,13 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_stop_scenario injection failed!")
 
                 raise RuntimeError()
-
+            logging.info("stopedd affected node" + str(affected_node.to_json()))
             self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_termination_scenario injection")
                 instance = self.gcp.get_node_instance(node)
@@ -280,7 +290,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                     % (node, instance_id)
                 )
                 self.gcp.terminate_instances(instance_id)
-                self.gcp.wait_until_terminated(instance_id, timeout)
+                self.gcp.wait_until_terminated(instance_id, timeout, affected_node=affected_node)
                 for _ in range(timeout):
                     if node not in self.kubecli.list_nodes():
                         break
@@ -299,6 +309,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_termination_scenario injection failed!")
 
                 raise RuntimeError()
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to reboot the node
     def node_reboot_scenario(self, instance_kill_count, node, timeout):
@@ -312,7 +323,8 @@ class gcp_node_scenarios(abstract_node_scenarios):
                     "Rebooting the node %s with instance ID: %s " % (node, instance_id)
                 )
                 self.gcp.reboot_instances(instance_id)
-                self.gcp.wait_until_running(instance_id, timeout)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
+                self.gcp.wait_until_running(instance_id, timeout, affected_node)
                 nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info(
                     "Node with instance ID: %s has been rebooted" % instance_id

--- a/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
@@ -7,7 +7,7 @@ from krkn.scenario_plugins.node_actions.abstract_node_scenarios import (
 )
 from google.cloud import compute_v1
 from krkn_lib.k8s import KrknKubernetes
-
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
 
 class GCP:
     def __init__(self):
@@ -206,13 +206,14 @@ class GCP:
 
 # krkn_lib
 class gcp_node_scenarios(abstract_node_scenarios):
-    def __init__(self, kubecli: KrknKubernetes):
-        super().__init__(kubecli)
+    def __init__(self, kubecli: KrknKubernetes, affected_nodes_status: AffectedNodeStatus):
+        super().__init__(kubecli, affected_nodes_status)
         self.gcp = GCP()
 
     # Node scenario to start the node
     def node_start_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_start_scenario injection")
                 instance = self.gcp.get_node_instance(node)
@@ -222,7 +223,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 )
                 self.gcp.start_instances(instance_id)
                 self.gcp.wait_until_running(instance_id, timeout)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info(
                     "Node with instance ID: %s is in running state" % instance_id
                 )
@@ -235,10 +236,12 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_start_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_stop_scenario injection")
                 instance = self.gcp.get_node_instance(node)
@@ -251,7 +254,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.info(
                     "Node with instance ID: %s is in stopped state" % instance_id
                 )
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
             except Exception as e:
                 logging.error(
                     "Failed to stop node instance. Encountered following exception: %s. "
@@ -260,6 +263,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_stop_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)
 
     # Node scenario to terminate the node
     def node_termination_scenario(self, instance_kill_count, node, timeout):
@@ -296,6 +300,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
     # Node scenario to reboot the node
     def node_reboot_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_reboot_scenario injection")
                 instance = self.gcp.get_node_instance(node)
@@ -305,7 +310,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 )
                 self.gcp.reboot_instances(instance_id)
                 self.gcp.wait_until_running(instance_id, timeout)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info(
                     "Node with instance ID: %s has been rebooted" % instance_id
                 )
@@ -318,3 +323,4 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_reboot_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)

--- a/krkn/scenario_plugins/node_actions/general_cloud_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/general_cloud_node_scenarios.py
@@ -3,7 +3,7 @@ from krkn.scenario_plugins.node_actions.abstract_node_scenarios import (
     abstract_node_scenarios,
 )
 from krkn_lib.k8s import KrknKubernetes
-
+from krkn_lib.models.k8s import AffectedNodeStatus
 
 class GENERAL:
     def __init__(self):
@@ -12,8 +12,8 @@ class GENERAL:
 
 # krkn_lib
 class general_node_scenarios(abstract_node_scenarios):
-    def __init__(self, kubecli: KrknKubernetes):
-        super().__init__(kubecli)
+    def __init__(self, kubecli: KrknKubernetes, affected_nodes_status: AffectedNodeStatus):
+        super().__init__(kubecli, affected_nodes_status)
         self.general = GENERAL()
 
     # Node scenario to start the node

--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -150,7 +150,6 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             for single_node in nodes:
                 self.run_node(single_node, node_scenario_object, action, node_scenario)
         affected_nodes_status = node_scenario_object.affected_nodes_status
-        logging.info('final affected nodes ' + str(affected_nodes_status.affected_nodes[0].node_name) + str(len(str(affected_nodes_status.affected_nodes))))
         scenario_telemetry.affected_nodes = affected_nodes_status.affected_nodes
 
     def multiprocess_nodes(self, nodes, node_scenario_object, action, node_scenario, affected_nodes_status):

--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -144,7 +144,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             )
         
         # GCP api doesn't support multiprocessing calls, will only actually run 1 
-        if parallel_nodes and node_scenario['cloud_type'].lower() != "gcp":
+        if parallel_nodes:
             self.multiprocess_nodes(nodes, node_scenario_object, action, node_scenario)
         else: 
             for single_node in nodes:

--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -150,7 +150,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             for single_node in nodes:
                 self.run_node(single_node, node_scenario_object, action, node_scenario)
         affected_nodes_status = node_scenario_object.affected_nodes_status
-        logging.info('final affected nodes ' + str(affected_nodes_status.affected_nodes))
+        logging.info('final affected nodes ' + str(affected_nodes_status.affected_nodes[0].node_name) + str(len(str(affected_nodes_status.affected_nodes))))
         scenario_telemetry.affected_nodes = affected_nodes_status.affected_nodes
 
     def multiprocess_nodes(self, nodes, node_scenario_object, action, node_scenario, affected_nodes_status):

--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -6,7 +6,7 @@ from itertools import repeat
 import yaml
 from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.models.telemetry import ScenarioTelemetry
-from krkn_lib.models.k8s import AffectedNode
+from krkn_lib.models.k8s import AffectedNodeStatus
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 from krkn_lib.utils import get_yaml_item_value, log_exception
 
@@ -61,28 +61,29 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                     return 0
 
     def get_node_scenario_object(self, node_scenario, kubecli: KrknKubernetes):
+        affected_nodes_status = AffectedNodeStatus()
         if (
             "cloud_type" not in node_scenario.keys()
             or node_scenario["cloud_type"] == "generic"
         ):
             global node_general
             node_general = True
-            return general_node_scenarios(kubecli)
+            return general_node_scenarios(kubecli, affected_nodes_status)
         if node_scenario["cloud_type"].lower() == "aws":
-            return aws_node_scenarios(kubecli)
+            return aws_node_scenarios(kubecli, affected_nodes_status)
         elif node_scenario["cloud_type"].lower() == "gcp":
-            return gcp_node_scenarios(kubecli)
+            return gcp_node_scenarios(kubecli, affected_nodes_status)
         elif node_scenario["cloud_type"].lower() == "openstack":
             from krkn.scenario_plugins.node_actions.openstack_node_scenarios import (
                 openstack_node_scenarios,
             )
 
-            return openstack_node_scenarios(kubecli)
+            return openstack_node_scenarios(kubecli, affected_nodes_status)
         elif (
             node_scenario["cloud_type"].lower() == "azure"
             or node_scenario["cloud_type"] == "az"
         ):
-            return azure_node_scenarios(kubecli)
+            return azure_node_scenarios(kubecli, affected_nodes_status)
         elif (
             node_scenario["cloud_type"].lower() == "alibaba"
             or node_scenario["cloud_type"] == "alicloud"
@@ -91,7 +92,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                 alibaba_node_scenarios,
             )
 
-            return alibaba_node_scenarios(kubecli)
+            return alibaba_node_scenarios(kubecli, affected_nodes_status)
         elif node_scenario["cloud_type"].lower() == "bm":
             from krkn.scenario_plugins.node_actions.bm_node_scenarios import (
                 bm_node_scenarios,
@@ -102,9 +103,10 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                 node_scenario.get("bmc_user", None),
                 node_scenario.get("bmc_password", None),
                 kubecli,
+                affected_nodes_status
             )
         elif node_scenario["cloud_type"].lower() == "docker":
-            return docker_node_scenarios(kubecli)
+            return docker_node_scenarios(kubecli, affected_nodes_status)
         else:
             logging.error(
                 "Cloud type "
@@ -140,16 +142,18 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             nodes = common_node_functions.get_node(
                 label_selector, instance_kill_count, kubecli
             )
-
+        
         # GCP api doesn't support multiprocessing calls, will only actually run 1 
         if parallel_nodes and node_scenario['cloud_type'].lower() != "gcp":
             self.multiprocess_nodes(nodes, node_scenario_object, action, node_scenario)
         else: 
             for single_node in nodes:
                 self.run_node(single_node, node_scenario_object, action, node_scenario)
-        scenario_telemetry.
+        affected_nodes_status = node_scenario_object.affected_nodes_status
+        logging.info('final affected nodes ' + str(affected_nodes_status.affected_nodes))
+        scenario_telemetry.affected_nodes = affected_nodes_status.affected_nodes
 
-    def multiprocess_nodes(self, nodes, node_scenario_object, action, node_scenario):
+    def multiprocess_nodes(self, nodes, node_scenario_object, action, node_scenario, affected_nodes_status):
         try:
             logging.info("parallely call to nodes")
             # pool object with number of element
@@ -158,6 +162,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             pool.starmap(self.run_node,zip(nodes, repeat(node_scenario_object), repeat(action), repeat(node_scenario)))
 
             pool.close()
+            return affected_nodes_status
         except Exception as e:
             logging.info("Error on pool multiprocessing: " + str(e))
 
@@ -175,7 +180,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             node_scenario, "ssh_private_key", "~/.ssh/id_rsa"
         )
         generic_cloud_scenarios = ("stop_kubelet_scenario", "node_crash_scenario")
-        affected_node = AffectedNode()
+
         if node_general and action not in generic_cloud_scenarios:
             logging.info(
                 "Scenario: "
@@ -184,43 +189,43 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             )
         else:
             if action == "node_start_scenario":
-                node_scenario_object.node_start_scenario(
-                    run_kill_count, single_node, timeout, affected_node
+                affected_node = node_scenario_object.node_start_scenario(
+                    run_kill_count, single_node, timeout
                 )
             elif action == "node_stop_scenario":
-                node_scenario_object.node_stop_scenario(
-                    run_kill_count, single_node, timeout, affected_node
+                affected_node = node_scenario_object.node_stop_scenario(
+                    run_kill_count, single_node, timeout
                 )
             elif action == "node_stop_start_scenario":
-                node_scenario_object.node_stop_start_scenario(
-                    run_kill_count, single_node, timeout, duration, affected_node
+                affected_node = node_scenario_object.node_stop_start_scenario(
+                    run_kill_count, single_node, timeout, duration
                 )
             elif action == "node_termination_scenario":
-                node_scenario_object.node_termination_scenario(
-                    run_kill_count, single_node, timeout, affected_node
+                affected_node = node_scenario_object.node_termination_scenario(
+                    run_kill_count, single_node, timeout
                 )
             elif action == "node_reboot_scenario":
-                node_scenario_object.node_reboot_scenario(
-                    run_kill_count, single_node, timeout, affected_node
+                affected_node = node_scenario_object.node_reboot_scenario(
+                    run_kill_count, single_node, timeout
                 )
             elif action == "node_disk_detach_attach_scenario":
                 node_scenario_object.node_disk_detach_attach_scenario(
                     run_kill_count, single_node, timeout, duration)
             elif action == "stop_start_kubelet_scenario":
-                node_scenario_object.stop_start_kubelet_scenario(
-                    run_kill_count, single_node, timeout, affected_node
+                affected_node = node_scenario_object.stop_start_kubelet_scenario(
+                    run_kill_count, single_node, timeout
                 )
             elif action == "restart_kubelet_scenario":
-                node_scenario_object.restart_kubelet_scenario(
-                    run_kill_count, single_node, timeout, affected_node
+                affected_node = node_scenario_object.restart_kubelet_scenario(
+                    run_kill_count, single_node, timeout
                 )
             elif action == "stop_kubelet_scenario":
-                node_scenario_object.stop_kubelet_scenario(
-                    run_kill_count, single_node, timeout, affected_node
+                affected_node = node_scenario_object.stop_kubelet_scenario(
+                    run_kill_count, single_node, timeout
                 )
             elif action == "node_crash_scenario":
-                node_scenario_object.node_crash_scenario(
-                    run_kill_count, single_node, timeout, affected_node
+                affected_node = node_scenario_object.node_crash_scenario(
+                    run_kill_count, single_node, timeout
                 )
             elif action == "stop_start_helper_node_scenario":
                 if node_scenario["cloud_type"] != "openstack":
@@ -236,10 +241,10 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                         raise Exception(
                             "Helper node IP address is not provided"
                         )
-                    node_scenario_object.helper_node_stop_start_scenario(
+                    affected_node = node_scenario_object.helper_node_stop_start_scenario(
                         run_kill_count, node_scenario["helper_node_ip"], timeout
                     )
-                    node_scenario_object.helper_node_service_status(
+                    affected_node = node_scenario_object.helper_node_service_status(
                         node_scenario["helper_node_ip"],
                         service,
                         ssh_private_key,
@@ -250,6 +255,8 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                     "There is no node action that matches %s, skipping scenario"
                     % action
                 )
+        logging.info('last line run node')
+
 
     def get_scenario_types(self) -> list[str]:
         return ["node_scenarios"]

--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -152,7 +152,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         affected_nodes_status = node_scenario_object.affected_nodes_status
         scenario_telemetry.affected_nodes = affected_nodes_status.affected_nodes
 
-    def multiprocess_nodes(self, nodes, node_scenario_object, action, node_scenario, affected_nodes_status):
+    def multiprocess_nodes(self, nodes, node_scenario_object, action, node_scenario):
         try:
             logging.info("parallely call to nodes")
             # pool object with number of element
@@ -161,7 +161,6 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             pool.starmap(self.run_node,zip(nodes, repeat(node_scenario_object), repeat(action), repeat(node_scenario)))
 
             pool.close()
-            return affected_nodes_status
         except Exception as e:
             logging.info("Error on pool multiprocessing: " + str(e))
 

--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -6,6 +6,7 @@ from itertools import repeat
 import yaml
 from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn_lib.models.k8s import AffectedNode
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 from krkn_lib.utils import get_yaml_item_value, log_exception
 
@@ -49,6 +50,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                                 node_scenario,
                                 node_scenario_object,
                                 lib_telemetry.get_lib_kubernetes(),
+                                scenario_telemetry,
                             )
                             end_time = int(time.time())
                             cerberus.get_status(krkn_config, start_time, end_time)
@@ -120,7 +122,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             )
 
     def inject_node_scenario(
-        self, action, node_scenario, node_scenario_object, kubecli: KrknKubernetes
+        self, action, node_scenario, node_scenario_object, kubecli: KrknKubernetes, scenario_telemetry: ScenarioTelemetry
     ):
         
         # Get the node scenario configurations for setting nodes
@@ -145,6 +147,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         else: 
             for single_node in nodes:
                 self.run_node(single_node, node_scenario_object, action, node_scenario)
+        scenario_telemetry.
 
     def multiprocess_nodes(self, nodes, node_scenario_object, action, node_scenario):
         try:
@@ -172,7 +175,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             node_scenario, "ssh_private_key", "~/.ssh/id_rsa"
         )
         generic_cloud_scenarios = ("stop_kubelet_scenario", "node_crash_scenario")
-
+        affected_node = AffectedNode()
         if node_general and action not in generic_cloud_scenarios:
             logging.info(
                 "Scenario: "
@@ -182,42 +185,42 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         else:
             if action == "node_start_scenario":
                 node_scenario_object.node_start_scenario(
-                    run_kill_count, single_node, timeout
+                    run_kill_count, single_node, timeout, affected_node
                 )
             elif action == "node_stop_scenario":
                 node_scenario_object.node_stop_scenario(
-                    run_kill_count, single_node, timeout
+                    run_kill_count, single_node, timeout, affected_node
                 )
             elif action == "node_stop_start_scenario":
                 node_scenario_object.node_stop_start_scenario(
-                    run_kill_count, single_node, timeout, duration
+                    run_kill_count, single_node, timeout, duration, affected_node
                 )
             elif action == "node_termination_scenario":
                 node_scenario_object.node_termination_scenario(
-                    run_kill_count, single_node, timeout
+                    run_kill_count, single_node, timeout, affected_node
                 )
             elif action == "node_reboot_scenario":
                 node_scenario_object.node_reboot_scenario(
-                    run_kill_count, single_node, timeout
+                    run_kill_count, single_node, timeout, affected_node
                 )
             elif action == "node_disk_detach_attach_scenario":
                 node_scenario_object.node_disk_detach_attach_scenario(
                     run_kill_count, single_node, timeout, duration)
             elif action == "stop_start_kubelet_scenario":
                 node_scenario_object.stop_start_kubelet_scenario(
-                    run_kill_count, single_node, timeout
+                    run_kill_count, single_node, timeout, affected_node
                 )
             elif action == "restart_kubelet_scenario":
                 node_scenario_object.restart_kubelet_scenario(
-                    run_kill_count, single_node, timeout
+                    run_kill_count, single_node, timeout, affected_node
                 )
             elif action == "stop_kubelet_scenario":
                 node_scenario_object.stop_kubelet_scenario(
-                    run_kill_count, single_node, timeout
+                    run_kill_count, single_node, timeout, affected_node
                 )
             elif action == "node_crash_scenario":
                 node_scenario_object.node_crash_scenario(
-                    run_kill_count, single_node, timeout
+                    run_kill_count, single_node, timeout, affected_node
                 )
             elif action == "stop_start_helper_node_scenario":
                 if node_scenario["cloud_type"] != "openstack":

--- a/krkn/scenario_plugins/node_actions/openstack_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/openstack_node_scenarios.py
@@ -132,7 +132,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.error("node_start_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
@@ -154,7 +154,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.error("node_stop_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to reboot the node
     def node_reboot_scenario(self, instance_kill_count, node, timeout):
@@ -177,7 +177,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.error("node_reboot_scenario injection failed!")
 
                 raise RuntimeError()
-            self.add_affected_node(affected_node)
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to start the node
     def helper_node_start_scenario(self, instance_kill_count, node_ip, timeout):

--- a/krkn/scenario_plugins/node_actions/openstack_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/openstack_node_scenarios.py
@@ -56,12 +56,22 @@ class OPENSTACKCLOUD:
             raise RuntimeError()
 
     # Wait until the node instance is running
-    def wait_until_running(self, node, timeout):
-        return self.get_instance_status(node, "ACTIVE", timeout)
+    def wait_until_running(self, node, timeout, affected_node):
+        start_time = time.time()
+        instance_status= self.get_instance_status(node, "ACTIVE", timeout)
+        end_time = time.time()
+        if affected_node:
+            affected_node.set_affected_node_status("running", end_time - start_time)
+        return instance_status
 
     # Wait until the node instance is stopped
-    def wait_until_stopped(self, node, timeout):
-        return self.get_instance_status(node, "SHUTOFF", timeout)
+    def wait_until_stopped(self, node, timeout, affected_node):
+        start_time = time.time()
+        instance_status = self.get_instance_status(node, "SHUTOFF", timeout)
+        end_time = time.time()
+        if affected_node:
+            affected_node.set_affected_node_status("stopped", end_time - start_time)
+        return instance_status
 
     # Get instance status
     def get_instance_status(self, node, expected_status, timeout):
@@ -120,7 +130,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.info("Starting the node %s" % (node))
                 openstack_node_name = self.openstackcloud.get_instance_id(node)
                 self.openstackcloud.start_instances(openstack_node_name)
-                self.openstackcloud.wait_until_running(openstack_node_name, timeout)
+                self.openstackcloud.wait_until_running(openstack_node_name, timeout, affected_node)
                 nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info("Node with instance ID: %s is in running state" % (node))
                 logging.info("node_start_scenario has been successfully injected!")
@@ -143,7 +153,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.info("Stopping the node %s " % (node))
                 openstack_node_name = self.openstackcloud.get_instance_id(node)
                 self.openstackcloud.stop_instances(openstack_node_name)
-                self.openstackcloud.wait_until_stopped(openstack_node_name, timeout)
+                self.openstackcloud.wait_until_stopped(openstack_node_name, timeout, affected_node)
                 logging.info("Node with instance name: %s is in stopped state" % (node))
                 nodeaction.wait_for_not_ready_status(node, timeout, self.kubecli, affected_node)
             except Exception as e:
@@ -182,6 +192,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
     # Node scenario to start the node
     def helper_node_start_scenario(self, instance_kill_count, node_ip, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node_ip)
             try:
                 logging.info("Starting helper_node_start_scenario injection")
                 openstack_node_name = self.openstackcloud.get_openstack_nodename(
@@ -189,7 +200,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 )
                 logging.info("Starting the helper node %s" % (openstack_node_name))
                 self.openstackcloud.start_instances(openstack_node_name)
-                self.openstackcloud.wait_until_running(openstack_node_name, timeout)
+                self.openstackcloud.wait_until_running(openstack_node_name, timeout, affected_node)
                 logging.info("Helper node with IP: %s is in running state" % (node_ip))
                 logging.info("node_start_scenario has been successfully injected!")
             except Exception as e:
@@ -200,10 +211,12 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.error("helper_node_start_scenario injection failed!")
 
                 raise RuntimeError()
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to stop the node
     def helper_node_stop_scenario(self, instance_kill_count, node_ip, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node_ip)
             try:
                 logging.info("Starting helper_node_stop_scenario injection")
                 openstack_node_name = self.openstackcloud.get_openstack_nodename(
@@ -211,7 +224,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 )
                 logging.info("Stopping the helper node %s " % (openstack_node_name))
                 self.openstackcloud.stop_instances(openstack_node_name)
-                self.openstackcloud.wait_until_stopped(openstack_node_name, timeout)
+                self.openstackcloud.wait_until_stopped(openstack_node_name, timeout, affected_node)
                 logging.info("Helper node with IP: %s is in stopped state" % (node_ip))
             except Exception as e:
                 logging.error(
@@ -221,6 +234,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.error("helper_node_stop_scenario injection failed!")
 
                 raise RuntimeError()
+            self.affected_nodes_status.affected_nodes.append(affected_node)
 
     def helper_node_service_status(self, node_ip, service, ssh_private_key, timeout):
         try:

--- a/krkn/scenario_plugins/node_actions/openstack_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/openstack_node_scenarios.py
@@ -7,7 +7,7 @@ from krkn.scenario_plugins.node_actions.abstract_node_scenarios import (
     abstract_node_scenarios,
 )
 from krkn_lib.k8s import KrknKubernetes
-
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
 
 class OPENSTACKCLOUD:
     def __init__(self):
@@ -107,19 +107,21 @@ class OPENSTACKCLOUD:
 
 # krkn_lib
 class openstack_node_scenarios(abstract_node_scenarios):
-    def __init__(self, kubecli: KrknKubernetes):
+    def __init__(self, kubecli: KrknKubernetes, affected_nodes_status: AffectedNodeStatus ):
+        super().__init__(kubecli, affected_nodes_status)
         self.openstackcloud = OPENSTACKCLOUD()
-
+    
     # Node scenario to start the node
     def node_start_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_start_scenario injection")
                 logging.info("Starting the node %s" % (node))
                 openstack_node_name = self.openstackcloud.get_instance_id(node)
                 self.openstackcloud.start_instances(openstack_node_name)
                 self.openstackcloud.wait_until_running(openstack_node_name, timeout)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info("Node with instance ID: %s is in running state" % (node))
                 logging.info("node_start_scenario has been successfully injected!")
             except Exception as e:
@@ -130,10 +132,12 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.error("node_start_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)
 
     # Node scenario to stop the node
     def node_stop_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_stop_scenario injection")
                 logging.info("Stopping the node %s " % (node))
@@ -141,7 +145,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 self.openstackcloud.stop_instances(openstack_node_name)
                 self.openstackcloud.wait_until_stopped(openstack_node_name, timeout)
                 logging.info("Node with instance name: %s is in stopped state" % (node))
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_not_ready_status(node, timeout, self.kubecli, affected_node)
             except Exception as e:
                 logging.error(
                     "Failed to stop node instance. Encountered following exception: %s. "
@@ -150,17 +154,19 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.error("node_stop_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)
 
     # Node scenario to reboot the node
     def node_reboot_scenario(self, instance_kill_count, node, timeout):
         for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_reboot_scenario injection")
                 logging.info("Rebooting the node %s" % (node))
                 openstack_node_name = self.openstackcloud.get_instance_id(node)
                 self.openstackcloud.reboot_instances(openstack_node_name)
-                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli)
-                nodeaction.wait_for_ready_status(node, timeout, self.kubecli)
+                nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
+                nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info("Node with instance name: %s has been rebooted" % (node))
                 logging.info("node_reboot_scenario has been successfuly injected!")
             except Exception as e:
@@ -171,6 +177,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 logging.error("node_reboot_scenario injection failed!")
 
                 raise RuntimeError()
+            self.add_affected_node(affected_node)
 
     # Node scenario to start the node
     def helper_node_start_scenario(self, instance_kill_count, node_ip, timeout):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ google-cloud-compute==1.22.0
 ibm_cloud_sdk_core==3.18.0
 ibm_vpc==0.20.0
 jinja2==3.1.5
-krkn-lib==4.0.4
+#krkn-lib==4.0.4
 lxml==5.1.0
 kubernetes==28.1.0
 numpy==1.26.4
@@ -36,6 +36,7 @@ werkzeug==3.0.6
 wheel==0.42.0
 zope.interface==5.4.0
 
+git+https://github.com/krkn-chaos/krkn-lib.git@node_timing
 git+https://github.com/krkn-chaos/arcaflow-plugin-kill-pod.git@v0.1.0
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
 cryptography>=42.0.4 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
This is adding in the ability to add AffectedNode timing to a list that we can track in the telemetry and other output. 

This tracks the amount of time that is taken for the cloud provider to stop/start the node, and the amount of time after the node from the cloud side is stopped/started what is the time the node is in not ready/ready state. 

Needs to go in after https://github.com/krkn-chaos/krkn-lib/pull/143

Any suggestions on how to make this not touch as many files? 