### PR TITLE
Feature/add exclude label

### DIFF
--- a/docs/pod_network_scenarios.md
+++ b/docs/pod_network_scenarios.md
@@ -4,6 +4,8 @@
 Scenario to block the traffic ( Ingress/Egress ) of a pod matching the labels for the specified duration of time to understand the behavior of the service/other services which depend on it during downtime. This helps with planning the requirements accordingly, be it improving the timeouts or tweaking the alerts etc.
 With the current network policies, it is not possible to explicitly block ports which are enabled by allowed network policy rule. This chaos scenario addresses this issue by using OVS flow rules to block ports related to the pod. It supports OpenShiftSDN and OVNKubernetes based networks.
 
+The scenario also supports excluding specific pods from the outage using the `exclude_label` parameter, which allows keeping critical pods running within the same namespace while causing outages to others.
+
 ##### Sample scenario config (using a plugin)
 ```
 - id: pod_network_outage
@@ -14,6 +16,8 @@ With the current network policies, it is not possible to explicitly block ports 
     ingress_ports:                 # Optional - List of ports to block traffic on
         - 8443                     # Blocks 8443, Default [], i.e. all ports.
     label_selector: 'component=ui' # Blocks access to openshift console
+    exclude_label: 'skip=true'     # Optional - Pods matching this label will be excluded from the chaos
+    exclude_label: 'excluded=true'               # Optional - Pods matching this label will be excluded from the chaos
 ```
 ### Pod Network shaping
 Scenario to introduce network latency, packet loss, and bandwidth restriction in the Pod's network interface. The purpose of this scenario is to observe faults caused by random variations in the network.
@@ -25,6 +29,7 @@ Scenario to introduce network latency, packet loss, and bandwidth restriction in
     namespace: openshift-console   # Required - Namespace of the pod to which filter need to be applied.
     label_selector: 'component=ui' # Applies traffic shaping to access openshift console.
     network_params:
+    exclude_label: 'excluded=true'               # Optional - Pods matching this label will be excluded from the chaos
         latency: 500ms             # Add 500ms latency to egress traffic from the pod.
 ```
 ##### Sample scenario config for ingress traffic shaping (using plugin)
@@ -34,6 +39,7 @@ Scenario to introduce network latency, packet loss, and bandwidth restriction in
     namespace: openshift-console   # Required - Namespace of the pod to which filter need to be applied.
     label_selector: 'component=ui' # Applies traffic shaping to access openshift console.
     network_params:
+    exclude_label: 'excluded=true'               # Optional - Pods matching this label will be excluded from the chaos
         latency: 500ms             # Add 500ms latency to egress traffic from the pod.
 ```
 

--- a/scenarios/plugin.schema.json
+++ b/scenarios/plugin.schema.json
@@ -44,6 +44,11 @@
 										"title": "Label selector",
 										"description": "Kubernetes label selector for the target pods. Required if name_pattern is not set.\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for details."
 									},
+									"exclude_label": {
+										"type": "string",
+										"title": "Exclude label",
+										"description": "Kubernetes label selector for pods to exclude from the chaos. Pods matching this label will be excluded even if they match the label_selector"
+									},
 									"kubeconfig_path": {
 										"type": "string",
 										"title": "Kubeconfig path",
@@ -103,6 +108,11 @@
 								"title": "Label selector",
 								"description": "Kubernetes label selector for the target pods. Required if name_pattern is not set.\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ for details."
 							},
+									"exclude_label": {
+										"type": "string",
+										"title": "Exclude label",
+										"description": "Kubernetes label selector for pods to exclude from the chaos. Pods matching this label will be excluded even if they match the label_selector"
+									},
 							"kubeconfig_path": {
 								"type": "string",
 								"title": "Kubeconfig path",
@@ -2141,6 +2151,11 @@
 										"title": "Label selector",
 										"description": "Kubernetes label selector for the target pod. When pod_name is not specified, pod with matching label_selector is selected for chaos scenario"
 									},
