### PR TITLE
refactor: add ExecutionType Enum

### DIFF
--- a/krkn/scenario_plugins/native/pod_network_outage/pod_network_outage_plugin.py
+++ b/krkn/scenario_plugins/native/pod_network_outage/pod_network_outage_plugin.py
@@ -16,6 +16,7 @@ from kubernetes import client
 from kubernetes.client.api.apiextensions_v1_api import ApiextensionsV1Api
 from kubernetes.client.api.custom_objects_api import CustomObjectsApi
 from . import cerberus
+from krkn.scenario_plugins.types import ExecutionType
 
 
 def get_test_pods(
@@ -457,7 +458,7 @@ def get_ingress_cmd(
     tc_unset = "{0} tc qdisc del dev {1} root ;".format(tc_unset, ifb_dev)
     tc_unset = "{0} tc qdisc del dev {1} ingress".format(tc_unset, test_interface)
     tc_ls = "{0} tc qdisc ls dev {1} ;".format(tc_ls, ifb_dev)
-    if execution == "parallel":
+    if execution == ExecutionType.PARALLEL.value:
         for val in vallst.keys():
             tc_set += " {0} {1} ".format(param_map[val], vallst[val])
         tc_set += ";"
@@ -502,7 +503,7 @@ def get_egress_cmd(
     tc_set = "{0} tc qdisc replace dev {1} root netem".format(tc_set, test_interface)
     tc_unset = "{0} tc qdisc del dev {1} root ;".format(tc_unset, test_interface)
     tc_ls = "{0} tc qdisc ls dev {1} ;".format(tc_ls, test_interface)
-    if execution == "parallel":
+    if execution == ExecutionType.PARALLEL.value:
         for val in vallst.keys():
             tc_set += " {0} {1} ".format(param_map[val], vallst[val])
         tc_set += ";"
@@ -1157,11 +1158,11 @@ class EgressParams:
     )
 
     execution_type: typing.Optional[str] = field(
-        default="parallel",
+        default=ExecutionType.PARALLEL.value,
         metadata={
             "name": "Execution Type",
-            "description": "The order in which the ingress filters are applied. "
-            "Execution type can be 'serial' or 'parallel'",
+            "description": f"The order in which the ingress filters are applied. "
+            f"Execution type can be one of the following: {ExecutionType.available_options}",
         },
     )
 
@@ -1290,7 +1291,7 @@ def pod_egress_shaping(
                         params.execution_type,
                     )
                 )
-            if params.execution_type == "serial":
+            if params.execution_type == ExecutionType.SERIAL.value:
                 logging.info("Waiting for serial job to finish")
                 start_time = int(time.time())
                 wait_for_job(job_list[:], kubecli, params.test_duration + 20)
@@ -1301,9 +1302,9 @@ def pod_egress_shaping(
                     cerberus.publish_kraken_status(
                         params.kraken_config, "", start_time, end_time
                     )
-            if params.execution_type == "parallel":
+            if params.execution_type == ExecutionType.PARALLEL.value:
                 break
-        if params.execution_type == "parallel":
+        if params.execution_type == ExecutionType.PARALLEL.value:
             logging.info("Waiting for parallel job to finish")
             start_time = int(time.time())
             wait_for_job(job_list[:], kubecli, params.test_duration + 300)
@@ -1420,11 +1421,11 @@ class IngressParams:
     )
 
     execution_type: typing.Optional[str] = field(
-        default="parallel",
+        default=ExecutionType.PARALLEL.value,
         metadata={
             "name": "Execution Type",
-            "description": "The order in which the ingress filters are applied. "
-            "Execution type can be 'serial' or 'parallel'",
+            "description": f"The order in which the ingress filters are applied. "
+            f"Execution type can be one of the following: {ExecutionType.available_options}",
         },
     )
 
@@ -1554,7 +1555,7 @@ def pod_ingress_shaping(
                         params.execution_type,
                     )
                 )
-            if params.execution_type == "serial":
+            if params.execution_type == ExecutionType.SERIAL.value:
                 logging.info("Waiting for serial job to finish")
                 start_time = int(time.time())
                 wait_for_job(job_list[:], kubecli, params.test_duration + 20)
