### PR TITLE
added workload image as scenario parameter

### DIFF
--- a/krkn/scenario_plugins/network_chaos_ng/models.py
+++ b/krkn/scenario_plugins/network_chaos_ng/models.py
@@ -6,6 +6,7 @@ class NetworkChaosScenarioType(Enum):
     Node = 1
     Pod = 2
 
+
 @dataclass
 class BaseNetworkChaosConfig:
     supported_execution = ["serial", "parallel"]
@@ -20,12 +21,17 @@ class BaseNetworkChaosConfig:
     def validate(self) -> list[str]:
         errors = []
         if self.execution is None:
-            errors.append(f"execution cannot be None, supported values are: {','.join(self.supported_execution)}")
+            errors.append(
+                f"execution cannot be None, supported values are: {','.join(self.supported_execution)}"
+            )
         if self.execution not in self.supported_execution:
-            errors.append(f"{self.execution} is not in supported execution mod: {','.join(self.supported_execution)}")
+            errors.append(
+                f"{self.execution} is not in supported execution mod: {','.join(self.supported_execution)}"
+            )
         if self.label_selector is None:
             errors.append("label_selector cannot be None")
         return errors
+
 
 @dataclass
 class NetworkFilterConfig(BaseNetworkChaosConfig):
@@ -34,6 +40,7 @@ class NetworkFilterConfig(BaseNetworkChaosConfig):
     interfaces: list[str]
     target: str
     ports: list[int]
+    workload_image: str
 
     def validate(self) -> list[str]:
         errors = super().validate()

--- a/krkn/scenario_plugins/network_chaos_ng/modules/node_network_filter.py
+++ b/krkn/scenario_plugins/network_chaos_ng/modules/node_network_filter.py
@@ -41,6 +41,7 @@ class NodeNetworkFilterModule(AbstractNetworkChaosModule):
                     namespace=self.config.namespace,
                     host_network=True,
                     target=target,
+                    workload_image=self.config.workload_image,
                 )
             )
             self.log_info(

--- a/krkn/scenario_plugins/network_chaos_ng/modules/templates/network-chaos.j2
+++ b/krkn/scenario_plugins/network_chaos_ng/modules/templates/network-chaos.j2
@@ -12,6 +12,6 @@ spec:
   containers:
   - name: fedora
     imagePullPolicy: Always
-    image: quay.io/krkn-chaos/krkn-network-chaos:latest
+    image: {{workload_image}}
     securityContext:
       privileged: true

--- a/scenarios/kube/network-filter.yml
+++ b/scenarios/kube/network-filter.yml
@@ -1,7 +1,8 @@
 - id: node_network_filter
+  workload_image: "quay.io/krkn-chaos/krkn-network-chaos:latest"
   wait_duration: 300
   test_duration: 100
-  label_selector: "kubernetes.io/hostname=ip-10-0-39-182.us-east-2.compute.internal"
+  label_selector: "kubernetes.io/hostname=minikube"
   namespace: 'default'
   instance_count: 1
   execution: parallel


### PR DESCRIPTION
## Description  
this change introduces `workload_image` parameter to allow user in air-gapped environment to mirror the network filter workload on the private repo.

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  