### PR TITLE
#950: Add exclude label support to container scenario plugin

### DIFF
--- a/scenarios/kube/container_dns.yml
+++ b/scenarios/kube/container_dns.yml
@@ -6,3 +6,4 @@ scenarios:
   action: 1
   count: 1
   retry_wait: 60
+  exclude_label: ""

--- a/scenarios/openshift/container_etcd.yml
+++ b/scenarios/openshift/container_etcd.yml
@@ -6,3 +6,4 @@ scenarios:
   action: 1
   count: 1
   expected_recovery_time: 120
+  exclude_label: ""


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization

## Description  
Add exclude label support to container scenario plugin, allowing users to exclude specific pods from chaos testing based on labels. This enhancement provides more granular control over which containers are targeted during chaos scenarios.

## Related Tickets & Documents

- Related Issue #
- Closes #
#950

## Documentation  
- [X] **Is documentation needed for this update?**
If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
https://github.com/krkn-chaos/website/pull/179

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
<img width="1050" height="247" alt="Screenshot 2025-11-20 at 4 07 20 PM" src="https://github.com/user-attachments/assets/25dd8f1e-340c-4c34-be25-6c4de7def875" />

