### PR TITLE
749_node_scenerio_failing_to_run_multiple_actions

### DIFF
--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -58,8 +58,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                 except (RuntimeError, Exception) as e:
                     logging.error("Node Actions exiting due to Exception %s" % e)
                     return 1
-                else:
-                    return 0
+            return 0
 
     def get_node_scenario_object(self, node_scenario, kubecli: KrknKubernetes):
         affected_nodes_status = AffectedNodeStatus()


### PR DESCRIPTION
## Ref Issue(https://github.com/krkn-chaos/krkn/issues/749) 

## Description  
The node scenario runner was returning after the first scenario due to a misplaced `return 0` inside the loop.
This fix moves the return statement outside the loop to ensure all node scenarios are executed as defined in the configuration.
