### PR TITLE
Updating health checks

### DIFF
--- a/krkn/utils/HealthChecker.py
+++ b/krkn/utils/HealthChecker.py
@@ -13,16 +13,15 @@ class HealthChecker:
 
     def make_request(self, url, auth=None, headers=None, verify=True):
         response_data = {}
-        response = requests.get(url, auth=auth, headers=headers, verify=verify)
+        response = requests.get(url, auth=auth, headers=headers, verify=verify, timeout=3)
         response_data["url"] = url
         response_data["status"] = response.status_code == 200
         response_data["status_code"] = response.status_code
         return response_data
 
 
-    def run_health_check(self, health_check_config, health_check_telemetry_queue: queue.Queue):
+    def run_health_check(self, health_check_config, health_check_telemetry_queue: queue.Queue):        
         if health_check_config and health_check_config["config"] and any(config.get("url") for config in health_check_config["config"]):
-            health_check_start_time_stamp = datetime.now()
             health_check_telemetry = []
             health_check_tracker = {}
             interval = health_check_config["interval"] if health_check_config["interval"] else 2
@@ -37,49 +36,54 @@ class HealthChecker:
                     if config["bearer_token"]:
                         bearer_token = "Bearer " + config["bearer_token"]
                         headers = {"Authorization": bearer_token}
-
                     if config["auth"]: auth = tuple(config["auth"].split(','))
-                    response = self.make_request(url, auth, headers, verify_url)
-
-                    if response["status_code"] != 200:
-                        if config["url"] not in health_check_tracker:
-                            start_timestamp = datetime.now()
-                            health_check_tracker[config["url"]] = {
-                                "status_code": response["status_code"],
-                                "start_timestamp": start_timestamp
-                            }
+                    try: 
+                        response = self.make_request(url, auth, headers, verify_url)
+                    except Exception:
+                        response = {}
+                        response['status_code'] = 500
+                    
+                    if config["url"] not in health_check_tracker:
+                        start_timestamp = datetime.now()
+                        health_check_tracker[config["url"]] = {
+                            "status_code": response["status_code"],
+                            "start_timestamp": start_timestamp
+                        }
+                        if response["status_code"] != 200: 
                             if response_tracker[config["url"]] != False: response_tracker[config["url"]] = False
                             if config["exit_on_failure"] and config["exit_on_failure"] == True and self.ret_value==0: self.ret_value = 2
                     else:
-                        if config["url"] in health_check_tracker:
-                            end_timestamp = datetime.now()
-                            start_timestamp = health_check_tracker[config["url"]]["start_timestamp"]
-                            previous_status_code = str(health_check_tracker[config["url"]]["status_code"])
-                            duration = (end_timestamp - start_timestamp).total_seconds()
-                            downtime_record = {
-                                "url": config["url"],
-                                "status": False,
-                                "status_code": previous_status_code,
-                                "start_timestamp": start_timestamp.isoformat(),
-                                "end_timestamp": end_timestamp.isoformat(),
-                                "duration": duration
-                            }
-                            health_check_telemetry.append(HealthCheck(downtime_record))
-                            del health_check_tracker[config["url"]]
+                            if response["status_code"] != health_check_tracker[config["url"]]["status_code"]:
+                                end_timestamp = datetime.now()
+                                start_timestamp = health_check_tracker[config["url"]]["start_timestamp"]
+                                previous_status_code = str(health_check_tracker[config["url"]]["status_code"])
+                                duration = (end_timestamp - start_timestamp).total_seconds()
+                                change_record = {
+                                    "url": config["url"],
+                                    "status": False,
+                                    "status_code": previous_status_code,
+                                    "start_timestamp": start_timestamp.isoformat(),
+                                    "end_timestamp": end_timestamp.isoformat(),
+                                    "duration": duration
+                                }
+
+                                health_check_telemetry.append(HealthCheck(change_record))
+                                if response_tracker[config["url"]] != True: response_tracker[config["url"]] = True
+                                del health_check_tracker[config["url"]]
                     time.sleep(interval)
             health_check_end_time_stamp = datetime.now()
-            for url, status in response_tracker.items():
-                if status == True:
-                    duration = (health_check_end_time_stamp - health_check_start_time_stamp).total_seconds()
-                    success_response = {
-                        "url": url,
-                        "status": True,
-                        "status_code": 200,
-                        "start_timestamp": health_check_start_time_stamp.isoformat(),
-                        "end_timestamp": health_check_end_time_stamp.isoformat(),
-                        "duration": duration
-                    }
-                    health_check_telemetry.append(HealthCheck(success_response))
+            for url in health_check_tracker.keys():
+                duration = (health_check_end_time_stamp - health_check_tracker[url]["start_timestamp"]).total_seconds()
+                success_response = {
+                    "url": url,
+                    "status": True,
+                    "status_code": response["status_code"],
+                    "start_timestamp": health_check_tracker[url]["start_timestamp"].isoformat(),
+                    "end_timestamp": health_check_end_time_stamp.isoformat(),
+                    "duration": duration
+                }
+                health_check_telemetry.append(HealthCheck(success_response))
+
             health_check_telemetry_queue.put(health_check_telemetry)
         else:
             logging.info("health checks config is not defined, skipping them")


### PR DESCRIPTION
## Description  
Updating health checks to properly report all status'

Noticed that sometimes the health check was only printing off the downtime and not when it was up or vice versa

This should cover: 
- always up
- up, goes down, back up 
- always down 


```
"health_checks": [
            {
                "url": "http://dittybopper-dittybopper.apps***.com",
                "status": false,
                "status_code": "200",
                "start_timestamp": "2025-06-04T14:31:23.898876",
                "end_timestamp": "2025-06-04T14:32:36.651562",
                "duration": 72.752686
            },
            {
                "url": "http://dittybopper-dittybopper.apps***.com",
                "status": false,
                "status_code": "500",
                "start_timestamp": "2025-06-04T14:32:40.703783",
                "end_timestamp": "2025-06-04T14:33:06.385526",
                "duration": 25.681743
            },
            {
                "url": "http://dittybopper-dittybopper.apps***.com",
                "status": true,
                "status_code": 200,
                "start_timestamp": "2025-06-04T14:33:07.678126",
                "end_timestamp": "2025-06-04T14:33:12.556255",
                "duration": 4.878129
            }
        ],
```


## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  