### PR TITLE
Adding kube check into gcp zone

### DIFF
--- a/krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py
+++ b/krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py
@@ -32,6 +32,7 @@ class ZoneOutageScenarioPlugin(AbstractScenarioPlugin):
                 zone_outage_config_yaml = yaml.full_load(f)
                 scenario_config = zone_outage_config_yaml["zone_outage"]
                 cloud_type = scenario_config["cloud_type"]
+                kube_check = get_yaml_item_value(scenario_config, "kube_check", True)
                 start_time = int(time.time())
                 if cloud_type.lower() == "aws":
                     self.cloud_object = AWS()
@@ -40,7 +41,7 @@ class ZoneOutageScenarioPlugin(AbstractScenarioPlugin):
                     kubecli = lib_telemetry.get_lib_kubernetes()
                     if cloud_type.lower() == "gcp":
                         affected_nodes_status = AffectedNodeStatus()
-                        self.cloud_object = gcp_node_scenarios(kubecli, affected_nodes_status)
+                        self.cloud_object = gcp_node_scenarios(kubecli, kube_check, affected_nodes_status)
                         self.node_based_zone(scenario_config, kubecli)
                         affected_nodes_status = self.cloud_object.affected_nodes_status
                         scenario_telemetry.affected_nodes.extend(affected_nodes_status.affected_nodes)


### PR DESCRIPTION
## Description  
Need to add kube check as parameter into gcp zone outage since we're using the node scenario functions

Error: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/64134/rehearse-64134-periodic-ci-redhat-chaos-prow-scripts-main-4.18-nightly-gcp-fipsetcd-krkn-hub-node-tests/1932529253853696000/artifacts/gcp-fipsetcd-krkn-hub-node-tests/redhat-chaos-zone-outage/build-log.txt

## Documentation  
- [X] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
https://github.com/krkn-chaos/website/pull/88 