@@ -1565,9 +1566,9 @@ def pod_ingress_shaping(
                     cerberus.publish_kraken_status(
                         params.kraken_config, "", start_time, end_time
                     )
-            if params.execution_type == "parallel":
+            if params.execution_type == ExecutionType.PARALLEL.value:
                 break
-        if params.execution_type == "parallel":
+        if params.execution_type == ExecutionType.PARALLEL.value:
             logging.info("Waiting for parallel job to finish")
             start_time = int(time.time())
             wait_for_job(job_list[:], kubecli, params.test_duration + 300)

--- a/krkn/scenario_plugins/network_chaos/network_chaos_scenario_plugin.py
+++ b/krkn/scenario_plugins/network_chaos/network_chaos_scenario_plugin.py
@@ -13,6 +13,7 @@ from krkn_lib.utils import get_yaml_item_value, log_exception
 from krkn import cerberus, utils
 from krkn.scenario_plugins.node_actions import common_node_functions
 from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+from krkn.scenario_plugins.types import ExecutionType
 
 
 class NetworkChaosScenarioPlugin(AbstractScenarioPlugin):
@@ -35,7 +36,7 @@ class NetworkChaosScenarioPlugin(AbstractScenarioPlugin):
                 test_node_label = get_yaml_item_value(
                     test_dict, "label_selector", "node-role.kubernetes.io/master"
                 )
-                test_execution = get_yaml_item_value(test_dict, "execution", "serial")
+                test_execution = get_yaml_item_value(test_dict, "execution", ExecutionType.SERIAL.value)
                 test_instance_count = get_yaml_item_value(
                     test_dict, "instance_count", 1
                 )
@@ -105,7 +106,7 @@ class NetworkChaosScenarioPlugin(AbstractScenarioPlugin):
                                     "NetworkChaosScenarioPlugin Error creating job"
                                 )
                                 return 1
-                        if test_execution == "serial":
+                        if test_execution == ExecutionType.SERIAL.value:
                             logging.info("Waiting for serial job to finish")
                             start_time = int(time.time())
                             self.wait_for_job(
@@ -121,9 +122,9 @@ class NetworkChaosScenarioPlugin(AbstractScenarioPlugin):
                                 start_time,
                                 end_time,
                             )
-                        if test_execution == "parallel":
+                        if test_execution == ExecutionType.PARALLEL.value:
                             break
