### PR TITLE
Fixing batch size limit

### DIFF
--- a/krkn/utils/VirtChecker.py
+++ b/krkn/utils/VirtChecker.py
@@ -127,7 +127,7 @@ class VirtChecker:
             # Provided prints to easily visualize how the threads are processed.    
             for i in range (0, len(self.vm_list),self.batch_size):
                 if i+self.batch_size > len(self.vm_list):
-                    sub_list = self.vm_list[i:  len(self.vm_list)-1]
+                    sub_list = self.vm_list[i:]
                 else:
                     sub_list = self.vm_list[i: i+self.batch_size]
                 index = i

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -408,13 +408,8 @@ def main(options, command: Optional[str]) -> int:
         
         kubevirt_checker.thread_join()
         kubevirt_check_telem = []
-        i =0
-        while i <= kubevirt_checker.threads_limit:
-            if not kubevirt_check_telemetry_queue.empty():
-                kubevirt_check_telem.extend(kubevirt_check_telemetry_queue.get_nowait())
-            else:
-                break
-            i+= 1
+        while not kubevirt_check_telemetry_queue.empty():
+            kubevirt_check_telem.extend(kubevirt_check_telemetry_queue.get_nowait())
         chaos_telemetry.virt_checks = kubevirt_check_telem
         post_kubevirt_check = kubevirt_checker.gather_post_virt_checks(kubevirt_check_telem)
         chaos_telemetry.post_virt_checks = post_kubevirt_check


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization

## Description  
Fixing when there are less than the batch size number of vm's to add to the list for tracking. 

Batch size: 2
VMs: 21

Missing the last one, added test for coverage


## Related Tickets & Documents

- Related Issue #
- Closes #

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.