### PR TITLE
Hog ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,27 +21,7 @@ jobs:
           helm repo add stable https://charts.helm.sh/stable
           helm repo update
       - name: Deploy prometheus & Port Forwarding
-        run: |
-          kubectl create namespace prometheus-k8s
-          helm install \
-          --wait --timeout 360s \
-          kind-prometheus \
-          prometheus-community/kube-prometheus-stack \
-          --namespace prometheus-k8s \
-          --set prometheus.service.nodePort=30000 \
-          --set prometheus.service.type=NodePort \
-          --set grafana.service.nodePort=31000 \
-          --set grafana.service.type=NodePort \
-          --set alertmanager.service.nodePort=32000 \
-          --set alertmanager.service.type=NodePort \
-          --set prometheus-node-exporter.service.nodePort=32001 \
-          --set prometheus-node-exporter.service.type=NodePort \
-          --set prometheus.prometheusSpec.maximumStartupDurationSeconds=300
-
-          SELECTOR=`kubectl -n prometheus-k8s get service kind-prometheus-kube-prome-prometheus -o wide --no-headers=true | awk '{ print $7 }'`
-          POD_NAME=`kubectl -n prometheus-k8s get pods --selector="$SELECTOR" --no-headers=true | awk '{ print $1 }'`
-          kubectl -n prometheus-k8s port-forward $POD_NAME 9090:9090 &
-          sleep 5
+        uses: redhat-chaos/actions/prometheus@main
       - name: Install Python
         uses: actions/setup-python@v4
         with:

--- a/CI/tests/test_cpu_hog.sh
+++ b/CI/tests/test_cpu_hog.sh
@@ -7,7 +7,7 @@ trap finish EXIT
 
 
 function functional_test_cpu_hog {
-  yq -i '.node_selector="kubernetes.io/hostname=kind-worker2"' scenarios/kube/cpu-hog.yml
+  yq -i '."node-selector"="kubernetes.io/hostname=kind-worker2"' scenarios/kube/cpu-hog.yml
 
   export scenario_type="hog_scenarios"
   export scenario_file="scenarios/kube/cpu-hog.yml"

--- a/CI/tests/test_io_hog.sh
+++ b/CI/tests/test_io_hog.sh
@@ -5,12 +5,13 @@ source CI/tests/common.sh
 trap error ERR
 trap finish EXIT
 
-
 function functional_test_io_hog {
-  yq -i '.node_selector="kubernetes.io/hostname=kind-worker2"' scenarios/kube/io-hog.yml
+  yq -i '."node-selector"="kubernetes.io/hostname=kind-worker2"' scenarios/kube/io-hog.yml
   export scenario_type="hog_scenarios"
   export scenario_file="scenarios/kube/io-hog.yml"
   export post_config=""
+
+  cat $scenario_file
   envsubst < CI/config/common_test_config.yaml > CI/config/io_hog.yaml
   python3 -m coverage run -a run_kraken.py -c CI/config/io_hog.yaml
   echo "IO Hog: Success"

--- a/CI/tests/test_memory_hog.sh
+++ b/CI/tests/test_memory_hog.sh
@@ -7,7 +7,7 @@ trap finish EXIT
 
 
 function functional_test_memory_hog {
-  yq -i '.node_selector="kubernetes.io/hostname=kind-worker2"' scenarios/kube/memory-hog.yml
+  yq -i '."node-selector"="kubernetes.io/hostname=kind-worker2"' scenarios/kube/memory-hog.yml
   export scenario_type="hog_scenarios"
   export scenario_file="scenarios/kube/memory-hog.yml"
   export post_config=""


### PR DESCRIPTION
## Description  
Editing node_selector field to node-selector for hog scenarios to properly run CI tests 

Also replacing prometheus installation to use the common action in redhat-chaos/actions



```
results CI/out/test_io_hog.out
+ source CI/tests/common.sh
++ ERRORED=false
+ trap error ERR
+ trap finish EXIT
+ functional_test_io_hog
+ yq -i '."node-selector"="kubernetes.io/hostname=kind-worker2"' scenarios/kube/io-hog.yml
+ export scenario_type=hog_scenarios
+ scenario_type=hog_scenarios
+ export scenario_file=scenarios/kube/io-hog.yml
+ scenario_file=scenarios/kube/io-hog.yml
+ export post_config=
+ post_config=
+ cat scenarios/kube/io-hog.yml
duration: 30
workers: '' # leave it empty '' node cpu auto-detection
hog-type: io
image: quay.io/krkn-chaos/krkn-hog
namespace: default
io-block-size: 1m
io-write-bytes: 1g
io-target-pod-folder: /hog-data
io-target-pod-volume:
  name: node-volume
  hostPath:
    path: /root # a path writable by kubelet in the root filesystem of the node
node-selector: "kubernetes.io/hostname=kind-worker2"
number-of-nodes: ''
taints: [] #example ["node-role.kubernetes.io/master:NoSchedule"]
+ envsubst
+ python3 -m coverage run -a run_kraken.py -c CI/config/io_hog.yaml
2025-07-10 19:27:17,206 [INFO] Starting kraken
2025-07-10 19:27:17,224 [INFO] Initializing client to talk to the Kubernetes cluster
2025-07-10 19:27:17,224 [INFO] Generated a uuid for the run: 1321ab98-81f5-4139-ae3c-51af9663f717
2025-07-10 19:27:17,259 [INFO] Detected distribution kubernetes
2025-07-10 19:27:17,553 [INFO] Fetching cluster info
2025-07-10 19:27:17,554 [INFO] Cluster version CRD not detected, skipping
2025-07-10 19:27:17,554 [INFO] Server URL: https://127.0.0.1:36481
2025-07-10 19:27:17,554 [INFO] Daemon mode not enabled, will run through 1 iterations

2025-07-10 19:27:20,328 [INFO] 📣 `ScenarioPluginFactory`: types from config.yaml mapped to respective classes for execution:
2025-07-10 19:27:20,328 [INFO]   ✅ type: application_outages_scenarios ➡️ `ApplicationOutageScenarioPlugin` 
2025-07-10 19:27:20,328 [INFO]   ✅ type: container_scenarios ➡️ `ContainerScenarioPlugin` 
2025-07-10 19:27:20,328 [INFO]   ✅ type: hog_scenarios ➡️ `HogsScenarioPlugin` 
2025-07-10 19:27:20,328 [INFO]   ✅ type: kubevirt_vm_outage ➡️ `KubevirtVmOutageScenarioPlugin` 
2025-07-10 19:27:20,328 [INFO]   ✅ type: managedcluster_scenarios ➡️ `ManagedClusterScenarioPlugin` 
2025-07-10 19:27:20,328 [INFO]   ✅ types: [pod_network_scenarios, ingress_node_scenarios] ➡️ `NativeScenarioPlugin` 
2025-07-10 19:27:20,328 [INFO]   ✅ type: network_chaos_scenarios ➡️ `NetworkChaosScenarioPlugin` 
2025-07-10 19:27:20,328 [INFO]   ✅ type: network_chaos_ng_scenarios ➡️ `NetworkChaosNgScenarioPlugin` 
2025-07-10 19:27:20,328 [INFO]   ✅ type: node_scenarios ➡️ `NodeActionsScenarioPlugin` 
2025-07-10 19:27:20,328 [INFO]   ✅ type: pod_disruption_scenarios ➡️ `PodDisruptionScenarioPlugin` 
2025-07-10 19:27:20,329 [INFO]   ✅ type: pvc_scenarios ➡️ `PvcScenarioPlugin` 
2025-07-10 19:27:20,329 [INFO]   ✅ type: service_disruption_scenarios ➡️ `ServiceDisruptionScenarioPlugin` 
2025-07-10 19:27:20,329 [INFO]   ✅ type: service_hijacking_scenarios ➡️ `ServiceHijackingScenarioPlugin` 
2025-07-10 19:27:20,329 [INFO]   ✅ type: cluster_shut_down_scenarios ➡️ `ShutDownScenarioPlugin` 
2025-07-10 19:27:20,329 [INFO]   ✅ type: syn_flood_scenarios ➡️ `SynFloodScenarioPlugin` 
2025-07-10 19:27:20,329 [INFO]   ✅ type: time_scenarios ➡️ `TimeActionsScenarioPlugin` 
2025-07-10 19:27:20,329 [INFO]   ✅ type: zone_outages_scenarios ➡️ `ZoneOutageScenarioPlugin` 
2025-07-10 19:27:20,329 [INFO] 

2025-07-10 19:27:20,329 [INFO] health checks config is not defined, skipping them
2025-07-10 19:27:20,329 [INFO] Executing scenarios for iteration 0
2025-07-10 19:27:20,335 [INFO] Running HogsScenarioPlugin: ['hog_scenarios'] -> scenarios/kube/io-hog.yml
2025-07-10 19:27:20,358 [INFO] running io hog scenario
2025-07-10 19:27:20,358 [INFO] targeting nodes: [kind-worker2]
2025-07-10 19:27:20,375 [INFO] [kind-worker2] detected 4 cpus for node kind-worker2
2025-07-10 19:27:20,375 [INFO] [kind-worker2] workers number: 4
2025-07-10 19:27:53,753 [INFO] [kind-worker2] waiting 30 up to seconds pod: io-hog-rxhdr namespace: default to finish
2025-07-10 19:27:53,773 [INFO] [kind-worker2] deleting pod: io-hog-rxhdr namespace: default
2025-07-10 19:27:53,831 [INFO] [kind-worker2] detected disk space allocated: -175.65888201871712 MB
2025-07-10 19:27:54,054 [INFO] Find cluster events in file /tmp/events.json
2025-07-10 19:27:54,054 [INFO] wating 6 before running the next scenario
2025-07-10 19:28:00,060 [INFO] collecting Kubernetes cluster metadata....
2025-07-10 19:28:00,618 [INFO] Chaos data:
{
    "telemetry": {
        "scenarios": [
            {
                "start_timestamp": 1752175640,
                "end_timestamp": 1752175673,
                "scenario": "scenarios/kube/io-hog.yml",
                "scenario_type": "hog_scenarios",
                "exit_status": 0,
                "parameters_base64": "",
                "parameters": {
                    "duration": 30,
                    "hog-type": "io",
                    "image": "quay.io/krkn-chaos/krkn-hog",
                    "io-block-size": "1m",
                    "io-target-pod-folder": "/hog-data",
                    "io-target-pod-volume": {
                        "hostPath": {
                            "path": "/root"
                        },
                        "name": "node-volume"
                    },
                    "io-write-bytes": "1g",
                    "namespace": "default",
                    "node-selector": "kubernetes.io/hostname=kind-worker2",
                    "number-of-nodes": "",
                    "taints": [],
                    "workers": ""
                },
                "affected_pods": {
                    "recovered": [],
                    "unrecovered": [],
                    "error": null
                },
                "affected_nodes": [],
                "cluster_events": []
            }
        ],
        "node_summary_infos": [
            {
                "count": 5,
                "architecture": "amd64",
                "instance_type": "unknown",
                "nodes_type": "unknown",
                "kernel_version": "6.11.0-1015-azure",
                "kubelet_version": "v1.32.0",
                "os_version": "Debian GNU/Linux 12 (bookworm)"
            }
        ],
        "node_taints": [
            {
                "node_name": "kind-control-plane",
                "effect": "NoSchedule",
                "key": "node-role.kubernetes.io/control-plane",
                "value": null
            },
            {
                "node_name": "kind-control-plane2",
                "effect": "NoSchedule",
                "key": "node-role.kubernetes.io/control-plane",
                "value": null
            },
            {
                "node_name": "kind-control-plane3",
                "effect": "NoSchedule",
                "key": "node-role.kubernetes.io/control-plane",
                "value": null
            }
        ],
        "kubernetes_objects_count": {
            "ConfigMap": 47,
            "Pod": 39,
            "Deployment": 5
        },
        "network_plugins": [
            "Unknown"
        ],
        "timestamp": "2025-07-10T19:27:17Z",
        "health_checks": null,
        "total_node_count": 5,
        "cloud_infrastructure": null,
        "cloud_type": null,
        "cluster_version": "1.32",
        "major_version": ".32",
        "run_uuid": "1321ab98-81f5-4139-ae3c-51af9663f717",
        "job_status": true
    },
    "critical_alerts": null
}
2025-07-10 19:28:00,618 [INFO] telemetry collection disabled, skipping.
2025-07-10 19:28:00,618 [INFO] Successfully finished running Kraken. UUID for the run: 1321ab98-81f5-4139-ae3c-51af9663f717. Report generated at kraken.report. Exiting
 _              _              
| | ___ __ __ _| | _____ _ __  
| |/ / '__/ _` | |/ / _ \ '_ \ 
|   <| | | (_| |   <  __/ | | |
|_|\_\_|  \__,_|_|\_\___|_| |_|
                               

+ echo 'IO Hog: Success'
IO Hog: Success
+ finish
+ '[' 0 '!=' 0 ']'

```


## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  