-                    if test_execution == "parallel":
+                    if test_execution == ExecutionType.PARALLEL.value:
                         logging.info("Waiting for parallel job to finish")
                         start_time = int(time.time())
                         self.wait_for_job(
@@ -237,7 +238,7 @@ class NetworkChaosScenarioPlugin(AbstractScenarioPlugin):
             tc_set = "{0} tc qdisc add dev {1} root netem".format(tc_set, i)
             tc_unset = "{0} tc qdisc del dev {1} root ;".format(tc_unset, i)
             tc_ls = "{0} tc qdisc ls dev {1} ;".format(tc_ls, i)
-            if execution == "parallel":
+            if execution == ExecutionType.PARALLEL.value:
                 for val in vallst.keys():
                     tc_set += " {0} {1} ".format(param_map[val], vallst[val])
                 tc_set += ";"

--- a/krkn/scenario_plugins/network_chaos_ng/models.py
+++ b/krkn/scenario_plugins/network_chaos_ng/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+from krkn.scenario_plugins.types import ExecutionType
 
 
 class NetworkChaosScenarioType(Enum):
@@ -8,7 +9,6 @@ class NetworkChaosScenarioType(Enum):
 
 @dataclass
 class BaseNetworkChaosConfig:
-    supported_execution = ["serial", "parallel"]
     id: str
     wait_duration: int
     test_duration: int
@@ -20,9 +20,9 @@ class BaseNetworkChaosConfig:
     def validate(self) -> list[str]:
         errors = []
         if self.execution is None:
-            errors.append(f"execution cannot be None, supported values are: {','.join(self.supported_execution)}")
-        if self.execution not in self.supported_execution:
-            errors.append(f"{self.execution} is not in supported execution mod: {','.join(self.supported_execution)}")
+            errors.append(f"execution cannot be None, supported values are: {', '.join([e.value for e in ExecutionType])}")
+        if self.execution not in [e.value for e in ExecutionType]:
+            errors.append(f"{self.execution} is not in supported execution mode: {', '.join([e.value for e in ExecutionType])}")
         if self.label_selector is None:
             errors.append("label_selector cannot be None")
         return errors

--- a/krkn/scenario_plugins/network_chaos_ng/network_chaos_ng_scenario_plugin.py
+++ b/krkn/scenario_plugins/network_chaos_ng/network_chaos_ng_scenario_plugin.py
@@ -19,6 +19,7 @@ from krkn.scenario_plugins.network_chaos_ng.modules.abstract_network_chaos_modul
 from krkn.scenario_plugins.network_chaos_ng.network_chaos_factory import (
     NetworkChaosFactory,
 )
+from krkn.scenario_plugins.types import ExecutionType
 
 
 class NetworkChaosNgScenarioPlugin(AbstractScenarioPlugin):
@@ -63,7 +64,7 @@ class NetworkChaosNgScenarioPlugin(AbstractScenarioPlugin):
                     if network_chaos_config[1].instance_count != 0 and network_chaos_config[1].instance_count > len(targets):
                         targets = random.sample(targets, network_chaos_config[1].instance_count)
 
-                    if network_chaos_config[1].execution == "parallel":
+                    if network_chaos_config[1].execution == ExecutionType.PARALLEL.value:
                         self.run_parallel(targets, network_chaos, lib_telemetry)
                     else:
                         self.run_serial(targets, network_chaos, lib_telemetry)

--- a/krkn/scenario_plugins/types.py
+++ b/krkn/scenario_plugins/types.py
@@ -1,0 +1,68 @@
+from enum import Enum
+from typing import List, Optional
+
+class classproperty(property):
+    """
+    A decorator for class-level properties.
+
+    """
+    def __get__(self, instance, owner):
+        return self.fget(owner)
+
+
+class BaseType(Enum):
+    """
+    Base class for all enumeration types in scenario plugins.
+    
+    Provides common utility methods for all type enums.
+    """
+    
+    @classproperty
+    def available_options(cls) -> List[str]:
+        """
+        Returns a list of all available values for this enum.
+        
+        Returns:
+            List[str]: List of string values for all enum options
+        """
+        return [option.value for option in cls]
+    
+    @classmethod
+    def from_string(cls, value: str) -> Optional['BaseType']:
+        """
+        Convert a string value to the corresponding enum member.
+        
+        Args:
+            value: String representation of the enum value
+            
+        Returns:
+            The enum member if found, None otherwise
+        """
+        for item in cls:
+            if item.value == value:
+                return item
+        return None
+
+    @classmethod
+    def validate(cls, value: str) -> bool:
+        """
+        Validates if the provided string is a valid enum value.
+        
+        Args:
+            value: String value to validate
+            
+        Returns:
+            bool: True if value is valid, False otherwise
+        """
+        return cls.from_string(value) is not None
+
+
+class ExecutionType(BaseType):
+    """
+    Defines how scenario operations should be executed.
+    
+    PARALLEL: Run operations concurrently
+    SERIAL: Run operations sequentially
+    """
+    PARALLEL = "parallel"
+    SERIAL = "serial"

--- a/tests/test_ingress_network_plugin.py
+++ b/tests/test_ingress_network_plugin.py
@@ -3,6 +3,7 @@ import logging
 from arcaflow_plugin_sdk import plugin
 
 from krkn.scenario_plugins.native.network import ingress_shaping
+from krkn.scenario_plugins.types import ExecutionType
 
 
 class NetworkScenariosTest(unittest.TestCase):
@@ -28,7 +29,7 @@ class NetworkScenariosTest(unittest.TestCase):
                     "loss": "0.02",
                     "bandwidth": "100mbit",
                 },
-                execution_type="parallel",
+                execution_type=ExecutionType.PARALLEL.value,
             ),
             self.fail,
         )


### PR DESCRIPTION
### Why

This improves maintainability and reduces the risk of errors from typos or inconsistent usage.


### What

Use the `ExecutionType` Enum to represent execution type arguments, replacing the use of hardcoded string literals such as `"parallel"` and `"serial"` in the codebase. 
