### PR TITLE
Adding node id to affected node

### DIFF
--- a/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
@@ -239,6 +239,7 @@ class alibaba_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_start_scenario injection")
                 vm_id = self.alibaba.get_instance_id(node)
+                affected_node.node_id = vm_id
                 logging.info(
                     "Starting the node %s with instance ID: %s " % (node, vm_id)
                 )
@@ -263,6 +264,7 @@ class alibaba_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_stop_scenario injection")
                 vm_id = self.alibaba.get_instance_id(node)
+                affected_node.node_id = vm_id
                 logging.info(
                     "Stopping the node %s with instance ID: %s " % (node, vm_id)
                 )
@@ -289,6 +291,7 @@ class alibaba_node_scenarios(abstract_node_scenarios):
                     "Starting node_termination_scenario injection by first stopping instance"
                 )
                 vm_id = self.alibaba.get_instance_id(node)
+                affected_node.node_id = vm_id
                 self.alibaba.stop_instances(vm_id)
                 self.alibaba.wait_until_stopped(vm_id, timeout, affected_node)
                 logging.info(
@@ -316,6 +319,7 @@ class alibaba_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_reboot_scenario injection")
                 instance_id = self.alibaba.get_instance_id(node)
+                affected_node.node_id = instance_id
                 logging.info("Rebooting the node with instance ID: %s " % (instance_id))
                 self.alibaba.reboot_instances(instance_id)
                 nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)

--- a/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
@@ -272,6 +272,7 @@ class aws_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_start_scenario injection")
                 instance_id = self.aws.get_instance_id(node)
+                affected_node.node_id = instance_id
                 logging.info(
                     "Starting the node %s with instance ID: %s " % (node, instance_id)
                 )
@@ -299,6 +300,7 @@ class aws_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_stop_scenario injection")
                 instance_id = self.aws.get_instance_id(node)
+                affected_node.node_id = instance_id
                 logging.info(
                     "Stopping the node %s with instance ID: %s " % (node, instance_id)
                 )
@@ -325,6 +327,7 @@ class aws_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_termination_scenario injection")
                 instance_id = self.aws.get_instance_id(node)
+                affected_node.node_id = instance_id
                 logging.info(
                     "Terminating the node %s with instance ID: %s "
                     % (node, instance_id)
@@ -358,6 +361,7 @@ class aws_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_reboot_scenario injection" + str(node))
                 instance_id = self.aws.get_instance_id(node)
+                affected_node.node_id = instance_id
                 logging.info(
                     "Rebooting the node %s with instance ID: %s " % (node, instance_id)
                 )

--- a/krkn/scenario_plugins/node_actions/az_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/az_node_scenarios.py
@@ -170,7 +170,7 @@ class azure_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_start_scenario injection")
                 vm_name, resource_group = self.azure.get_instance_id(node)
-                
+                affected_node.node_id = vm_name
                 logging.info(
                     "Starting the node %s with instance ID: %s "
                     % (vm_name, resource_group)
@@ -197,6 +197,7 @@ class azure_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_stop_scenario injection")
                 vm_name, resource_group = self.azure.get_instance_id(node)
+                affected_node.node_id = vm_name
                 logging.info(
                     "Stopping the node %s with instance ID: %s "
                     % (vm_name, resource_group)
@@ -221,8 +222,8 @@ class azure_node_scenarios(abstract_node_scenarios):
             affected_node = AffectedNode(node)
             try:
                 logging.info("Starting node_termination_scenario injection")
-                affected_node = AffectedNode(node)
                 vm_name, resource_group = self.azure.get_instance_id(node)
+                affected_node.node_id = vm_name
                 logging.info(
                     "Terminating the node %s with instance ID: %s "
                     % (vm_name, resource_group)
@@ -257,6 +258,7 @@ class azure_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_reboot_scenario injection")
                 vm_name, resource_group = self.azure.get_instance_id(node)
+                affected_node.node_id = vm_name
                 logging.info(
                     "Rebooting the node %s with instance ID: %s "
                     % (vm_name, resource_group)

--- a/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
@@ -49,6 +49,7 @@ class docker_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_start_scenario injection")
                 container_id = self.docker.get_container_id(node)
+                affected_node.node_id = container_id
                 logging.info(
                     "Starting the node %s with container ID: %s " % (node, container_id)
                 )
@@ -74,6 +75,7 @@ class docker_node_scenarios(abstract_node_scenarios):
             try:
                 logging.info("Starting node_stop_scenario injection")
                 container_id = self.docker.get_container_id(node)
+                affected_node.node_id = container_id
                 logging.info(
                     "Stopping the node %s with container ID: %s " % (node, container_id)
                 )

--- a/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
@@ -234,6 +234,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.info("Starting node_start_scenario injection")
                 instance = self.gcp.get_node_instance(node)
                 instance_id = self.gcp.get_instance_name(instance)
+                affected_node.node_id = instance_id
                 logging.info(
                     "Starting the node %s with instance ID: %s " % (node, instance_id)
                 )
@@ -252,7 +253,6 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_start_scenario injection failed!")
 
                 raise RuntimeError()
-            logging.info("started affected node" + str(affected_node.to_json()))
             self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to stop the node
@@ -263,6 +263,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.info("Starting node_stop_scenario injection")
                 instance = self.gcp.get_node_instance(node)
                 instance_id = self.gcp.get_instance_name(instance)
+                affected_node.node_id = instance_id
                 logging.info(
                     "Stopping the node %s with instance ID: %s " % (node, instance_id)
                 )
@@ -280,7 +281,6 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.error("node_stop_scenario injection failed!")
 
                 raise RuntimeError()
-            logging.info("stopedd affected node" + str(affected_node.to_json()))
             self.affected_nodes_status.affected_nodes.append(affected_node)
 
     # Node scenario to terminate the node
@@ -291,6 +291,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.info("Starting node_termination_scenario injection")
                 instance = self.gcp.get_node_instance(node)
                 instance_id = self.gcp.get_instance_name(instance)
+                affected_node.node_id = instance_id
                 logging.info(
                     "Terminating the node %s with instance ID: %s "
                     % (node, instance_id)
@@ -325,6 +326,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.info("Starting node_reboot_scenario injection")
                 instance = self.gcp.get_node_instance(node)
                 instance_id = self.gcp.get_instance_name(instance)
+                affected_node.node_id = instance_id
                 logging.info(
                     "Rebooting the node %s with instance ID: %s " % (node, instance_id)
                 )


### PR DESCRIPTION
Need to add affected node node id to the details. In the cluster shut down scenario we only have knowledge of the instance id that is being stopped not the node name and we don't have a way to easily get it during the run 


Correlating PR in krkn-lib: https://github.com/krkn-chaos/krkn-lib/pull/146

See error below:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-chaos-prow-scripts-main-4.18-nightly-krkn-hub-node-tests/1886263731898290176