### PR TITLE
fixes krknctl describe bug

### DIFF
--- a/containers/Dockerfile.template
+++ b/containers/Dockerfile.template
@@ -49,9 +49,9 @@ RUN python3.9 -m ensurepip
 RUN pip3.9 install -r requirements.txt
 RUN pip3.9 install jsonschema
 
-LABEL krknctl.title="Krkn Base Image"
-LABEL krknctl.description="This is the krkn base image."
-LABEL krknctl.input_fields='$KRKNCTL_INPUT'
+LABEL krknctl.title.global="Krkn Base Image"
+LABEL krknctl.description.global="This is the krkn base image."
+LABEL krknctl.input_fields.global='$KRKNCTL_INPUT'
 
 
 RUN chown -R krkn:krkn /home/krkn && chmod 755 /home/krkn


### PR DESCRIPTION
krknctl is currently confusing base image and tag labels preventing describe to print the correct scenario metadata