### PR TITLE
Migrate to modern Python logger API

### DIFF
--- a/krkn/scenario_plugins/native/network/ingress_shaping.py
+++ b/krkn/scenario_plugins/native/network/ingress_shaping.py
@@ -256,7 +256,7 @@ def verify_interface(
                         % (interface, node, node_interface_list)
                     )
     finally:
-        logging.info("Deleteing pod to query interface on node")
+        logging.info("Deleting pod to query interface on node")
         kube_helper.delete_pod(cli, "fedtools", "default")
 
     return input_interface_list
@@ -546,7 +546,7 @@ def wait_for_job(
                     count += 1
                     job_list.remove(job_name)
             except Exception:
-                logging.warn("Exception in getting job status")
+                logging.warning("Exception in getting job status")
             if time.time() > wait_time:
                 raise Exception(
                     "Jobs did not complete within "
@@ -585,7 +585,7 @@ def delete_jobs(cli: CoreV1Api, batch_cli: BatchV1Api, job_list: typing.List[str
                 pod_log = pod_log_response.data.decode("utf-8")
                 logging.error(pod_log)
         except Exception as e:
-            logging.warn("Exception in getting job status: %s" % str(e))
+            logging.warning("Exception in getting job status: %s" % str(e))
         api_response = kube_helper.delete_job(
             batch_cli, name=job_name, namespace="default"
         )

--- a/krkn/scenario_plugins/native/network/kubernetes_functions.py
+++ b/krkn/scenario_plugins/native/network/kubernetes_functions.py
@@ -29,13 +29,13 @@ def create_job(batch_cli, body, namespace="default"):
         api_response = batch_cli.create_namespaced_job(body=body, namespace=namespace)
         return api_response
     except ApiException as api:
-        logging.warn(
+        logging.warning(
             "Exception when calling \
                        BatchV1Api->create_job: %s"
             % api
         )
         if api.status == 409:
-            logging.warn("Job already present")
+            logging.warning("Job already present")
     except Exception as e:
         logging.error(
             "Exception when calling \
@@ -218,12 +218,12 @@ def delete_job(batch_cli, name, namespace="default"):
         logging.debug("Job deleted. status='%s'" % str(api_response.status))
         return api_response
     except ApiException as api:
-        logging.warn(
+        logging.warning(
             "Exception when calling \
                        BatchV1Api->create_namespaced_job: %s"
             % api
         )
-        logging.warn("Job already deleted\n")
+        logging.warning("Job already deleted\n")
     except Exception as e:
         logging.error(
             "Exception when calling \

--- a/krkn/scenario_plugins/native/pod_network_outage/kubernetes_functions.py
+++ b/krkn/scenario_plugins/native/pod_network_outage/kubernetes_functions.py
@@ -27,13 +27,13 @@ def create_job(batch_cli, body, namespace="default"):
             body=body, namespace=namespace)
         return api_response
     except ApiException as api:
-        logging.warn(
+        logging.warning(
             "Exception when calling \
                        BatchV1Api->create_job: %s"
             % api
         )
         if api.status == 409:
-            logging.warn("Job already present")
+            logging.warning("Job already present")
     except Exception as e:
         logging.error(
             "Exception when calling \
@@ -196,12 +196,12 @@ def delete_job(batch_cli, name, namespace="default"):
         logging.debug("Job deleted. status='%s'" % str(api_response.status))
         return api_response
     except ApiException as api:
-        logging.warn(
+        logging.warning(
             "Exception when calling \
                        BatchV1Api->create_namespaced_job: %s"
             % api
         )
-        logging.warn("Job already deleted\n")
+        logging.warning("Job already deleted\n")
     except Exception as e:
         logging.error(
             "Exception when calling \

--- a/krkn/scenario_plugins/native/pod_network_outage/pod_network_outage_plugin.py
+++ b/krkn/scenario_plugins/native/pod_network_outage/pod_network_outage_plugin.py
@@ -102,7 +102,7 @@ def delete_jobs(kubecli: KrknKubernetes, job_list: typing.List[str]):
                 pod_log = pod_log_response.data.decode("utf-8")
                 logging.error(pod_log)
         except Exception as e:
-            logging.warn("Exception in getting job status: %s" % str(e))
+            logging.warning("Exception in getting job status: %s" % str(e))
         api_response = kubecli.delete_job(name=job_name, namespace="default")
 
 
@@ -137,7 +137,7 @@ def wait_for_job(
                     count += 1
                     job_list.remove(job_name)
             except Exception:
-                logging.warn("Exception in getting job status")
+                logging.warning("Exception in getting job status")
             if time.time() > wait_time:
                 raise Exception(
                     "Jobs did not complete within "


### PR DESCRIPTION
## Description  
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Documentation  

## Related Documentation PR (if applicable)  
