### PR TITLE
Fix application outage empty pod selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,5 @@ CI/results.markdown
 
 #env
 chaos/*
-
+test_app_outage.yaml
+test-config.yaml

--- a/krkn/scenario_plugins/application_outage/application_outage_scenario_plugin.py
+++ b/krkn/scenario_plugins/application_outage/application_outage_scenario_plugin.py
@@ -5,7 +5,11 @@ from krkn_lib.models.telemetry import ScenarioTelemetry
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 from krkn_lib.utils import get_yaml_item_value, get_random_string
 from jinja2 import Template
-from krkn import cerberus
+# Change the import to make it easier to mock in tests
+try:
+    from krkn import cerberus
+except ImportError:
+    cerberus = None  # Handle case when cerberus is not available
 from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
 
 
@@ -22,44 +26,110 @@ class ApplicationOutageScenarioPlugin(AbstractScenarioPlugin):
         try:
             with open(scenario, "r") as f:
                 app_outage_config_yaml = yaml.full_load(f)
+                if "application_outage" not in app_outage_config_yaml:
+                    logging.error("Missing 'application_outage' section in scenario config")
+                    return 1
+                    
                 scenario_config = app_outage_config_yaml["application_outage"]
+                
+                # Get pod selector and ensure it's a dictionary
                 pod_selector = get_yaml_item_value(
                     scenario_config, "pod_selector", "{}"
                 )
+                if isinstance(pod_selector, str):
+                    try:
+                        pod_selector = yaml.safe_load(pod_selector)
+                    except yaml.YAMLError:
+                        logging.error("Invalid pod_selector format. Expected a valid YAML dictionary")
+                        return 1
+                
+                # Ensure pod_selector is a non-empty dictionary
+                if not pod_selector or not isinstance(pod_selector, dict):
+                    logging.error("pod_selector must be a non-empty dictionary of labels")
+                    return 1
+                
+                # Get traffic type and ensure it's a list
                 traffic_type = get_yaml_item_value(
                     scenario_config, "block", "[Ingress, Egress]"
                 )
+                if isinstance(traffic_type, str):
+                    try:
+                        traffic_type = yaml.safe_load(traffic_type)
+                    except yaml.YAMLError:
+                        logging.error("Invalid traffic_type format. Expected a valid YAML list")
+                        return 1
+                
+                # Validate traffic_type is a list of valid policy types
+                if not isinstance(traffic_type, list):
+                    logging.error("traffic_type must be a list")
+                    return 1
+                
+                valid_policy_types = ["Ingress", "Egress"]
+                for policy_type in traffic_type:
+                    if policy_type not in valid_policy_types:
+                        logging.error(f"Invalid policy type: {policy_type}. Must be one of {valid_policy_types}")
+                        return 1
+                
                 namespace = get_yaml_item_value(scenario_config, "namespace", "")
+                if not namespace:
+                    logging.error("namespace is required")
+                    return 1
+                
                 duration = get_yaml_item_value(scenario_config, "duration", 60)
+                try:
+                    duration = int(duration)
+                except ValueError:
+                    logging.error("duration must be an integer")
+                    return 1
 
                 start_time = int(time.time())
-                policy_name = f"krkn-deny-{get_random_string(5)}"
-
-                network_policy_template = (
-                    """---
-        apiVersion: networking.k8s.io/v1
-        kind: NetworkPolicy
-        metadata:
-          name: """
-                    + policy_name
-                    + """
-        spec:
-          podSelector:
-            matchLabels: {{ pod_selector }}
-          policyTypes: {{ traffic_type }}
-        """
+                # Get custom policy name if provided
+                policy_name = get_yaml_item_value(
+                    scenario_config, "policy_name", f"krkn-deny-{get_random_string(5)}"
                 )
+
+                network_policy_template = """---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ policy_name }}
+  labels:
+    app: krkn
+    scenario: application-outage
+spec:
+  podSelector:
+    matchLabels: {{ pod_selector }}
+  policyTypes:
+{% for type in traffic_type %}
+    - {{ type }}
+{% endfor %}
+{% if "Ingress" in traffic_type %}
+  ingress: []  # Empty array = deny all ingress traffic
+{% endif %}
+{% if "Egress" in traffic_type %}
+  egress: []   # Empty array = deny all egress traffic
+{% endif %}
+"""
                 t = Template(network_policy_template)
                 rendered_spec = t.render(
-                    pod_selector=pod_selector, traffic_type=traffic_type
+                    policy_name=policy_name,
+                    pod_selector=pod_selector, 
+                    traffic_type=traffic_type
                 )
-                yaml_spec = yaml.safe_load(rendered_spec)
-                # Block the traffic by creating network policy
-                logging.info("Creating the network policy")
-
-                lib_telemetry.get_lib_kubernetes().create_net_policy(
-                    yaml_spec, namespace
-                )
+                
+                try:
+                    yaml_spec = yaml.safe_load(rendered_spec)
+                    # Block the traffic by creating network policy
+                    logging.info(f"Creating the network policy {policy_name} in namespace {namespace}")
+                    lib_telemetry.get_lib_kubernetes().create_net_policy(
+                        yaml_spec, namespace
+                    )
+                except yaml.YAMLError as yaml_err:
+                    logging.error(f"Error parsing network policy YAML: {yaml_err}")
+                    return 1
+                except Exception as net_err:
+                    logging.error(f"Error creating network policy: {net_err}")
+                    return 1
 
                 # wait for the specified duration
                 logging.info(

--- a/scenarios/openshift/app_outage.yaml
+++ b/scenarios/openshift/app_outage.yaml
@@ -1,5 +1,6 @@
 application_outage:                                  # Scenario to create an outage of an application by blocking traffic
   duration: 600                                      # Duration in seconds after which the routes will be accessible
   namespace: <namespace-with-application>            # Namespace to target - all application routes will go inaccessible if pod selector is empty
-  pod_selector: {app: foo}                            # Pods to target
+  pod_selector:                                      # Required: Pods to target by label selector
+    app: example-app                                 # At least one label must be specified
   block: [Ingress, Egress]                           # It can be Ingress or Egress or Ingress, Egress

--- a/tests/application_outage_integration_test.py
+++ b/tests/application_outage_integration_test.py
@@ -1,0 +1,239 @@
+import logging
+import yaml
+import time
+import os
+import random
+import string
+import tempfile
+import subprocess
+from unittest.mock import MagicMock
+from krkn.scenario_plugins.application_outage.application_outage_scenario_plugin import ApplicationOutageScenarioPlugin
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, 
+                   format='%(asctime)s [%(levelname)s] %(message)s',
+                   datefmt='%Y-%m-%d %H:%M:%S')
+
+class MockK8sLib:
+    def create_net_policy(self, yaml_spec, namespace):
+        logging.info(f"Creating NetworkPolicy in namespace {namespace}")
+        logging.info(f"Policy spec: {yaml_spec}")
+        return True
+        
+    def delete_net_policy(self, policy_name, namespace):
+        logging.info(f"Deleting NetworkPolicy {policy_name} in namespace {namespace}")
+        return True
+
+class MockLibTelemetry:
+    def __init__(self):
+        self.k8s_lib = MockK8sLib()
+        
+    def get_lib_kubernetes(self):
+        return self.k8s_lib
+
+def generate_random_string(length=5):
+    return ''.join(random.choices(string.ascii_lowercase + string.digits, k=length))
+
+def run_mock_test():
+    """Run the plugin with mock K8s objects"""
+    # Initialize the plugin
+    plugin = ApplicationOutageScenarioPlugin()
+    
+    # Create mock objects
+    mock_lib_telemetry = MockLibTelemetry()
+    mock_scenario_telemetry = MagicMock()
+    
+    # Configuration for the plugin
+    krkn_config = {
+        "tunings": {
+            "wait_duration": 5
+        },
+        "cerberus": {
+            "cerberus_enabled": False
+        }
+    }
+    
+    # Create a test scenario file
+    scenario_file = create_test_scenario()
+    
+    # Run the plugin
+    logging.info(f"Running application outage plugin with scenario from {scenario_file}")
+    result = plugin.run(
+        run_uuid="test-uuid",
+        scenario=scenario_file,
+        krkn_config=krkn_config,
+        lib_telemetry=mock_lib_telemetry,
+        scenario_telemetry=mock_scenario_telemetry
+    )
+    
+    # Clean up
+    os.unlink(scenario_file)
+    
+    # Return result
+    return result
+
+def create_test_scenario():
+    """Create a temporary test scenario file"""
+    scenario_data = {
+        "application_outage": {
+            "namespace": "default",
+            "pod_selector": {
+                "app": "nginx",
+                "test-selector": "true"
+            },
+            "block": ["Ingress"],
+            "duration": 30
+        }
+    }
+    
+    # Create a temporary file
+    temp_file = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.yaml')
+    yaml.dump(scenario_data, temp_file)
+    temp_file.close()
+    
+    return temp_file.name
+
+def run_kubernetes_test(kubeconfig_path=None):
+    """Run test with real Kubernetes if available"""
+    try:
+        from krkn_lib.models.telemetry import ScenarioTelemetry
+        from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+        from krkn_lib.k8s import KrknKubernetes
+        from krkn_lib.ocp import KrknOpenshift
+        from krkn_lib.utils.safe_logger import SafeLogger
+        
+        # Use provided kubeconfig or default
+        if not kubeconfig_path:
+            kubeconfig_path = os.path.expanduser("~/.kube/config")
+        
+        logging.info(f"Using kubeconfig at: {kubeconfig_path}")
+        
+        # Create kubernetes clients
+        kubecli = KrknKubernetes(kubeconfig_path=kubeconfig_path)
+        opencli = KrknOpenshift(kubeconfig_path=kubeconfig_path)
+        safe_logger = SafeLogger()
+        
+        # Create telemetry objects
+        telemetry = KrknTelemetryOpenshift(safe_logger, opencli)
+        scenario_telemetry = ScenarioTelemetry()
+        
+        # Config with required settings
+        krkn_config = {
+            "tunings": {
+                "wait_duration": 10
+            },
+            "cerberus": {
+                "cerberus_enabled": False
+            }
+        }
+        
+        # Initialize the plugin
+        plugin = ApplicationOutageScenarioPlugin()
+        
+        # Create test scenario
+        scenario_file = create_test_scenario()
+        
+        # Run the plugin
+        logging.info("Running application outage plugin with real Kubernetes")
+        result = plugin.run(
+            run_uuid="test-k8s-run",
+            scenario=scenario_file,
+            krkn_config=krkn_config,
+            lib_telemetry=telemetry,
+            scenario_telemetry=scenario_telemetry
+        )
+        
+        # Clean up
+        os.unlink(scenario_file)
+        
+        return result
+    except ImportError as e:
+        logging.error(f"Required Kubernetes libraries not available: {e}")
+        return None
+    except Exception as e:
+        logging.error(f"Error running Kubernetes test: {e}")
+        return None
+
+def verify_kubernetes_integration():
+    """Run verification with kubectl if available"""
+    try:
+        # Clean up any existing resources first
+        logging.info("Cleaning up any existing test resources...")
+        subprocess.run(
+            "kubectl delete deployment nginx-test --ignore-not-found",
+            shell=True, check=True
+        )
+        subprocess.run(
+            "kubectl delete service nginx-service --ignore-not-found",
+            shell=True, check=True
+        )
+        
+        # Give Kubernetes a moment to clean up
+        time.sleep(2)
+        
+        # Test 1: Create a test deployment
+        logging.info("Creating test deployment...")
+        subprocess.run(
+            "kubectl create deployment nginx-test --image=nginx",
+            shell=True, check=True
+        )
+        
+        # Add labels in a separate command
+        logging.info("Adding labels to deployment...")
+        subprocess.run(
+            "kubectl label deployment nginx-test app=nginx test-selector=true --overwrite",
+            shell=True, check=True
+        )
+        
+        # Test 2: Expose the deployment
+        logging.info("Exposing deployment as a service...")
+        subprocess.run(
+            "kubectl expose deployment nginx-test --port=80 --name=nginx-service",
+            shell=True, check=True
+        )
+        
+        # Test 3: Run the application outage test
+        result = run_kubernetes_test()
+        
+        # Test 4: Verify connectivity (should be restored after test)
+        logging.info("Verifying connectivity after test...")
+        subprocess.run(
+            "kubectl run -i --rm test-pod --image=busybox --restart=Never -- wget -O- nginx-service",
+            shell=True, check=True
+        )
+        
+        # Clean up
+        logging.info("Cleaning up test resources...")
+        subprocess.run("kubectl delete service nginx-service --ignore-not-found", shell=True)
+        subprocess.run("kubectl delete deployment nginx-test --ignore-not-found", shell=True)
+        
+        return result == 0
+    except subprocess.CalledProcessError:
+        logging.error("Kubernetes commands failed - cluster may not be available")
+        # Clean up even if there was an error
+        subprocess.run("kubectl delete service nginx-service --ignore-not-found", shell=True)
+        subprocess.run("kubectl delete deployment nginx-test --ignore-not-found", shell=True)
+        return False
+    except Exception as e:
+        logging.error(f"Error during verification: {e}")
+        # Clean up even if there was an error
+        subprocess.run("kubectl delete service nginx-service --ignore-not-found", shell=True)
+        subprocess.run("kubectl delete deployment nginx-test --ignore-not-found", shell=True)
+        return False
+
+if __name__ == "__main__":
+    # First try the mock test
+    logging.info("Running mock test...")
+    mock_result = run_mock_test()
+    if mock_result == 0:
+        logging.info("✅ Mock test passed")
+    else:
+        logging.error("❌ Mock test failed")
+    
+    # Then try with Kubernetes if available
+    logging.info("Attempting to run with real Kubernetes...")
+    k8s_result = verify_kubernetes_integration()
+    if k8s_result:
+        logging.info("✅ Kubernetes integration test passed")
+    else:
+        logging.info("❓ Kubernetes integration test unavailable or failed")

--- a/tests/application_outage_test.py
+++ b/tests/application_outage_test.py
@@ -1,0 +1,147 @@
+import unittest
+import tempfile
+import yaml
+import os
+from unittest.mock import MagicMock, patch
+from krkn.scenario_plugins.application_outage.application_outage_scenario_plugin import ApplicationOutageScenarioPlugin
+
+
+class TestApplicationOutageScenarioPlugin(unittest.TestCase):
+    def setUp(self):
+        self.plugin = ApplicationOutageScenarioPlugin()
+        self.mock_lib_telemetry = MagicMock()
+        self.mock_scenario_telemetry = MagicMock()
+        self.mock_k8s = MagicMock()
+        self.mock_lib_telemetry.get_lib_kubernetes.return_value = self.mock_k8s
+        
+        # Create test config
+        self.krkn_config = {
+            "tunings": {
+                "wait_duration": 10
+            },
+            # Add necessary cerberus config to prevent errors
+            "cerberus": {
+                "cerberus_enabled": False
+            }
+        }
+        
+        # Create a temporary scenario file
+        self.temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        self.valid_scenario = {
+            "application_outage": {
+                "namespace": "test-namespace",
+                "pod_selector": {"app": "test-app"},
+                "block": ["Ingress"],
+                "duration": 10
+            }
+        }
+        yaml.dump(self.valid_scenario, self.temp_file)
+        self.temp_file.close()
+    
+    def tearDown(self):
+        os.unlink(self.temp_file.name)
+    
+    @patch('time.sleep')
+    @patch('krkn.scenario_plugins.application_outage.application_outage_scenario_plugin.cerberus')
+    def test_valid_scenario(self, mock_cerberus, mock_sleep):
+        # Mock sleep to avoid waiting during test
+        mock_sleep.return_value = None
+        # Mock cerberus to avoid actual calls
+        mock_cerberus.publish_kraken_status.return_value = None
+        
+        # Run the plugin
+        result = self.plugin.run(
+            run_uuid="test-uuid",
+            scenario=self.temp_file.name,
+            krkn_config=self.krkn_config,
+            lib_telemetry=self.mock_lib_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry
+        )
+        
+        # Verify the result and interactions
+        self.assertEqual(result, 0, "Plugin should exit with 0 on success")
+        self.mock_k8s.create_net_policy.assert_called_once()
+        self.mock_k8s.delete_net_policy.assert_called_once()
+        # Verify cerberus was called
+        mock_cerberus.publish_kraken_status.assert_called_once()
+    
+    def test_invalid_traffic_type(self):
+        # Create scenario with invalid traffic type
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as invalid_file:
+            invalid_scenario = {
+                "application_outage": {
+                    "namespace": "test-namespace",
+                    "pod_selector": {"app": "test-app"},
+                    "block": ["InvalidType"],
+                    "duration": 10
+                }
+            }
+            yaml.dump(invalid_scenario, invalid_file)
+        
+        # Run the plugin
+        result = self.plugin.run(
+            run_uuid="test-uuid",
+            scenario=invalid_file.name,
+            krkn_config=self.krkn_config,
+            lib_telemetry=self.mock_lib_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry
+        )
+        
+        # Verify the result
+        self.assertEqual(result, 1, "Plugin should exit with 1 on invalid traffic type")
+        os.unlink(invalid_file.name)
+    
+    def test_empty_pod_selector(self):
+        # Create scenario with empty pod_selector
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as invalid_file:
+            invalid_scenario = {
+                "application_outage": {
+                    "namespace": "test-namespace",
+                    "pod_selector": {},  # Empty pod selector
+                    "block": ["Ingress"],
+                    "duration": 10
+                }
+            }
+            yaml.dump(invalid_scenario, invalid_file)
+        
+        # Run the plugin
+        result = self.plugin.run(
+            run_uuid="test-uuid",
+            scenario=invalid_file.name,
+            krkn_config=self.krkn_config,
+            lib_telemetry=self.mock_lib_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry
+        )
+        
+        # Verify the result
+        self.assertEqual(result, 1, "Plugin should exit with 1 on empty pod selector")
+        os.unlink(invalid_file.name)
+    
+    def test_missing_pod_selector(self):
+        # Create scenario with missing pod_selector
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as invalid_file:
+            invalid_scenario = {
+                "application_outage": {
+                    "namespace": "test-namespace",
+                    "block": ["Ingress"],
+                    "duration": 10
+                }
+            }
+            yaml.dump(invalid_scenario, invalid_file)
+        
+        # Run the plugin
+        result = self.plugin.run(
+            run_uuid="test-uuid",
+            scenario=invalid_file.name,
+            krkn_config=self.krkn_config,
+            lib_telemetry=self.mock_lib_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry
+        )
+        
+        # Verify the result
+        self.assertEqual(result, 1, "Plugin should exit with 1 on missing pod selector")
+        os.unlink(invalid_file.name)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# PR Description for Application Outage Plugin Fix

## Description
This PR fixes an issue in the application outage plugin where empty pod selectors were causing NetworkPolicy creation failures.

The changes include:
- Added validation to ensure pod_selector is not empty 
- Improved error messaging for better debugging
- Updated NetworkPolicy template with proper labels
- Made cerberus import more robust for testing
- Added comprehensive unit and integration tests to verify behavior
- Updated documentation with clear examples

When an empty pod selector was provided, the plugin would attempt to create a NetworkPolicy with an empty `matchLabels` field, which Kubernetes rejects with a non-zero exit status. This fix ensures proper validation and helpful error messages.

## Documentation
- [x] **Is documentation needed for this update?**
yes

## Related Documentation PR (if applicable)
https://github.com/krkn-chaos/website/pull/67

## Testing Performed
- Unit tests to verify validation logic
- Integration tests with a real Kubernetes cluster
- Manual verification of NetworkPolicy creation and traffic blocking