### PR TITLE
[Rollback Scenario] Refactor execution

### DIFF
--- a/krkn/rollback/command.py
+++ b/krkn/rollback/command.py
@@ -96,17 +96,10 @@ def execute_rollback(telemetry_ocp: "KrknTelemetryOpenshift", run_uuid: Optional
     :return: Exit code (0 for success, 1 for error)
     """
     logging.info("Executing rollback version files")
-    
-    if not run_uuid:
-        logging.error("run_uuid is required for execute-rollback command")
-        return 1
-    
-    if not scenario_type:
-        logging.warning("scenario_type is not specified, executing all scenarios in rollback directory")
-    
+    logging.info(f"Executing rollback for run_uuid={run_uuid  or '*'}, scenario_type={scenario_type or '*'}")
+
     try:
         # Execute rollback version files
-        logging.info(f"Executing rollback for run_uuid={run_uuid}, scenario_type={scenario_type or '*'}")
         execute_rollback_version_files(telemetry_ocp, run_uuid, scenario_type)
         
         # If execution was successful, cleanup the version files

--- a/krkn/rollback/command.py
+++ b/krkn/rollback/command.py
@@ -100,7 +100,12 @@ def execute_rollback(telemetry_ocp: "KrknTelemetryOpenshift", run_uuid: Optional
 
     try:
         # Execute rollback version files
-        execute_rollback_version_files(telemetry_ocp, run_uuid, scenario_type)
+        execute_rollback_version_files(
+            telemetry_ocp,
+            run_uuid,
+            scenario_type,
+            ignore_auto_rollback_config=True
+        )
         return 0
         
     except Exception as e:

--- a/krkn/rollback/command.py
+++ b/krkn/rollback/command.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional, TYPE_CHECKING
 
 from krkn.rollback.config import RollbackConfig
-from krkn.rollback.handler import execute_rollback_version_files, cleanup_rollback_version_files
+from krkn.rollback.handler import execute_rollback_version_files
 
 
 
@@ -101,12 +101,6 @@ def execute_rollback(telemetry_ocp: "KrknTelemetryOpenshift", run_uuid: Optional
     try:
         # Execute rollback version files
         execute_rollback_version_files(telemetry_ocp, run_uuid, scenario_type)
-        
-        # If execution was successful, cleanup the version files
-        logging.info("Rollback execution completed successfully, cleaning up version files")
-        cleanup_rollback_version_files(run_uuid, scenario_type)
-        
-        logging.info("Rollback execution and cleanup completed successfully")
         return 0
         
     except Exception as e:

--- a/krkn/rollback/config.py
+++ b/krkn/rollback/config.py
@@ -108,7 +108,7 @@ class RollbackConfig(metaclass=SingletonMeta):
         return f"{cls().versions_directory}/{rollback_context}"
     
     @classmethod
-    def is_rollback_version_file_format(cls, file_name: str) -> bool:
+    def is_rollback_version_file_format(cls, file_name: str, expected_scenario_type: str | None = None) -> bool:
         """
         Validate the format of a rollback version file name.
 
@@ -120,6 +120,7 @@ class RollbackConfig(metaclass=SingletonMeta):
             - .py: file extension
 
         :param file_name: The name of the file to validate.
+        :param expected_scenario_type: The expected scenario type (if any) to validate against.
         :return: True if the file name matches the expected format, False otherwise.
         """
         if not file_name.endswith(".py"):
@@ -134,7 +135,7 @@ class RollbackConfig(metaclass=SingletonMeta):
         hash_suffix_with_ext = parts[-1]
         hash_suffix = hash_suffix_with_ext[:-3]
 
-        if not scenario_type:
+        if expected_scenario_type and scenario_type != expected_scenario_type:
             return False
 
         if not timestamp_str.isdigit():
@@ -144,9 +145,39 @@ class RollbackConfig(metaclass=SingletonMeta):
             return False
 
         return True
+    
+    @classmethod
+    def is_rollback_context_directory_format(cls, directory_name: str, expected_run_uuid: str | None = None) -> bool:
+        """
+        Validate the format of a rollback context directory name.
+
+        Expected format: <timestamp>-<run_uuid>
+        where:
+            - timestamp: integer (nanoseconds since epoch)
+            - run_uuid: alphanumeric string
+
+        :param directory_name: The name of the directory to validate.
+        :param expected_run_uuid: The expected run UUID (if any) to validate against.
+        :return: True if the directory name matches the expected format, False otherwise.
+        """
+        parts = directory_name.split("-", 1)
+        if len(parts) != 2:
+            return False
+
+        timestamp_str, run_uuid = parts
+
+        # Validate timestamp is numeric
+        if not timestamp_str.isdigit():
+            return False
+
+        # Validate run_uuid
+        if expected_run_uuid and expected_run_uuid != run_uuid:
+            return False
+
+        return True
 
     @classmethod
-    def search_rollback_version_files(cls, run_uuid: str, scenario_type: str | None = None) -> list[str]:
+    def search_rollback_version_files(cls, run_uuid: str | None = None, scenario_type: str | None = None) -> list[str]:
         """
         Search for rollback version files based on run_uuid and scenario_type.
 
@@ -161,33 +192,31 @@ class RollbackConfig(metaclass=SingletonMeta):
         if not os.path.exists(cls().versions_directory):
             return []
 
-        rollback_context_directories = [
-            dirname for dirname in os.listdir(cls().versions_directory) if run_uuid in dirname
-        ]
+        rollback_context_directories = []
+        for dir in os.listdir(cls().versions_directory):
+            if cls.is_rollback_context_directory_format(dir, run_uuid):
+                rollback_context_directories.append(dir)
+            else:
+                logger.warning(f"Directory {dir} does not match expected pattern of <timestamp>-<run_uuid>")
+
         if not rollback_context_directories:
             logger.warning(f"No rollback context directories found for run UUID {run_uuid}")
             return []
 
-        if len(rollback_context_directories) > 1:
-            logger.warning(
-                f"Expected one directory for run UUID {run_uuid}, found: {rollback_context_directories}"
-            )
-
-        rollback_context_directory = rollback_context_directories[0]
 
         version_files = []
-        scenario_rollback_versions_directory = os.path.join(
-            cls().versions_directory, rollback_context_directory
-        )
-        for file in os.listdir(scenario_rollback_versions_directory):
-            if cls.is_rollback_version_file_format(file):
-                version_files.append(
-                    os.path.join(scenario_rollback_versions_directory, file)
-                )
-            else:
-                logger.warning(
-                    f"File {file} does not match expected pattern for scenario type {scenario_type}"
-                )
+        for rollback_context_dir in rollback_context_directories:
+            rollback_context_dir = os.path.join(cls().versions_directory, rollback_context_dir)
+
+            for file in os.listdir(rollback_context_dir):
+                if cls.is_rollback_version_file_format(file, scenario_type):
+                    version_files.append(
+                        os.path.join(rollback_context_dir, file)
+                    )
+                else:
+                    logger.warning(
+                        f"File {file} does not match expected pattern of <{scenario_type or '*'}>_<timestamp>_<hash_suffix>.py"
+                    )
         return version_files
 
 @dataclass(frozen=True)

--- a/krkn/rollback/handler.py
+++ b/krkn/rollback/handler.py
@@ -117,15 +117,25 @@ def _parse_rollback_module(version_file_path: str) -> tuple[RollbackCallable, Ro
     return rollback_callable, rollback_content
 
 
-def execute_rollback_version_files(telemetry_ocp: "KrknTelemetryOpenshift", run_uuid: str, scenario_type: str | None = None):
+def execute_rollback_version_files(
+    telemetry_ocp: "KrknTelemetryOpenshift",
+    run_uuid: str | None = None,
+    scenario_type: str | None = None,
+    ignore_auto_rollback_config: bool = False
+):
     """
     Execute rollback version files for the given run_uuid and scenario_type.
     This function is called when a signal is received to perform rollback operations.
     
     :param run_uuid: Unique identifier for the run.
     :param scenario_type: Type of the scenario being rolled back.
+    :param ignore_auto_rollback_config: Flag to ignore auto rollback configuration. Will be set to True for manual execute-rollback calls.
     """
-    
+
+    if not ignore_auto_rollback_config and RollbackConfig.auto is False:
+        logger.warning(f"Auto rollback is disabled, skipping execution for run_uuid={run_uuid or '*'}, scenario_type={scenario_type or '*'}")
+        return
+
     # Get the rollback versions directory
     version_files = RollbackConfig.search_rollback_version_files(run_uuid, scenario_type)
     if not version_files:

--- a/krkn/rollback/handler.py
+++ b/krkn/rollback/handler.py
@@ -170,6 +170,30 @@ def execute_rollback_version_files(
                 logger.error(f"Failed to rename rollback version file {version_file}: {e}")
                 raise
 
+def cleanup_rollback_version_files(run_uuid: str, scenario_type: str):
+    """
+    Cleanup rollback version files for the given run_uuid and scenario_type.
+    This function is called to remove the rollback version files after successful scenario execution in run_scenarios.
+    
+    :param run_uuid: Unique identifier for the run.
+    :param scenario_type: Type of the scenario being rolled back.
+    """
+
+    # Get the rollback versions directory
+    version_files = RollbackConfig.search_rollback_version_files(run_uuid, scenario_type)
+    if not version_files:
+        logger.warning(f"Skip cleanup for run_uuid={run_uuid}, scenario_type={scenario_type or '*'}")
+        return
+
+    # Remove all version files in the directory
+    logger.info(f"Cleaning up rollback version files for run_uuid={run_uuid}, scenario_type={scenario_type}")
+    for version_file in version_files:
+        try:
+            os.remove(version_file)
+            logger.info(f"Removed {version_file} successfully.")
+        except Exception as e:
+            logger.error(f"Failed to remove rollback version file {version_file}: {e}")
+            raise
 
 class RollbackHandler:
     def __init__(

--- a/krkn/rollback/handler.py
+++ b/krkn/rollback/handler.py
@@ -129,11 +129,11 @@ def execute_rollback_version_files(telemetry_ocp: "KrknTelemetryOpenshift", run_
     # Get the rollback versions directory
     version_files = RollbackConfig.search_rollback_version_files(run_uuid, scenario_type)
     if not version_files:
-        logger.warning(f"Skip execution for run_uuid={run_uuid}, scenario_type={scenario_type or '*'}")
+        logger.warning(f"Skip execution for run_uuid={run_uuid or '*'}, scenario_type={scenario_type or '*'}")
         return
 
     # Execute all version files in the directory
-    logger.info(f"Executing rollback version files for run_uuid={run_uuid}, scenario_type={scenario_type or '*'}")
+    logger.info(f"Executing rollback version files for run_uuid={run_uuid or '*'}, scenario_type={scenario_type or '*'}")
     for version_file in version_files:
         try:
             logger.info(f"Executing rollback version file: {version_file}")
@@ -144,37 +144,21 @@ def execute_rollback_version_files(telemetry_ocp: "KrknTelemetryOpenshift", run_
             logger.info('Executing rollback callable...')
             rollback_callable(rollback_content, telemetry_ocp)
             logger.info('Rollback completed.')
-            
-            logger.info(f"Executed {version_file} successfully.")
+            success = True
         except Exception as e:
+            success = False
             logger.error(f"Failed to execute rollback version file {version_file}: {e}")
             raise
 
-
-def cleanup_rollback_version_files(run_uuid: str, scenario_type: str):
-    """
-    Cleanup rollback version files for the given run_uuid and scenario_type.
-    This function is called to remove the rollback version files after execution.
-    
-    :param run_uuid: Unique identifier for the run.
-    :param scenario_type: Type of the scenario being rolled back.
-    """
-    
-    # Get the rollback versions directory
-    version_files = RollbackConfig.search_rollback_version_files(run_uuid, scenario_type)
-    if not version_files:
-        logger.warning(f"Skip cleanup for run_uuid={run_uuid}, scenario_type={scenario_type or '*'}")
-        return
-    
-    # Remove all version files in the directory
-    logger.info(f"Cleaning up rollback version files for run_uuid={run_uuid}, scenario_type={scenario_type}")
-    for version_file in version_files:
-        try:
-            os.remove(version_file)
-            logger.info(f"Removed {version_file} successfully.")
-        except Exception as e:
-            logger.error(f"Failed to remove rollback version file {version_file}: {e}")
-            raise
+        # Rename the version file with .executed suffix if successful
+        if success:
+            try:
+                executed_file = f"{version_file}.executed"
+                os.rename(version_file, executed_file)
+                logger.info(f"Renamed {version_file} to {executed_file} successfully.")
+            except Exception as e:
+                logger.error(f"Failed to rename rollback version file {version_file}: {e}")
+                raise
 
 
 class RollbackHandler:

--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -7,8 +7,7 @@ from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 from krkn import utils
 from krkn.rollback.handler import (
     RollbackHandler,
-    execute_rollback_version_files,
-    cleanup_rollback_version_files
+    execute_rollback_version_files
 )
 from krkn.rollback.signal import signal_handler
 from krkn.rollback.serialization import Serializer
@@ -120,9 +119,6 @@ class AbstractScenarioPlugin(ABC):
                 execute_rollback_version_files(
                     telemetry, run_uuid, scenario_telemetry.scenario_type
                 )
-            cleanup_rollback_version_files(
-                run_uuid, scenario_telemetry.scenario_type
-            )
             scenario_telemetry.exit_status = return_value
             scenario_telemetry.end_timestamp = time.time()
             utils.collect_and_put_ocp_logs(

--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -7,7 +7,8 @@ from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 from krkn import utils
 from krkn.rollback.handler import (
     RollbackHandler,
-    execute_rollback_version_files
+    execute_rollback_version_files,
+    cleanup_rollback_version_files
 )
 from krkn.rollback.signal import signal_handler
 from krkn.rollback.serialization import Serializer
@@ -114,8 +115,12 @@ class AbstractScenarioPlugin(ABC):
                     )
                     return_value = 1
 
-            # execute rollback files based on the return value
-            if return_value != 0:
+            if return_value == 0:
+                cleanup_rollback_version_files(
+                    run_uuid, scenario_telemetry.scenario_type
+                )
+            else:
+                # execute rollback files based on the return value
                 execute_rollback_version_files(
                     telemetry, run_uuid, scenario_telemetry.scenario_type
                 )

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -163,6 +163,17 @@ class TestRollbackScenarioPlugin:
 
 class TestRollbackConfig:
 
+    @pytest.mark.parametrize("directory_name,run_uuid,expected", [
+        ("123456789-abcdefgh", "abcdefgh", True),
+        ("123456789-abcdefgh", None, True),
+        ("123456789-abcdefgh", "ijklmnop", False),
+        ("123456789-", "abcdefgh", False),
+        ("-abcdefgh", "abcdefgh", False),
+        ("123456789-abcdefgh-ijklmnop", "abcdefgh", False),
+    ])
+    def test_is_rollback_context_directory_format(self, directory_name, run_uuid, expected):
+        assert RollbackConfig.is_rollback_context_directory_format(directory_name, run_uuid) == expected
+
     @pytest.mark.parametrize("file_name,expected", [
         ("simple_rollback_scenario_123456789_abcdefgh.py", True),
         ("simple_rollback_scenario_123456789_abcdefgh.py.executed", False),


### PR DESCRIPTION
## Description  


- Validate the format of context dis and version file when collecting
- Respect `auto_rollback` config in `execute_rollback_version_files` by adding  `ignore_auto_rollback_config` parameter
- Rename the version file by adding `.executed` extension instead of removing it
- For `execute-rollback` command
  - By default execute all version files under `/tmp/kraken-rollback`
  - Make `--run_id` flag optional 
- Add unit tests
  - `test_is_rollback_context_directory_format`
  - `test_is_rollback_version_file_format`
  - `test_execute_rollback_command_ignore_auto_rollback_config`
  - `test_run_scenarios_respect_auto_rollback_config`

## Documentation  
- [x] **Is documentation needed for this update?**


## Related Documentation PR (if applicable)  

TODO, should update the [[Rollback Scenarios] Add Overall Documentation #125](https://github.com/krkn-chaos/website/pull/125) to reflect the change in PR.