### PR TITLE
Enum of true/false variables

### DIFF
--- a/containers/krknctl-input.json
+++ b/containers/krknctl-input.json
@@ -408,8 +408,10 @@
     "short_description": "Health check exit on failure",
     "description": "Exit on failure when health check URL is not able to connect",
     "variable": "HEALTH_CHECK_EXIT_ON_FAILURE",
-    "type": "string",
-    "default": "",
+    "type": "enum",
+    "allowed_values": "True,False",
+    "separator": ",",
+    "default": "False",
     "required": "false"
   },
   {
@@ -417,8 +419,10 @@
     "short_description": "SSL Verification of health check url",
     "description": "SSL Verification to authenticate into health check URL",
     "variable": "HEALTH_CHECK_VERIFY",
-    "type": "string",
-    "default": "false",
+    "type": "enum",
+    "allowed_values": "True,False",
+    "separator": ",",
+    "default": "False",
     "required": "false"
   },
   {


### PR DESCRIPTION
## Description  
Need health-check-exit and health-check-verify to be a enum of either true or false

Getting error in krknctl because its a string and not true/false
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib64/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.9/threading.py", line 917, in run
2025-05-07 18:33:11,819 [INFO] Environment is configured for ClientSecretCredential
    self._target(*self._args, **self._kwargs)
  File "/home/krkn/kraken/krkn/utils/HealthChecker.py", line 42, in run_health_check
    response = self.make_request(url, auth, headers, verify_url)
  File "/home/krkn/kraken/krkn/utils/HealthChecker.py", line 16, in make_request
    response = requests.get(url, auth=auth, headers=headers, verify=verify)
  File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 589, in request
2025-05-07 18:33:11,820 [INFO] ManagedIdentityCredential will use IMDS
    resp = self.send(prep, **send_kwargs)
2025-05-07 18:33:11,820 [INFO] credential <azure.identity._credentials.default.DefaultAzureCredential object at 0xffff7332c280>
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 561, in send
    self.cert_verify(conn, request.url, verify, cert)
  File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 310, in cert_verify
    raise OSError(

```


## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  