### PR TITLE
Add rollback functionality to NodeActionsScenarioPlugin

### DIFF
--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -3,6 +3,7 @@ import logging
 import time
 from multiprocessing.pool import ThreadPool
 from itertools import repeat
+import base64
 
 import yaml
 from krkn_lib.k8s import KrknKubernetes
@@ -77,7 +78,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                         self.rollback_node_action,
                         RollbackContent(
                             namespace=None,
-                            resource_identifier=str(node_details[idx]),
+                            resource_identifier=str(base64.b64encode(json.dumps(node_details[idx]).encode('utf-8')).decode('utf-8')),
                         ),
                     )
                     return 1
@@ -353,7 +354,8 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         try:
             logging.info("Starting node action rollback...")
             import json # noqa
-            rollback_data = json.loads(rollback_content.resource_identifier)
+            import base64 # noqa
+            rollback_data = json.loads(base64.b64decode(rollback_content.resource_identifier.encode('utf-8')).decode('utf-8'))
             node_scenario = rollback_data["node_details"]
             failed_action = rollback_data["rollback_action"]
             


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

## Description  
this PR implements rollback node actions scenario in a chaos run 
- Implements a node_details json string with rollback action data ,  `rollback_node_action` static function to Deserializes JSON from rollback content and runs rollback process.
- Skips if action was: `node_start_scenario`, `node_stop_scenario`, `node_termination_scenario`, `node_reboot_scenario`  (These actions don't leave nodes in bad state)
- Continues for actions like: stop_kubelet_scenario, node_crash_scenario, etc.
- Gets nodes from scenario config (by name or label selector) and Uses Kubernetes API to find affected nodes
- creates a cloud scenario object and check each node & recover it. 

> I only tested with Kind k8s cluster , This PR might fail if any cloud managed cluster used with , this PR has been made under my assumptions and based on suggestions from @paigerube14 


## Related Tickets & Documents

- Closes #916 

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.