### PR TITLE
Fix broken contribution link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Enhancements being planned can be found in the [roadmap](ROADMAP.md).
 ### Contributions
 We are always looking for more enhancements, fixes to make it better, any contributions are most welcome. Feel free to report or work on the issues filed on github.
 
-[More information on how to Contribute](https://krkn-chaos.dev/docs/contribution-guidelines/contribute/)
+[More information on how to Contribute](https://krkn-chaos.dev/docs/contribution-guidelines/)
 
 
 ### Community


### PR DESCRIPTION
## Description  
<!-- Provide a brief description of the changes made in this PR. -->  
Fixed the broken "How to contribute" link in the README file under the **Contributions** section.  
Updated the outdated URL to point to the correct contribution guidelines page.

## Documentation  
- [x] **Is documentation needed for this update?**  
No documentation changes are needed in the website repository for this minor fix.

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  
N/A

### Closes Issue #808 