### PR TITLE
Fix CI failure by excluding temporary files from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,18 +5,3 @@ omit =
     /tmp/*
     */tmp*
     **/version_template.j2
-
-[report]
-ignore_errors = True
-omit =
-    tests/*
-    krkn/tests/**
-    /tmp/*
-    */tmp*
-    **/version_template.j2
-
-[html]
-skip_empty = True
-
-[json]
-pretty_print = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,5 @@
 omit =
     tests/*
     krkn/tests/**
-    /tmp/*
     */tmp*
     **/version_template.j2

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,21 @@
 omit =
     tests/*
     krkn/tests/**
+    /tmp/*
+    */tmp*
+    **/version_template.j2
+
+[report]
+ignore_errors = True
+omit =
+    tests/*
+    krkn/tests/**
+    /tmp/*
+    */tmp*
+    **/version_template.j2
+
+[html]
+skip_empty = True
+
+[json]
+pretty_print = True


### PR DESCRIPTION
…eporting

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

## Description  
<!-- Provide a brief description of the changes made in this PR. -->  
Due to a CI error:

```
/home/runner/work/krkn/krkn/krkn/rollback/version_template.j2:51: SyntaxWarning: 'set' object is not callable; perhaps you missed a comma? No source for code: '/tmp/tmp5qmvs6gs.py'. Error: Process completed with exit code 1.
```

When the tests finished, the temporary files were deleted. However, the coverage HTML report attempted to read these deleted temporary files, which caused the failure.

To resolve this, I added a report section in `.coveragerc` to omit the temporary file paths.


## Related Tickets & Documents

- Related Issue #1031
- Closes #

## Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<!-- Add the link to the corresponding documentation PR in the website repository -->  

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.