### PR TITLE
Disable SSL verification for IBM node scenarios and fix node reboot s…

### DIFF
--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -120,7 +120,8 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             node_scenario["cloud_type"].lower() == "ibm"
             or node_scenario["cloud_type"].lower() == "ibmcloud"
         ):
-            return ibm_node_scenarios(kubecli, node_action_kube_check, affected_nodes_status)
+            disable_ssl_verification = get_yaml_item_value(node_scenario, "disable_ssl_verification", True)
+            return ibm_node_scenarios(kubecli, node_action_kube_check, affected_nodes_status, disable_ssl_verification)
         else:
             logging.error(
                 "Cloud type "

--- a/scenarios/openshift/ibmcloud_node_scenarios.yml
+++ b/scenarios/openshift/ibmcloud_node_scenarios.yml
@@ -7,6 +7,7 @@ node_scenarios:
     timeout: 360
     duration: 120
     cloud_type: ibm
+    disable_ssl_verification: true  # Set to true for CI environments with certificate issues
   - actions:
     - node_reboot_scenario
     node_name:
@@ -14,3 +15,4 @@ node_scenarios:
     instance_count: 1
     timeout: 120
     cloud_type: ibm
+    disable_ssl_verification: true  # Set to true for CI environments with certificate issues


### PR DESCRIPTION
…cenario

## Description  
IBM Cloud node scenarios were failing due SSL certificate verification errors. 
Added DISABLE_SSL_VERIFICATION environment variable to disable SSL verification for IBM Cloud VPC API calls.

failure link : https://prow.ci.openshift.org/job-history/gs/test-platform-results/pr-logs/directory/rehearse-66408-pull-ci-redhat-chaos-prow-scripts-main-4.19-nightly-krkn-hub-ibm-cloud-node-tests-compact


## Documentation  
- [x] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  