+									"exclude_label": {
+										"type": "string",
+										"title": "Exclude label",
+										"description": "Kubernetes label selector for pods to exclude from the chaos. Pods matching this label will be excluded even if they match the label_selector"
+									},
 									"kraken_config": {
 										"type": "string",
 										"title": "Kraken Config",
@@ -2228,6 +2243,11 @@
 								"title": "Label selector",
 								"description": "Kubernetes label selector for the target pod. When pod_name is not specified, pod with matching label_selector is selected for chaos scenario"
 							},
+									"exclude_label": {
+										"type": "string",
+										"title": "Exclude label",
+										"description": "Kubernetes label selector for pods to exclude from the chaos. Pods matching this label will be excluded even if they match the label_selector"
+									},
 							"kraken_config": {
 								"type": "string",
 								"title": "Kraken Config",
@@ -2301,6 +2321,11 @@
 										"title": "Label selector",
 										"description": "Kubernetes label selector for the target pod. When pod_name is not specified, pod with matching label_selector is selected for chaos scenario"
 									},
+									"exclude_label": {
+										"type": "string",
+										"title": "Exclude label",
+										"description": "Kubernetes label selector for pods to exclude from the chaos. Pods matching this label will be excluded even if they match the label_selector"
+									},
 									"kraken_config": {
 										"type": "string",
 										"title": "Kraken Config",
@@ -2373,6 +2398,11 @@
 								"title": "Label selector",
 								"description": "Kubernetes label selector for the target pod. When pod_name is not specified, pod with matching label_selector is selected for chaos scenario"
 							},
+									"exclude_label": {
+										"type": "string",
+										"title": "Exclude label",
+										"description": "Kubernetes label selector for pods to exclude from the chaos. Pods matching this label will be excluded even if they match the label_selector"
+									},
 							"kraken_config": {
 								"type": "string",
 								"title": "Kraken Config",
@@ -2470,6 +2500,11 @@
 										"title": "Label selector",
 										"description": "Kubernetes label selector for the target pod. When pod_name is not specified, pod with matching label_selector is selected for chaos scenario"
 									},
+									"exclude_label": {
+										"type": "string",
+										"title": "Exclude label",
+										"description": "Kubernetes label selector for pods to exclude from the chaos. Pods matching this label will be excluded even if they match the label_selector"
+									},
 									"kraken_config": {
 										"type": "string",
 										"title": "Kraken Config",
@@ -2542,6 +2577,11 @@
 								"title": "Label selector",
 								"description": "Kubernetes label selector for the target pod. When pod_name is not specified, pod with matching label_selector is selected for chaos scenario"
 							},
