### PR TITLE
Logging getting into ingress shaping file

### DIFF
--- a/krkn/scenario_plugins/native/native_scenario_plugin.py
+++ b/krkn/scenario_plugins/native/native_scenario_plugin.py
@@ -49,6 +49,7 @@ class NativeScenarioPlugin(AbstractScenarioPlugin):
         return [
             "pod_disruption_scenarios",
             "pod_network_scenarios",
+            "ingress_node_scenarios"
         ]
 
     def start_monitoring(self, pool: PodsMonitorPool, scenarios: list[Any]):


### PR DESCRIPTION
## Description  
Hitting issue with kraken_config complaining about the wrong type. Also unclear on what scenario type needs to be specified for ingress network 


```
2025-04-21 15:04:57,753 [INFO] health checks config is not defined, skipping them
2025-04-21 15:04:57,754 [INFO] Executing scenarios for iteration 0
�2025-04-21 15:04:57,756 [INFO] Running NativeScenarioPlugin: ['pod_disruption_scenarios', 'pod_network_scenarios'] -> scenarios/network_chaos.yaml
�2025-04-21 15:04:57,759 [ERROR] NativeScenarioPlugin exiting due to Exception Validation failed for 'input -> NetworkScenarioConfig -> kraken_config': Must be a string, <class 'dict'> given
2025-04-21 15:05:00,526 [INFO] Find cluster events in file /tmp/events.json
2025-04-21 15:05:00,526 [INFO] wating 60 before running the next scenario
```

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related PR (if applicable)  
Related PR that will need updating after this PR