### PR TITLE
Add Privileged and Non-Privileged RBAC Configurations with Documentation

### DIFF
--- a/rbac/non-privileged-role.yaml
+++ b/rbac/non-privileged-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: krkn-non-privileged-role
+  namespace: target-namespace
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "delete"]

--- a/rbac/non-privileged-rolebinding.yaml
+++ b/rbac/non-privileged-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: krkn-non-privileged-rolebinding
+  namespace: target-namespace
+subjects:
+- kind: ServiceAccount
+  name: krkn-sa
+  namespace: target-namespace
+roleRef:
+  kind: Role
+  name: krkn-non-privileged-role
+  apiGroup: rbac.authorization.k8s.io

--- a/rbac/privileged-clusterrole.yaml
+++ b/rbac/privileged-clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: krkn-privileged-clusterrole
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: [""]
+  resources: ["pods", "services"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "statefulsets"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]

--- a/rbac/privileged-clusterrolebinding.yaml
+++ b/rbac/privileged-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: krkn-privileged-clusterrolebinding
+subjects:
+- kind: ServiceAccount
+  name: krkn-sa
+  namespace: krkn-namespace
+roleRef:
+  kind: ClusterRole
+  name: krkn-privileged-clusterrole
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Description  
This pull request introduces privileged and non-privileged RBAC configurations for Krkn, enabling users to run chaos scenarios based on their access level. It adds YAML files for `Role`, `ClusterRole`, `RoleBinding`, and `ClusterRoleBinding` in a new `rbac` directory, covering namespace-scoped and cluster-wide permissions. 

For writing the RBAC policies, I referred to the Kubernetes RBAC documentation (https://kubernetes.io/docs/reference/access-authn-authz/rbac/), Krkn’s scenario documentation (https://krkn-chaos.github.io/krkn/docs/scenarios/), and got refrence from Chaos Mesh’s permission management guide (https://chaos-mesh.org/docs/manage-user-permissions/).

## Documentation  
- [x] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  

https://github.com/krkn-chaos/website/pull/66

### Issue

It will resolve the issue #759 