### PR TITLE
Add exclude_label parameter to time disruption scenario

### DIFF
--- a/krkn/scenario_plugins/time_actions/time_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/time_actions/time_actions_scenario_plugin.py
@@ -144,6 +144,10 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
                 node_names = scenario["object_name"]
             elif "label_selector" in scenario.keys() and scenario["label_selector"]:
                 node_names = kubecli.list_nodes(scenario["label_selector"])
+                # going to filter out nodes with the exclude_label if it is provided
+                if "exclude_label" in scenario.keys() and scenario["exclude_label"]:
+                    excluded_nodes = kubleci.list_nodes(scenario["exclude_label"])
+                    node_names = [node for node in node_names if node not in excluded_nodes]
             for node in node_names:
                 self.skew_node(node, scenario["action"], kubecli)
                 logging.info("Reset date/time on node " + str(node))
@@ -189,6 +193,10 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
                     counter += 1
             elif "label_selector" in scenario.keys() and scenario["label_selector"]:
                 pod_names = kubecli.get_all_pods(scenario["label_selector"])
+                # and here filter out the pods with exclude_label if it is provided
+                if "exclude_label" in scenario.keys() and scenario["exclude_label"]:
+                    excluded_pods = kubleci.get_all_pods(scenario["exclude_label"])
+                    pod_names = [pod for pod in pod_names if pod not in excluded_pods]
 
             if len(pod_names) == 0:
                 logging.info(


### PR DESCRIPTION
## Type of change
Add exclude_label parameter to time disruption scenario

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

## Description  
<!-- Provide a brief description of the changes made in this PR. -->  
Added `exclude_label` parameter to the time disruption scenario mentioned. This parameter will filter out the pods/nodes that match the exclude label when using `label_selector`.

First pull request ever, quite exciting, any feedback is welcome.

## Related Tickets & Documents

- Related Issue #951 
- Closes #951 

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  
More than happy to create a docs PR if requested by the maintainers 😄 

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.