### PR TITLE
Update network scenario image

### DIFF
--- a/CI/templates/outage_pod.yaml
+++ b/CI/templates/outage_pod.yaml
@@ -8,7 +8,7 @@ spec:
   hostNetwork: true
   containers:
   - name: fedtools
-    image: docker.io/fedora/tools
+    image: quay.io/krkn-chaos/krkn:tools
     command:
     - /bin/sh
     - -c

--- a/CI/templates/time_pod.yaml
+++ b/CI/templates/time_pod.yaml
@@ -8,7 +8,7 @@ spec:
   hostNetwork: true
   containers:
   - name: fedtools
-    image: docker.io/fedora/tools
+    image: quay.io/krkn-chaos/krkn:tools
     command:
     - /bin/sh
     - -c

--- a/krkn/scenario_plugins/native/network/job.j2
+++ b/krkn/scenario_plugins/native/network/job.j2
@@ -9,7 +9,7 @@ spec:
       hostNetwork: true
       containers:
       - name: networkchaos
-        image: docker.io/fedora/tools
+        image: quay.io/krkn-chaos/krkn:tools
         command: ["/bin/sh",  "-c", "{{cmd}}"]
         securityContext:
           privileged: true

--- a/krkn/scenario_plugins/native/network/pod_interface.j2
+++ b/krkn/scenario_plugins/native/network/pod_interface.j2
@@ -7,7 +7,7 @@ spec:
   nodeName: {{nodename}}
   containers:
   - name: fedtools
-    image: docker.io/fedora/tools
+    image: quay.io/krkn-chaos/krkn:tools
     command:
     - /bin/sh
     - -c

--- a/krkn/scenario_plugins/native/network/pod_module.j2
+++ b/krkn/scenario_plugins/native/network/pod_module.j2
@@ -6,7 +6,7 @@ spec:
   nodeName: {{nodename}}
   containers:
   - name: modtools
-    image: docker.io/fedora/tools
+    image: quay.io/krkn-chaos/krkn:tools
     imagePullPolicy: IfNotPresent
     command:
     - /bin/sh

--- a/krkn/scenario_plugins/native/pod_network_outage/job.j2
+++ b/krkn/scenario_plugins/native/pod_network_outage/job.j2
@@ -9,7 +9,7 @@ spec:
       hostNetwork: true
       containers:
       - name: networkchaos
-        image: docker.io/fedora/tools
+        image: quay.io/krkn-chaos/krkn:tools
         command: ["chroot", "/host", "/bin/sh",  "-c", "{{cmd}}"]
         securityContext:
           privileged: true

--- a/krkn/scenario_plugins/native/pod_network_outage/pod_module.j2
+++ b/krkn/scenario_plugins/native/pod_network_outage/pod_module.j2
@@ -6,7 +6,7 @@ spec:
   nodeName: {{nodename}}
   containers:
   - name: modtools
-    image: docker.io/fedora/tools
+    image: quay.io/krkn-chaos/krkn:tools
     imagePullPolicy: IfNotPresent
     command:
     - /bin/sh

--- a/krkn/scenario_plugins/network_chaos/job.j2
+++ b/krkn/scenario_plugins/network_chaos/job.j2
@@ -9,7 +9,7 @@ spec:
       hostNetwork: true
       containers:
       - name: networkchaos
-        image: docker.io/fedora/tools
+        image: quay.io/krkn-chaos/krkn:tools
         command: ["/bin/sh",  "-c", "{{cmd}}"]
         securityContext:
           privileged: true

--- a/krkn/scenario_plugins/network_chaos/pod.j2
+++ b/krkn/scenario_plugins/network_chaos/pod.j2
@@ -7,7 +7,7 @@ spec:
   nodeName: {{nodename}}
   containers:
   - name: fedtools
-    image: docker.io/fedora/tools
+    image: quay.io/krkn-chaos/krkn:tools
     command:
     - /bin/sh
     - -c


### PR DESCRIPTION
## Description  
This commit updates fedora tools image reference used by the network scenarios to the one hosted in the krkn-chaos quay org. This also fixes the issues with RHACS flagging runs when using latest tag by using tools tag instead:

```
Container 'modtools' has image with tag 'latest'\n\n\nIn case of emergency, add the annotation {\"[admission.stackrox.io/break-glass\](http://admission.stackrox.io/break-glass%5C)": \"ticket-xyz\"} to your deployment with an updated ticket number\n\n","reason":"Failed currently enforced policies from RHACS","code":400}
```