+									"exclude_label": {
+										"type": "string",
+										"title": "Exclude label",
+										"description": "Kubernetes label selector for pods to exclude from the chaos. Pods matching this label will be excluded even if they match the label_selector"
+									},
 							"kraken_config": {
 								"type": "string",
 								"title": "Kraken Config",

--- a/tests/test_pod_network_outage.py
+++ b/tests/test_pod_network_outage.py
@@ -1,0 +1,93 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from krkn.scenario_plugins.native.pod_network_outage.kubernetes_functions import (
+    list_pods,
+)
+from krkn.scenario_plugins.native.pod_network_outage.pod_network_outage_plugin import (
+    get_test_pods,
+)
+
+
+class TestPodNetworkOutage(unittest.TestCase):
+    def test_list_pods_with_exclude_label(self):
+        """Test that list_pods correctly excludes pods with matching exclude_label"""
+        # Create mock pod items
+        pod1 = MagicMock()
+        pod1.metadata.name = "pod1"
+        pod1.metadata.labels = {"app": "test", "skip": "true"}
+
+        pod2 = MagicMock()
+        pod2.metadata.name = "pod2"
+        pod2.metadata.labels = {"app": "test"}
+
+        pod3 = MagicMock()
+        pod3.metadata.name = "pod3"
+        pod3.metadata.labels = {"app": "test", "skip": "false"}
+
+        # Create mock API response
+        mock_response = MagicMock()
+        mock_response.items = [pod1, pod2, pod3]
+
+        # Create mock client
+        mock_cli = MagicMock()
+        mock_cli.list_namespaced_pod.return_value = mock_response
+
+        # Test without exclude_label
+        result = list_pods(mock_cli, "test-namespace", "app=test")
+        self.assertEqual(result, ["pod1", "pod2", "pod3"])
+
+        # Test with exclude_label
+        result = list_pods(mock_cli, "test-namespace", "app=test", "skip=true")
+        self.assertEqual(result, ["pod2", "pod3"])
+
+    def test_get_test_pods_with_exclude_label(self):
+        """Test that get_test_pods passes exclude_label to list_pods correctly"""
+        # Create mock kubecli
+        mock_kubecli = MagicMock()
+        mock_kubecli.list_pods.return_value = ["pod2", "pod3"]
+
+        # Test get_test_pods with exclude_label
+        result = get_test_pods(
+            None, "app=test", "test-namespace", mock_kubecli, "skip=true"
+        )
+
+        # Verify list_pods was called with the correct parameters
+        mock_kubecli.list_pods.assert_called_once_with(
+            label_selector="app=test",
+            namespace="test-namespace",
+            exclude_label="skip=true",
+        )
+
+        # Verify the result
+        self.assertEqual(result, ["pod2", "pod3"])
+
+    def test_get_test_pods_with_pod_name_and_exclude_label(self):
+        """Test that get_test_pods prioritizes pod_name over label filters"""
+        # Create mock kubecli
+        mock_kubecli = MagicMock()
+        mock_kubecli.list_pods.return_value = ["pod1", "pod2", "pod3"]
+
+        # Test get_test_pods with both pod_name and exclude_label
+        # The pod_name should take precedence
+        result = get_test_pods(
+            "pod1", "app=test", "test-namespace", mock_kubecli, "skip=true"
+        )
+
+        # Verify list_pods was called with the correct parameters
+        mock_kubecli.list_pods.assert_called_once_with(
+            label_selector="app=test",
+            namespace="test-namespace",
+            exclude_label="skip=true",
+        )
+
+        # Verify the result contains only the specified pod
+        self.assertEqual(result, ["pod1"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes made in this PR. -->

Hey team! I've implemented the feature in https://github.com/krkn-chaos/krkn/issues/784

The implementation adds an `exclude_label` parameter across the codebase that works just like the existing label_selector, but with the inverse effect—pods matching this label are excluded from chaos even if they match the main label_selector.

### Changes made:

- **krkn/scenario_plugins/native/pod_network_outage/kubernetes_functions.py**:
  - Added `exclude_label` parameter to `list_pods()` function
  - Implemented filtering logic that skips pods with matching exclude labels

- **krkn/scenario_plugins/native/pod_network_outage/pod_network_outage_plugin.py**:
  - Updated `get_test_pods()` to accept and pass through the exclude_label parameter
  - Added `exclude_label` field to all relevant plugin parameter classes (InputParams, EgressParams, IngressParams)
  - Updated calls in pod_outage, pod_egress_shaping, and pod_ingress_shaping functions

- **scenarios/plugin.schema.json**:
  - Added schema definition for the new parameter with proper descriptions

- **docs/pod_network_scenarios.md**:
  - Added documentation and example usage showing how to use the feature
  - Updated the sample configuration to demonstrate exclude_label

- **tests/test_pod_network_outage.py**:
  - Created comprehensive unit tests to verify the functionality
  - Tests verify that pods with matching exclude labels are properly filtered out

All tests are passing—I've verified the implementation works as expected both through unit tests and manual testing.

## Documentation
- [x] **Is documentation needed for this update?**

Documentation has been added directly in the main repository in docs/pod_network_scenarios.md with explanations and examples of how to use the new exclude_label parameter.

## Related Documentation PR (if applicable)
<!-- Add the link to the corresponding documentation PR in the website repository -->
N/A (documentation was added directly in this PR)