### PR TITLE
Adding vm name option

### DIFF
--- a/krkn/utils/VirtChecker.py
+++ b/krkn/utils/VirtChecker.py
@@ -57,7 +57,7 @@ class VirtChecker:
         :param namespace:
         :return: virtctl_status 'True' if successful, or an error message if it fails.
         """
-        virtctl_vm_cmd = f"virtctl ssh --local-ssh-opts='-o BatchMode=yes' --local-ssh-opts='-o PasswordAuthentication=no' --local-ssh-opts='-o ConnectTimeout=2' root@{vm_name} -n {namespace}"
+        virtctl_vm_cmd = f"virtctl ssh --local-ssh-opts='-o BatchMode=yes' --local-ssh-opts='-o PasswordAuthentication=no' --local-ssh-opts='-o ConnectTimeout=2' root@vmi/{vm_name} -n {namespace} 2>&1 |egrep 'denied|verification failed'  && echo 'True' || echo 'False'"
         check_virtctl_vm_cmd = f"virtctl ssh --local-ssh-opts='-o BatchMode=yes' --local-ssh-opts='-o PasswordAuthentication=no' --local-ssh-opts='-o ConnectTimeout=2' root@{vm_name} -n {namespace} 2>&1 |egrep 'denied|verification failed'  && echo 'True' || echo 'False'"
         if 'True' in invoke_no_exit(check_virtctl_vm_cmd):
             return True


### PR DESCRIPTION
## Description  
I think in newer versions of vritctl it expects a type of object when trying to connect 

 root@rhel-** error

root@vm/rhel-** works

```
 % virtctl ssh --local-ssh-opts='-o BatchMode=yes' --local-ssh-opts='-o PasswordAuthentication=no' --local-ssh-opts='-o ConnectTimeout=2' root@rhel-** -n openshift-cnv 2>&1      
You are using a client virtctl version that is different from the KubeVirt version running in the cluster
Client Version: 1.6.0
Server Version: v1.4.1-49-g9bfe27961c

target must contain type and name separated by '/'
```

After fix running in podman
```
        "health_checks": null,
        "virt_checks": [
            {
                "node_name": "prubenda-**.c.chaos-438115.internal",
                "ip_address": "10.**",
                "namespace": "openshift-cnv",
                "vm_name": "rhel-10-copper-**-81",
                "status": false,
                "start_timestamp": "2025-09-04T20:44:01.779900",
                "end_timestamp": "2025-09-04T20:44:43.657009",
                "duration": 41.877109
            },
            {
                "node_name": "prubenda-**.c.chaos-438115.internal",
                "ip_address": "10.**",
                "namespace": "openshift-cnv",
                "vm_name": "rhel-10-copper-**-81",
                "status": true,
                "start_timestamp": "2025-09-04T20:44:46.671068",
                "end_timestamp": "2025-09-04T20:45:13.043729",
                "duration": 26.372661
            }
        ],
        "total_node_count": 7,
        "cloud_infrastructure": "GCP",
        "cloud_type": "self-managed",
        "cluster_version": "4.18.0-0.nightly-2025-03-13-035622",
        "major_version": "4.18",
        "run_uuid": "c0caaa59-7c54-4a51-aece-346f9968cee3",
        "job_status": true,
        "build_url": "manual"
    },
    "critical_alerts": null
```

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  