### PR TITLE
feature: aws-s3-replication-chaos-scenario

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,7 @@ jobs:
           sudo apt-get install build-essential python3-dev
           pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r CI/tests_v2/requirements.txt
           pip install coverage
 
       - name: Deploy test workloads

--- a/CI/tests_v2/requirements.txt
+++ b/CI/tests_v2/requirements.txt
@@ -13,3 +13,6 @@ pytest-html>=4.1.0
 pytest-timeout>=2.2.0
 pytest-order>=1.2.0
 pytest-xdist>=3.5.0
+
+# AWS mocking for S3 replication tests
+moto[s3]==5.2.0

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -58,6 +58,9 @@ kraken:
               - scenarios/kubevirt/kubevirt-vm-outage.yaml
        - http_load_scenarios:
               - scenarios/kube/http_load_scenario.yml
+       - aws_s3_replication_scenarios:                    # AWS S3 replication chaos scenarios
+           - scenarios/aws_s3_replication/s3_replication_pause.yaml
+           - scenarios/aws_s3_replication/s3_replication_extended.yaml
 
 resiliency:
   resiliency_run_mode: standalone  # Options: standalone, detailed, disabled

--- a/krkn/scenario_plugins/aws_s3_replication/__init__.py
+++ b/krkn/scenario_plugins/aws_s3_replication/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""AWS S3 Replication Chaos Scenario Plugin.
+
+This plugin provides chaos engineering scenarios for AWS S3 bucket replication.
+It allows testing application resilience when S3 replication is temporarily paused.
+"""

--- a/krkn/scenario_plugins/aws_s3_replication/aws_s3_replication_scenario_plugin.py
+++ b/krkn/scenario_plugins/aws_s3_replication/aws_s3_replication_scenario_plugin.py
@@ -1,0 +1,293 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""AWS S3 Replication Chaos Scenario Plugin.
+
+This plugin implements chaos scenarios for AWS S3 bucket replication,
+allowing testing of application resilience when replication is temporarily paused.
+"""
+
+import base64
+import json
+import logging
+import time
+
+import yaml
+from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+from krkn_lib.utils import get_yaml_item_value
+
+from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+from krkn.scenario_plugins.aws_s3_replication.aws_s3_scenarios import AWSS3Replication
+from krkn.rollback.config import RollbackContent
+from krkn.rollback.handler import set_rollback_context_decorator
+
+
+class AwsS3ReplicationScenarioPlugin(AbstractScenarioPlugin):
+    """Plugin for AWS S3 replication chaos scenarios."""
+
+    @set_rollback_context_decorator
+    def run(
+        self,
+        run_uuid: str,
+        scenario: str,
+        lib_telemetry: KrknTelemetryOpenshift,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        """Execute the AWS S3 replication chaos scenario.
+
+        Args:
+            run_uuid: Unique identifier for this chaos run
+            scenario: Path to the scenario configuration file
+            lib_telemetry: Telemetry object for monitoring
+            scenario_telemetry: Scenario-specific telemetry
+
+        Returns:
+            int: 0 if successful, 1 if failed
+        """
+        try:
+            # Load scenario configuration
+            with open(scenario, "r") as f:
+                config_yaml = yaml.safe_load(f)
+                scenario_config = config_yaml["aws_s3_replication_scenarios"]
+
+            # Parse configuration parameters
+            bucket_name = get_yaml_item_value(scenario_config, "bucket_name", None)
+
+            try:
+                duration = int(get_yaml_item_value(scenario_config, "duration", 300))
+            except (TypeError, ValueError):
+                logging.error(f"AwsS3ReplicationScenarioPlugin: Invalid duration value '{scenario_config.get('duration')}', must be an integer.")
+                return 1
+                
+            region = get_yaml_item_value(scenario_config, "region", None)
+
+            logging.info(
+                "AWS S3 Replication Chaos Scenario - Input parameters:\n"
+                f"  Bucket name: '{bucket_name}'\n"
+                f"  Duration: {duration}s\n"
+                f"  Region: '{region if region else 'default'}'"
+            )
+
+            # Validate required parameters
+            if not bucket_name:
+                logging.error(
+                    "AwsS3ReplicationScenarioPlugin: 'bucket_name' is required. "
+                    "Please specify the S3 bucket name in the scenario configuration."
+                )
+                return 1
+
+            if duration <= 0:
+                logging.error(
+                    f"AwsS3ReplicationScenarioPlugin: Invalid duration '{duration}'. "
+                    f"Duration must be a positive integer (seconds)."
+                )
+                return 1
+
+            # Initialize AWS S3 handler
+            s3_handler = AWSS3Replication(region=region)
+
+            # Record start time for telemetry
+            start_time = int(time.time())
+
+            # Step 1: Save current replication config and pause replication
+            # pause_replication() internally retrieves and returns the original config
+            logging.info(
+                f"Step 1/3: Pausing replication for bucket '{bucket_name}'..."
+            )
+            
+            try:
+                original_config = s3_handler.pause_replication(bucket_name)
+                if not original_config or not original_config.get("Rules"):
+                    logging.error(f"AwsS3ReplicationScenarioPlugin: No original replication config retrieved for bucket '{bucket_name}', aborting.")
+                    return 1
+                
+                # Set rollback callable to ensure replication is restored on failure or interruption
+                rollback_data = {
+                    "bucket_name": bucket_name,
+                    "region": region,
+                    "original_config": original_config,
+                }
+                json_str = json.dumps(rollback_data)
+                encoded_data = base64.b64encode(json_str.encode('utf-8')).decode('utf-8')
+                
+                self.rollback_handler.set_rollback_callable(
+                    self.rollback_replication,
+                    RollbackContent(
+                        namespace="aws-s3",  # Logical namespace for AWS resources
+                        resource_identifier=encoded_data,
+                    ),
+                )
+                
+            except Exception as e:
+                logging.error(
+                    f"AwsS3ReplicationScenarioPlugin: Failed to pause replication: {str(e)}"
+                )
+                return 1
+
+            # Step 2: Wait for specified duration (chaos period)
+            logging.info(
+                f"Step 2/3: Replication paused. Waiting for {duration}s (chaos period)..."
+            )
+            
+            # Log periodic status updates during wait
+            elapsed = 0
+            log_interval = min(60, duration // 4) if duration >= 60 else duration
+            
+            while elapsed < duration:
+                wait_time = min(log_interval, duration - elapsed)
+                time.sleep(wait_time)
+                elapsed += wait_time
+                
+                if elapsed < duration:
+                    remaining = duration - elapsed
+                    logging.info(
+                        f"Chaos period in progress... {elapsed}s elapsed, {remaining}s remaining"
+                    )
+            
+            logging.info(f"Chaos period completed ({duration}s)")
+
+            # Step 3: Restore replication
+            logging.info(
+                f"Step 3/3: Restoring replication for bucket '{bucket_name}'..."
+            )
+            
+            try:
+                s3_handler.restore_replication(bucket_name, original_config)
+                logging.info(f"Successfully restored replication for bucket '{bucket_name}'")
+                
+                # Verify restored rule statuses match the original configuration.
+                # Comparing statuses avoids false warnings when the original policy
+                # intentionally includes disabled rules.
+                current_config = s3_handler.get_replication_configuration(bucket_name)
+                original_rules = {
+                    rule.get("ID"): rule.get("Status")
+                    for rule in original_config.get("Rules", [])
+                    if rule.get("ID")
+                }
+                current_rules = {
+                    rule.get("ID"): rule.get("Status")
+                    for rule in current_config.get("Rules", [])
+                    if rule.get("ID")
+                }
+
+                if current_rules == original_rules:
+                    logging.info(
+                        "Replication status verification: restored rule statuses match "
+                        "the original configuration."
+                    )
+                else:
+                    logging.warning(
+                        "Replication status verification: restored rule statuses do not "
+                        "match the original configuration. Please verify replication "
+                        "configuration manually."
+                    )
+                
+            except Exception as e:
+                logging.error(
+                    f"AwsS3ReplicationScenarioPlugin: Failed to restore replication: {str(e)}"
+                )
+                return 1
+
+            # Record end time and publish status
+            end_time = int(time.time())
+            total_duration = end_time - start_time
+            
+            logging.info(
+                f"AWS S3 Replication chaos scenario completed successfully in {total_duration}s"
+            )
+            
+            return 0
+
+        except FileNotFoundError:
+            logging.error(
+                f"AwsS3ReplicationScenarioPlugin: Scenario configuration file not found: {scenario}"
+            )
+            return 1
+        
+        except yaml.YAMLError as e:
+            logging.error(
+                f"AwsS3ReplicationScenarioPlugin: Failed to parse scenario configuration: {str(e)}"
+            )
+            return 1
+        
+        except KeyError as e:
+            logging.error(
+                f"AwsS3ReplicationScenarioPlugin: Missing required configuration key: {str(e)}. "
+                f"Please ensure 'aws_s3_replication_scenarios' is defined in the scenario file."
+            )
+            return 1
+        
+        except RuntimeError as e:
+            logging.error(
+                f"AwsS3ReplicationScenarioPlugin: Runtime error during scenario execution: {str(e)}"
+            )
+            return 1
+        
+        except Exception as e:
+            logging.error(
+                f"AwsS3ReplicationScenarioPlugin: Unexpected error during scenario execution: {str(e)}"
+            )
+            return 1
+
+    @staticmethod
+    def rollback_replication(
+        rollback_content: RollbackContent,
+        lib_telemetry: KrknTelemetryOpenshift,
+    ):
+        """Rollback function to restore S3 replication configuration.
+
+        This function is called automatically if the scenario fails or is interrupted,
+        ensuring that replication is restored to its original state.
+
+        Args:
+            rollback_content: Rollback content containing encoded configuration data
+            lib_telemetry: Telemetry object (not used for AWS operations)
+        """
+        try:
+            # Decode rollback data
+            decoded_data = base64.b64decode(
+                rollback_content.resource_identifier.encode('utf-8')
+            ).decode('utf-8')
+            rollback_data = json.loads(decoded_data)
+            
+            bucket_name = rollback_data["bucket_name"]
+            region = rollback_data.get("region")
+            original_config = rollback_data["original_config"]
+            
+            logging.info(
+                f"Rolling back AWS S3 replication scenario: "
+                f"Restoring replication for bucket '{bucket_name}'"
+            )
+            
+            # Initialize S3 handler and restore configuration
+            s3_handler = AWSS3Replication(region=region)
+            s3_handler.restore_replication(bucket_name, original_config)
+            
+            logging.info(
+                f"AWS S3 replication rollback completed successfully for bucket '{bucket_name}'"
+            )
+            
+        except Exception as e:
+            logging.error(
+                f"Failed to rollback AWS S3 replication scenario: {str(e)}. "
+                f"Manual intervention may be required to restore replication."
+            )
+
+    def get_scenario_types(self) -> list[str]:
+        """Return the scenario types handled by this plugin.
+
+        Returns:
+            list[str]: List containing 'aws_s3_replication_scenarios'
+        """
+        return ["aws_s3_replication_scenarios"]

--- a/krkn/scenario_plugins/aws_s3_replication/aws_s3_scenarios.py
+++ b/krkn/scenario_plugins/aws_s3_replication/aws_s3_scenarios.py
@@ -1,0 +1,308 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""AWS S3 Replication operations for chaos scenarios.
+
+This module provides the core functionality for pausing and restoring
+S3 bucket replication configurations.
+"""
+
+import logging
+import copy
+import boto3
+from botocore.exceptions import ClientError, BotoCoreError
+
+
+class AWSS3Replication:
+    """Handles AWS S3 replication operations for chaos scenarios."""
+
+    def __init__(self, region=None, s3_client=None):
+        """Initialize AWS S3 Replication handler.
+
+        Args:
+            region: AWS region name (optional, uses default if not specified)
+            s3_client: Pre-configured boto3 S3 client (optional, for testing)
+        """
+        if s3_client is not None:
+            # Use provided client (for testing with moto/localstack)
+            self.s3_client = s3_client
+        else:
+            # Create real AWS client
+            if region:
+                self.s3_client = boto3.client('s3', region_name=region)
+            else:
+                self.s3_client = boto3.client('s3')
+        
+        logging.info("AWS S3 Replication handler initialized")
+
+    def get_replication_configuration(self, bucket_name):
+        """Retrieve the current replication configuration for a bucket.
+
+        Args:
+            bucket_name: Name of the S3 bucket
+
+        Returns:
+            dict: The replication configuration
+
+        Raises:
+            RuntimeError: If unable to retrieve configuration
+        """
+        try:
+            logging.info(f"Retrieving replication configuration for bucket: {bucket_name}")
+            response = self.s3_client.get_bucket_replication(Bucket=bucket_name)
+            
+            if 'ReplicationConfiguration' not in response:
+                logging.error(
+                    f"Bucket {bucket_name} returned empty replication configuration"
+                )
+                raise RuntimeError(
+                    f"Bucket {bucket_name} has no replication configuration"
+                )
+            
+            config = response['ReplicationConfiguration']
+            num_rules = len(config.get('Rules', []))
+            logging.info(
+                f"Successfully retrieved replication configuration with {num_rules} rule(s)"
+            )
+            return config
+            
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            
+            if error_code == 'ReplicationConfigurationNotFoundError':
+                logging.error(
+                    f"Bucket '{bucket_name}' has no replication configured. "
+                    f"This scenario requires S3 replication to be set up first. "
+                    f"Please configure replication before running this chaos scenario."
+                )
+            elif error_code == 'NoSuchBucket':
+                logging.error(
+                    f"Bucket '{bucket_name}' does not exist. "
+                    f"Please verify the bucket name and try again."
+                )
+            elif error_code == 'AccessDenied':
+                logging.error(
+                    f"Access denied when trying to get replication configuration for bucket '{bucket_name}'. "
+                    f"The IAM user/role lacks 's3:GetReplicationConfiguration' permission. "
+                    f"Please add the required IAM permissions and try again."
+                )
+            else:
+                logging.error(
+                    f"Failed to get replication configuration for bucket '{bucket_name}': "
+                    f"{error_code} - {e.response['Error'].get('Message', 'Unknown error')}"
+                )
+            
+            raise RuntimeError(
+                f"Failed to retrieve replication configuration for bucket '{bucket_name}'"
+            )
+        
+        except BotoCoreError as e:
+            logging.error(
+                f"AWS connection error while accessing bucket '{bucket_name}': {str(e)}"
+            )
+            raise RuntimeError(
+                f"AWS connection error for bucket '{bucket_name}'"
+            )
+        
+        except Exception as e:
+            logging.error(
+                f"Unexpected error retrieving replication configuration for bucket '{bucket_name}': {str(e)}"
+            )
+            raise RuntimeError(
+                f"Unexpected error for bucket '{bucket_name}'"
+            )
+
+    def pause_replication(self, bucket_name):
+        """Pause replication by disabling all replication rules.
+
+        Args:
+            bucket_name: Name of the S3 bucket
+
+        Returns:
+            dict: The original replication configuration (for restoration)
+
+        Raises:
+            RuntimeError: If unable to pause replication
+        """
+        try:
+            # Get current configuration
+            original_config = self.get_replication_configuration(bucket_name)
+            
+            # Create a deep copy to modify
+            modified_config = copy.deepcopy(original_config)
+            
+            # Disable all replication rules
+            disabled_count = 0
+            for rule in modified_config.get('Rules', []):
+                if rule.get('Status') == 'Enabled':
+                    rule['Status'] = 'Disabled'
+                    disabled_count += 1
+                    logging.debug(f"Disabling replication rule: {rule.get('ID', 'unknown')}")
+            
+            if disabled_count == 0:
+                logging.warning(
+                    f"No enabled replication rules found for bucket '{bucket_name}'. "
+                    f"Replication may already be paused."
+                )
+            
+            # Apply the modified configuration
+            logging.info(
+                f"Pausing replication for bucket '{bucket_name}' "
+                f"({disabled_count} rule(s) will be disabled)"
+            )
+            
+            self.s3_client.put_bucket_replication(
+                Bucket=bucket_name,
+                ReplicationConfiguration=modified_config
+            )
+            
+            logging.info(
+                f"Successfully paused replication for bucket '{bucket_name}'"
+            )
+            
+            # Return original config for restoration
+            return original_config
+            
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            
+            if error_code == 'AccessDenied':
+                logging.error(
+                    f"Access denied when trying to pause replication for bucket '{bucket_name}'. "
+                    f"The IAM user/role lacks 's3:PutReplicationConfiguration' permission. "
+                    f"Please add the required IAM permissions and try again."
+                )
+            else:
+                logging.error(
+                    f"Failed to pause replication for bucket '{bucket_name}': "
+                    f"{error_code} - {e.response['Error'].get('Message', 'Unknown error')}"
+                )
+            
+            raise RuntimeError(
+                f"Failed to pause replication for bucket '{bucket_name}'"
+            )
+        
+        except Exception as e:
+            logging.error(
+                f"Unexpected error pausing replication for bucket '{bucket_name}': {str(e)}"
+            )
+            raise RuntimeError(
+                f"Unexpected error pausing replication for bucket '{bucket_name}'"
+            )
+
+    def restore_replication(self, bucket_name, original_config):
+        """Restore replication by re-enabling rules from original configuration.
+
+        Args:
+            bucket_name: Name of the S3 bucket
+            original_config: The original replication configuration to restore
+
+        Raises:
+            RuntimeError: If unable to restore replication
+        """
+        try:
+            if not original_config:
+                logging.error(
+                    f"Cannot restore replication for bucket '{bucket_name}': "
+                    f"original configuration is empty or None"
+                )
+                raise RuntimeError(
+                    f"Cannot restore replication for bucket '{bucket_name}': "
+                    f"original configuration is invalid or missing"
+                )
+            
+            enabled_count = sum(
+                1 for rule in original_config.get('Rules', [])
+                if rule.get('Status') == 'Enabled'
+            )
+            
+            logging.info(
+                f"Restoring replication for bucket '{bucket_name}' "
+                f"({enabled_count} rule(s) will be re-enabled)"
+            )
+            
+            self.s3_client.put_bucket_replication(
+                Bucket=bucket_name,
+                ReplicationConfiguration=original_config
+            )
+            
+            logging.info(
+                f"Successfully restored replication for bucket '{bucket_name}'"
+            )
+            
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            
+            if error_code == 'AccessDenied':
+                logging.error(
+                    f"Access denied when trying to restore replication for bucket '{bucket_name}'. "
+                    f"The IAM user/role lacks 's3:PutReplicationConfiguration' permission. "
+                    f"Please add the required IAM permissions and try again."
+                )
+            else:
+                logging.error(
+                    f"Failed to restore replication for bucket '{bucket_name}': "
+                    f"{error_code} - {e.response['Error'].get('Message', 'Unknown error')}"
+                )
+            
+            raise RuntimeError(
+                f"Failed to restore replication for bucket '{bucket_name}'"
+            )
+        
+        except Exception as e:
+            logging.error(
+                f"Unexpected error restoring replication for bucket '{bucket_name}': {str(e)}"
+            )
+            raise RuntimeError(
+                f"Unexpected error restoring replication for bucket '{bucket_name}'"
+            )
+
+    def verify_replication_status(self, bucket_name, expected_status='Enabled'):
+        """Verify the current status of replication rules.
+
+        Args:
+            bucket_name: Name of the S3 bucket
+            expected_status: Expected status ('Enabled' or 'Disabled')
+
+        Returns:
+            bool: True if all rules match expected status, False otherwise
+        """
+        try:
+            config = self.get_replication_configuration(bucket_name)
+            rules = config.get('Rules', [])
+            
+            if not rules:
+                logging.warning(f"No replication rules found for bucket '{bucket_name}'")
+                return False
+            
+            status_match = all(
+                rule.get('Status') == expected_status
+                for rule in rules
+            )
+            
+            if status_match:
+                logging.info(
+                    f"All replication rules for bucket '{bucket_name}' are '{expected_status}'"
+                )
+            else:
+                logging.warning(
+                    f"Not all replication rules for bucket '{bucket_name}' are '{expected_status}'"
+                )
+            
+            return status_match
+            
+        except Exception as e:
+            logging.error(
+                f"Failed to verify replication status for bucket '{bucket_name}': {str(e)}"
+            )
+            return False

--- a/scenarios/aws_s3_replication/s3_replication_extended.yaml
+++ b/scenarios/aws_s3_replication/s3_replication_extended.yaml
@@ -1,0 +1,9 @@
+# AWS S3 Replication Chaos Scenario - Extended Duration
+#
+# This scenario pauses replication for an extended period to test
+# long-term resilience and recovery procedures.
+
+aws_s3_replication_scenarios:
+  bucket_name: "<YOUR-SOURCE-BUCKET-NAME>"
+  duration: 1800  # 30 minutes
+  region: "<YOUR-AWS-REGION>"  # e.g., us-east-1, us-west-2

--- a/scenarios/aws_s3_replication/s3_replication_pause.yaml
+++ b/scenarios/aws_s3_replication/s3_replication_pause.yaml
@@ -1,0 +1,18 @@
+# AWS S3 Replication Chaos Scenario Configuration
+#
+# This scenario temporarily pauses S3 bucket replication to test application
+# resilience when replicated data becomes unavailable or out of sync.
+#
+# Use Case: Test how your application handles replication lag or failures
+
+aws_s3_replication_scenarios:
+  # Required: Name of the S3 source bucket with replication configured
+  bucket_name: "<YOUR-SOURCE-BUCKET-NAME>"
+  
+  # Required: Duration to pause replication (in seconds)
+  # During this time, new objects won't be replicated to destination buckets
+  duration: 300  # 5 minutes
+  
+  # Optional: AWS region where the bucket is located
+  # If not specified, uses the default region from AWS configuration
+  region: "<YOUR-AWS-REGION>"  # e.g., us-east-1, us-west-2

--- a/tests/aws_s3_replication/__init__.py
+++ b/tests/aws_s3_replication/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for AWS S3 Replication chaos scenario plugin."""

--- a/tests/aws_s3_replication/conftest.py
+++ b/tests/aws_s3_replication/conftest.py
@@ -1,0 +1,118 @@
+"""Pytest fixtures for AWS S3 Replication scenario tests."""
+
+import pytest
+import boto3
+from moto import mock_aws
+
+
+@pytest.fixture
+def s3_client():
+    """Provides a mocked S3 client for testing."""
+    with mock_aws():
+        yield boto3.client('s3', region_name='us-east-1')
+
+
+@pytest.fixture
+def sample_replication_config():
+    """Provides a sample replication configuration for testing."""
+    return {
+        'Role': 'arn:aws:iam::123456789012:role/s3-replication-role',
+        'Rules': [
+            {
+                'ID': 'rule-1',
+                'Status': 'Enabled',
+                'Priority': 1,
+                'Filter': {'Prefix': ''},
+                'Destination': {
+                    'Bucket': 'arn:aws:s3:::destination-bucket',
+                    'StorageClass': 'STANDARD'
+                },
+                'DeleteMarkerReplication': {'Status': 'Disabled'}
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def s3_bucket_with_replication(s3_client, sample_replication_config):
+    """Creates test S3 buckets with replication configured."""
+    source_bucket = 'test-source-bucket'
+    dest_bucket = 'test-destination-bucket'
+    
+    # Create buckets
+    s3_client.create_bucket(Bucket=source_bucket)
+    s3_client.create_bucket(Bucket=dest_bucket)
+    
+    # Enable versioning on source bucket (required for replication)
+    s3_client.put_bucket_versioning(
+        Bucket=source_bucket,
+        VersioningConfiguration={'Status': 'Enabled'}
+    )
+    
+    # Enable versioning on destination bucket
+    s3_client.put_bucket_versioning(
+        Bucket=dest_bucket,
+        VersioningConfiguration={'Status': 'Enabled'}
+    )
+    
+    # Configure replication
+    s3_client.put_bucket_replication(
+        Bucket=source_bucket,
+        ReplicationConfiguration=sample_replication_config
+    )
+    
+    return s3_client, source_bucket, dest_bucket
+
+
+@pytest.fixture
+def s3_bucket_without_replication(s3_client):
+    """Creates a test S3 bucket without replication configured."""
+    bucket_name = 'test-bucket-no-replication'
+    
+    s3_client.create_bucket(Bucket=bucket_name)
+    s3_client.put_bucket_versioning(
+        Bucket=bucket_name,
+        VersioningConfiguration={'Status': 'Enabled'}
+    )
+    
+    return s3_client, bucket_name
+
+
+@pytest.fixture
+def multi_rule_replication_config():
+    """Provides a replication configuration with multiple rules."""
+    return {
+        'Role': 'arn:aws:iam::123456789012:role/s3-replication-role',
+        'Rules': [
+            {
+                'ID': 'rule-1',
+                'Status': 'Enabled',
+                'Priority': 1,
+                'Filter': {'Prefix': 'documents/'},
+                'Destination': {
+                    'Bucket': 'arn:aws:s3:::destination-bucket-1'
+                },
+                'DeleteMarkerReplication': {'Status': 'Disabled'}
+            },
+            {
+                'ID': 'rule-2',
+                'Status': 'Enabled',
+                'Priority': 2,
+                'Filter': {'Prefix': 'images/'},
+                'Destination': {
+                    'Bucket': 'arn:aws:s3:::destination-bucket-2'
+                },
+                'DeleteMarkerReplication': {'Status': 'Disabled'}
+            },
+            {
+                'ID': 'rule-3',
+                'Status': 'Disabled',
+                'Priority': 3,
+                'Filter': {'Prefix': 'archive/'},
+                'Destination': {
+                    'Bucket': 'arn:aws:s3:::destination-bucket-3'
+                },
+                'DeleteMarkerReplication': {'Status': 'Disabled'}
+            }
+        ]
+    }

--- a/tests/aws_s3_replication/test_aws_s3_scenarios.py
+++ b/tests/aws_s3_replication/test_aws_s3_scenarios.py
@@ -1,0 +1,646 @@
+"""Unit tests for AWS S3 Replication scenarios module."""
+
+import unittest
+import boto3
+from moto import mock_aws
+from krkn.scenario_plugins.aws_s3_replication.aws_s3_scenarios import AWSS3Replication
+
+
+class TestAWSS3ReplicationInit(unittest.TestCase):
+    """Tests for AWSS3Replication initialization."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock = mock_aws()
+        self.mock.start()
+        self.s3_client = boto3.client('s3', region_name='us-east-1')
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.mock.stop()
+
+    def test_init_with_client(self):
+        """Test initialization with provided S3 client."""
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        self.assertIsNotNone(handler.s3_client)
+        self.assertEqual(handler.s3_client, self.s3_client)
+
+    def test_init_with_region(self):
+        """Test initialization with region parameter."""
+        handler = AWSS3Replication(region='us-west-2')
+        self.assertIsNotNone(handler.s3_client)
+
+
+class TestGetReplicationConfiguration(unittest.TestCase):
+    """Tests for get_replication_configuration method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock = mock_aws()
+        self.mock.start()
+        self.s3_client = boto3.client('s3', region_name='us-east-1')
+        
+        # Sample replication config
+        self.sample_replication_config = {
+            'Role': 'arn:aws:iam::123456789012:role/s3-replication-role',
+            'Rules': [
+                {
+                    'ID': 'rule-1',
+                    'Status': 'Enabled',
+                    'Priority': 1,
+                    'Filter': {'Prefix': ''},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket',
+                        'StorageClass': 'STANDARD'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                }
+            ]
+        }
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.mock.stop()
+
+    def _create_bucket_with_replication(self):
+        """Helper method to create buckets with replication."""
+        source_bucket = 'test-source-bucket'
+        dest_bucket = 'test-destination-bucket'
+        
+        self.s3_client.create_bucket(Bucket=source_bucket)
+        self.s3_client.create_bucket(Bucket=dest_bucket)
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=source_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=dest_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_replication(
+            Bucket=source_bucket,
+            ReplicationConfiguration=self.sample_replication_config
+        )
+        
+        return source_bucket, dest_bucket
+
+    def _create_bucket_without_replication(self):
+        """Helper method to create bucket without replication."""
+        bucket_name = 'test-bucket-no-replication'
+        
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.s3_client.put_bucket_versioning(
+            Bucket=bucket_name,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        return bucket_name
+
+    def test_get_replication_config_success(self):
+        """Test successfully retrieving replication configuration."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        config = handler.get_replication_configuration(source_bucket)
+        
+        self.assertIsNotNone(config)
+        self.assertIn('Role', config)
+        self.assertIn('Rules', config)
+        self.assertGreater(len(config['Rules']), 0)
+        self.assertEqual(config['Rules'][0]['Status'], 'Enabled')
+
+    def test_get_replication_config_no_replication(self):
+        """Test error handling when bucket has no replication configured."""
+        bucket_name = self._create_bucket_without_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        with self.assertRaisesRegex(RuntimeError, "Failed to retrieve replication configuration"):
+            handler.get_replication_configuration(bucket_name)
+
+    def test_get_replication_config_nonexistent_bucket(self):
+        """Test error handling when bucket does not exist."""
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        with self.assertRaisesRegex(RuntimeError, "Failed to retrieve replication configuration"):
+            handler.get_replication_configuration('nonexistent-bucket')
+
+
+class TestPauseReplication(unittest.TestCase):
+    """Tests for pause_replication method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock = mock_aws()
+        self.mock.start()
+        self.s3_client = boto3.client('s3', region_name='us-east-1')
+        
+        self.sample_replication_config = {
+            'Role': 'arn:aws:iam::123456789012:role/s3-replication-role',
+            'Rules': [
+                {
+                    'ID': 'rule-1',
+                    'Status': 'Enabled',
+                    'Priority': 1,
+                    'Filter': {'Prefix': ''},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket',
+                        'StorageClass': 'STANDARD'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                }
+            ]
+        }
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.mock.stop()
+
+    def _create_bucket_with_replication(self):
+        """Helper method to create buckets with replication."""
+        source_bucket = 'test-source-bucket'
+        dest_bucket = 'test-destination-bucket'
+        
+        self.s3_client.create_bucket(Bucket=source_bucket)
+        self.s3_client.create_bucket(Bucket=dest_bucket)
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=source_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=dest_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_replication(
+            Bucket=source_bucket,
+            ReplicationConfiguration=self.sample_replication_config
+        )
+        
+        return source_bucket, dest_bucket
+
+    def _create_bucket_without_replication(self):
+        """Helper method to create bucket without replication."""
+        bucket_name = 'test-bucket-no-replication'
+        
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.s3_client.put_bucket_versioning(
+            Bucket=bucket_name,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        return bucket_name
+
+    def test_pause_replication_success(self):
+        """Test successfully pausing replication."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        # Pause replication
+        original_config = handler.pause_replication(source_bucket)
+        
+        # Verify original config was returned
+        self.assertIsNotNone(original_config)
+        self.assertEqual(original_config['Rules'][0]['Status'], 'Enabled')
+        
+        # Verify replication is now paused
+        current_config = handler.get_replication_configuration(source_bucket)
+        self.assertEqual(current_config['Rules'][0]['Status'], 'Disabled')
+
+    def test_pause_replication_multiple_rules(self):
+        """Test pausing replication with multiple rules."""
+        bucket_name = 'test-multi-rule-bucket'
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.s3_client.put_bucket_versioning(
+            Bucket=bucket_name,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        multi_rule_config = {
+            'Role': 'arn:aws:iam::123456789012:role/s3-replication-role',
+            'Rules': [
+                {
+                    'ID': 'rule-1',
+                    'Status': 'Enabled',
+                    'Priority': 1,
+                    'Filter': {'Prefix': 'documents/'},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket-1'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                },
+                {
+                    'ID': 'rule-2',
+                    'Status': 'Enabled',
+                    'Priority': 2,
+                    'Filter': {'Prefix': 'images/'},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket-2'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                },
+                {
+                    'ID': 'rule-3',
+                    'Status': 'Disabled',
+                    'Priority': 3,
+                    'Filter': {'Prefix': 'archive/'},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket-3'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                }
+            ]
+        }
+        
+        self.s3_client.put_bucket_replication(
+            Bucket=bucket_name,
+            ReplicationConfiguration=multi_rule_config
+        )
+        
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        original_config = handler.pause_replication(bucket_name)
+        
+        # Verify all enabled rules are now disabled
+        current_config = handler.get_replication_configuration(bucket_name)
+        for rule in current_config['Rules']:
+            self.assertEqual(rule['Status'], 'Disabled')
+        
+        # Verify original config had enabled rules
+        enabled_count = sum(1 for rule in original_config['Rules'] if rule['Status'] == 'Enabled')
+        self.assertEqual(enabled_count, 2)  # rule-1 and rule-2 were enabled
+
+    def test_pause_replication_already_paused(self):
+        """Test pausing replication when already paused."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        # Pause once
+        handler.pause_replication(source_bucket)
+        
+        # Pause again (should not fail)
+        original_config = handler.pause_replication(source_bucket)
+        self.assertIsNotNone(original_config)
+
+    def test_pause_replication_no_replication(self):
+        """Test error handling when pausing bucket without replication."""
+        bucket_name = self._create_bucket_without_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        with self.assertRaises(RuntimeError):
+            handler.pause_replication(bucket_name)
+
+
+class TestRestoreReplication(unittest.TestCase):
+    """Tests for restore_replication method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock = mock_aws()
+        self.mock.start()
+        self.s3_client = boto3.client('s3', region_name='us-east-1')
+        
+        self.sample_replication_config = {
+            'Role': 'arn:aws:iam::123456789012:role/s3-replication-role',
+            'Rules': [
+                {
+                    'ID': 'rule-1',
+                    'Status': 'Enabled',
+                    'Priority': 1,
+                    'Filter': {'Prefix': ''},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket',
+                        'StorageClass': 'STANDARD'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                }
+            ]
+        }
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.mock.stop()
+
+    def _create_bucket_with_replication(self):
+        """Helper method to create buckets with replication."""
+        source_bucket = 'test-source-bucket'
+        dest_bucket = 'test-destination-bucket'
+        
+        self.s3_client.create_bucket(Bucket=source_bucket)
+        self.s3_client.create_bucket(Bucket=dest_bucket)
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=source_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=dest_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_replication(
+            Bucket=source_bucket,
+            ReplicationConfiguration=self.sample_replication_config
+        )
+        
+        return source_bucket, dest_bucket
+
+    def test_restore_replication_success(self):
+        """Test successfully restoring replication."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        # Pause replication
+        original_config = handler.pause_replication(source_bucket)
+        
+        # Verify it's paused
+        config = handler.get_replication_configuration(source_bucket)
+        self.assertEqual(config['Rules'][0]['Status'], 'Disabled')
+        
+        # Restore replication
+        handler.restore_replication(source_bucket, original_config)
+        
+        # Verify it's restored
+        config = handler.get_replication_configuration(source_bucket)
+        self.assertEqual(config['Rules'][0]['Status'], 'Enabled')
+
+    def test_restore_replication_multiple_rules(self):
+        """Test restoring replication with multiple rules."""
+        bucket_name = 'test-multi-rule-restore'
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.s3_client.put_bucket_versioning(
+            Bucket=bucket_name,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        multi_rule_config = {
+            'Role': 'arn:aws:iam::123456789012:role/s3-replication-role',
+            'Rules': [
+                {
+                    'ID': 'rule-1',
+                    'Status': 'Enabled',
+                    'Priority': 1,
+                    'Filter': {'Prefix': 'documents/'},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket-1'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                },
+                {
+                    'ID': 'rule-2',
+                    'Status': 'Enabled',
+                    'Priority': 2,
+                    'Filter': {'Prefix': 'images/'},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket-2'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                },
+                {
+                    'ID': 'rule-3',
+                    'Status': 'Disabled',
+                    'Priority': 3,
+                    'Filter': {'Prefix': 'archive/'},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket-3'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                }
+            ]
+        }
+        
+        self.s3_client.put_bucket_replication(
+            Bucket=bucket_name,
+            ReplicationConfiguration=multi_rule_config
+        )
+        
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        # Pause and restore
+        original_config = handler.pause_replication(bucket_name)
+        handler.restore_replication(bucket_name, original_config)
+        
+        # Verify restoration
+        config = handler.get_replication_configuration(bucket_name)
+        enabled_count = sum(1 for rule in config['Rules'] if rule['Status'] == 'Enabled')
+        disabled_count = sum(1 for rule in config['Rules'] if rule['Status'] == 'Disabled')
+        
+        self.assertEqual(enabled_count, 2)  # rule-1 and rule-2
+        self.assertEqual(disabled_count, 1)  # rule-3 was originally disabled
+
+    def test_restore_replication_empty_config(self):
+        """Test error handling when restoring with empty config."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        with self.assertRaisesRegex(RuntimeError, "restoring replication"):
+            handler.restore_replication(source_bucket, None)
+
+    def test_restore_replication_invalid_config(self):
+        """Test error handling when restoring with invalid config."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        with self.assertRaisesRegex(RuntimeError, "restoring replication"):
+            handler.restore_replication(source_bucket, {})
+
+
+class TestVerifyReplicationStatus(unittest.TestCase):
+    """Tests for verify_replication_status method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock = mock_aws()
+        self.mock.start()
+        self.s3_client = boto3.client('s3', region_name='us-east-1')
+        
+        self.sample_replication_config = {
+            'Role': 'arn:aws:iam::123456789012:role/s3-replication-role',
+            'Rules': [
+                {
+                    'ID': 'rule-1',
+                    'Status': 'Enabled',
+                    'Priority': 1,
+                    'Filter': {'Prefix': ''},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket',
+                        'StorageClass': 'STANDARD'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                }
+            ]
+        }
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.mock.stop()
+
+    def _create_bucket_with_replication(self):
+        """Helper method to create buckets with replication."""
+        source_bucket = 'test-source-bucket'
+        dest_bucket = 'test-destination-bucket'
+        
+        self.s3_client.create_bucket(Bucket=source_bucket)
+        self.s3_client.create_bucket(Bucket=dest_bucket)
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=source_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=dest_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_replication(
+            Bucket=source_bucket,
+            ReplicationConfiguration=self.sample_replication_config
+        )
+        
+        return source_bucket, dest_bucket
+
+    def _create_bucket_without_replication(self):
+        """Helper method to create bucket without replication."""
+        bucket_name = 'test-bucket-no-replication'
+        
+        self.s3_client.create_bucket(Bucket=bucket_name)
+        self.s3_client.put_bucket_versioning(
+            Bucket=bucket_name,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        return bucket_name
+
+    def test_verify_status_enabled(self):
+        """Test verifying enabled replication status."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        result = handler.verify_replication_status(source_bucket, expected_status='Enabled')
+        self.assertTrue(result)
+
+    def test_verify_status_disabled(self):
+        """Test verifying disabled replication status."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        # Pause replication
+        handler.pause_replication(source_bucket)
+        
+        # Verify disabled status
+        result = handler.verify_replication_status(source_bucket, expected_status='Disabled')
+        self.assertTrue(result)
+
+    def test_verify_status_mismatch(self):
+        """Test verification when status doesn't match expected."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        # Replication is enabled, but we expect disabled
+        result = handler.verify_replication_status(source_bucket, expected_status='Disabled')
+        self.assertFalse(result)
+
+    def test_verify_status_no_replication(self):
+        """Test verification when bucket has no replication."""
+        bucket_name = self._create_bucket_without_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        result = handler.verify_replication_status(bucket_name, expected_status='Enabled')
+        self.assertFalse(result)
+
+
+class TestEndToEndScenario(unittest.TestCase):
+    """End-to-end tests for complete chaos scenario workflow."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock = mock_aws()
+        self.mock.start()
+        self.s3_client = boto3.client('s3', region_name='us-east-1')
+        
+        self.sample_replication_config = {
+            'Role': 'arn:aws:iam::123456789012:role/s3-replication-role',
+            'Rules': [
+                {
+                    'ID': 'rule-1',
+                    'Status': 'Enabled',
+                    'Priority': 1,
+                    'Filter': {'Prefix': ''},
+                    'Destination': {
+                        'Bucket': 'arn:aws:s3:::destination-bucket',
+                        'StorageClass': 'STANDARD'
+                    },
+                    'DeleteMarkerReplication': {'Status': 'Disabled'}
+                }
+            ]
+        }
+
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.mock.stop()
+
+    def _create_bucket_with_replication(self):
+        """Helper method to create buckets with replication."""
+        source_bucket = 'test-source-bucket'
+        dest_bucket = 'test-destination-bucket'
+        
+        self.s3_client.create_bucket(Bucket=source_bucket)
+        self.s3_client.create_bucket(Bucket=dest_bucket)
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=source_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_versioning(
+            Bucket=dest_bucket,
+            VersioningConfiguration={'Status': 'Enabled'}
+        )
+        
+        self.s3_client.put_bucket_replication(
+            Bucket=source_bucket,
+            ReplicationConfiguration=self.sample_replication_config
+        )
+        
+        return source_bucket, dest_bucket
+
+    def test_complete_pause_restore_cycle(self):
+        """Test complete pause and restore cycle."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        # Get initial config
+        initial_config = handler.get_replication_configuration(source_bucket)
+        self.assertEqual(initial_config['Rules'][0]['Status'], 'Enabled')
+        
+        # Pause replication
+        original_config = handler.pause_replication(source_bucket)
+        paused_config = handler.get_replication_configuration(source_bucket)
+        self.assertEqual(paused_config['Rules'][0]['Status'], 'Disabled')
+        
+        # Restore replication
+        handler.restore_replication(source_bucket, original_config)
+        restored_config = handler.get_replication_configuration(source_bucket)
+        self.assertEqual(restored_config['Rules'][0]['Status'], 'Enabled')
+        
+        # Verify final state matches initial state
+        self.assertEqual(restored_config['Rules'][0]['Status'], initial_config['Rules'][0]['Status'])
+
+    def test_multiple_pause_restore_cycles(self):
+        """Test multiple pause and restore cycles."""
+        source_bucket, _ = self._create_bucket_with_replication()
+        handler = AWSS3Replication(s3_client=self.s3_client)
+        
+        for i in range(3):
+            # Pause
+            original_config = handler.pause_replication(source_bucket)
+            self.assertTrue(handler.verify_replication_status(source_bucket, 'Disabled'))
+            
+            # Restore
+            handler.restore_replication(source_bucket, original_config)
+            self.assertTrue(handler.verify_replication_status(source_bucket, 'Enabled'))

--- a/tests/aws_s3_replication/test_scenario_plugin.py
+++ b/tests/aws_s3_replication/test_scenario_plugin.py
@@ -1,0 +1,281 @@
+"""Unit tests for AWS S3 Replication scenario plugin."""
+
+import os
+import tempfile
+import unittest
+import yaml
+from unittest.mock import Mock, patch
+from krkn.scenario_plugins.aws_s3_replication.aws_s3_replication_scenario_plugin import (
+    AwsS3ReplicationScenarioPlugin
+)
+
+
+class TestAwsS3ReplicationScenarioPlugin(unittest.TestCase):
+    """Tests for AwsS3ReplicationScenarioPlugin class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_telemetry = Mock()
+        self.mock_scenario_telemetry = Mock()
+        
+        self.valid_scenario_config = {
+            'aws_s3_replication_scenarios': {
+                'bucket_name': 'test-bucket',
+                'duration': 1,  # Short duration for tests
+                'region': 'us-east-1'
+            }
+        }
+
+    def _create_scenario_config_file(self, config):
+        """Helper method to create a temporary scenario configuration file."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            yaml.dump(config, f)
+            return f.name
+
+    def test_plugin_initialization(self):
+        """Test plugin initialization."""
+        plugin = AwsS3ReplicationScenarioPlugin("aws_s3_replication_scenarios")
+        self.assertIsNotNone(plugin)
+
+    def test_get_scenario_types(self):
+        """Test get_scenario_types method."""
+        plugin = AwsS3ReplicationScenarioPlugin("aws_s3_replication_scenarios")
+        scenario_types = plugin.get_scenario_types()
+        
+        self.assertIsInstance(scenario_types, list)
+        self.assertEqual(len(scenario_types), 1)
+        self.assertIn('aws_s3_replication_scenarios', scenario_types)
+
+    @patch('krkn.scenario_plugins.aws_s3_replication.aws_s3_replication_scenario_plugin.AWSS3Replication')
+    @patch('krkn.scenario_plugins.aws_s3_replication.aws_s3_replication_scenario_plugin.time.sleep')
+    def test_run_success(self, mock_sleep, mock_s3_class):
+        """Test successful scenario execution."""
+        scenario_config_file = self._create_scenario_config_file(self.valid_scenario_config)
+        
+        try:
+            # Setup mocks
+            original_config = {
+                'Role': 'arn:aws:iam::123456789012:role/test-role',
+                'Rules': [{'ID': 'rule-1', 'Status': 'Enabled', 'Priority': 1}]
+            }
+            mock_s3_instance = Mock()
+            mock_s3_instance.pause_replication.return_value = original_config
+            mock_s3_instance.restore_replication.return_value = None
+            mock_s3_instance.verify_replication_status.return_value = True
+            mock_s3_instance.get_replication_configuration.return_value = original_config
+            mock_s3_class.return_value = mock_s3_instance
+            
+            # Run scenario
+            plugin = AwsS3ReplicationScenarioPlugin("aws_s3_replication_scenarios")
+            result = plugin.run(
+                run_uuid='test-uuid',
+                scenario=scenario_config_file,
+                lib_telemetry=self.mock_telemetry,
+                scenario_telemetry=self.mock_scenario_telemetry
+            )
+            
+            # Verify
+            self.assertEqual(result, 0)
+            mock_s3_instance.pause_replication.assert_called_once_with('test-bucket')
+            mock_s3_instance.restore_replication.assert_called_once_with('test-bucket', original_config)
+        finally:
+            if os.path.exists(scenario_config_file):
+                os.unlink(scenario_config_file)
+
+    def test_run_missing_bucket_name(self):
+        """Test scenario execution with missing bucket_name."""
+        config = {
+            'aws_s3_replication_scenarios': {
+                'duration': 60
+            }
+        }
+        
+        scenario_config_file = self._create_scenario_config_file(config)
+        
+        try:
+            plugin = AwsS3ReplicationScenarioPlugin("aws_s3_replication_scenarios")
+            result = plugin.run(
+                run_uuid='test-uuid',
+                scenario=scenario_config_file,
+                lib_telemetry=self.mock_telemetry,
+                scenario_telemetry=self.mock_scenario_telemetry
+            )
+            
+            self.assertEqual(result, 1)
+        finally:
+            if os.path.exists(scenario_config_file):
+                os.unlink(scenario_config_file)
+
+    def test_run_invalid_duration(self):
+        """Test scenario execution with invalid duration."""
+        config = {
+            'aws_s3_replication_scenarios': {
+                'bucket_name': 'test-bucket',
+                'duration': -10
+            }
+        }
+        
+        scenario_config_file = self._create_scenario_config_file(config)
+        
+        try:
+            plugin = AwsS3ReplicationScenarioPlugin("aws_s3_replication_scenarios")
+            result = plugin.run(
+                run_uuid='test-uuid',
+                scenario=scenario_config_file,
+                lib_telemetry=self.mock_telemetry,
+                scenario_telemetry=self.mock_scenario_telemetry
+            )
+            
+            self.assertEqual(result, 1)
+        finally:
+            if os.path.exists(scenario_config_file):
+                os.unlink(scenario_config_file)
+
+    def test_run_file_not_found(self):
+        """Test scenario execution with non-existent config file."""
+        plugin = AwsS3ReplicationScenarioPlugin("aws_s3_replication_scenarios")
+        result = plugin.run(
+            run_uuid='test-uuid',
+            scenario='/nonexistent/file.yaml',
+            lib_telemetry=self.mock_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry
+        )
+        
+        self.assertEqual(result, 1)
+
+    @patch('krkn.scenario_plugins.aws_s3_replication.aws_s3_replication_scenario_plugin.AWSS3Replication')
+    def test_run_pause_failure(self, mock_s3_class):
+        """Test scenario execution when pause fails."""
+        scenario_config_file = self._create_scenario_config_file(self.valid_scenario_config)
+        
+        try:
+            mock_s3_instance = Mock()
+            mock_s3_instance.pause_replication.side_effect = RuntimeError("Pause failed")
+            mock_s3_class.return_value = mock_s3_instance
+            
+            plugin = AwsS3ReplicationScenarioPlugin("aws_s3_replication_scenarios")
+            result = plugin.run(
+                run_uuid='test-uuid',
+                scenario=scenario_config_file,
+                lib_telemetry=self.mock_telemetry,
+                scenario_telemetry=self.mock_scenario_telemetry
+            )
+            
+            self.assertEqual(result, 1)
+        finally:
+            if os.path.exists(scenario_config_file):
+                os.unlink(scenario_config_file)
+
+    @patch('krkn.scenario_plugins.aws_s3_replication.aws_s3_replication_scenario_plugin.AWSS3Replication')
+    @patch('krkn.scenario_plugins.aws_s3_replication.aws_s3_replication_scenario_plugin.time.sleep')
+    def test_run_restore_failure(self, mock_sleep, mock_s3_class):
+        """Test scenario execution when restore fails."""
+        scenario_config_file = self._create_scenario_config_file(self.valid_scenario_config)
+        
+        try:
+            original_config = {
+                'Role': 'arn:aws:iam::123456789012:role/test-role',
+                'Rules': [{'ID': 'rule-1', 'Status': 'Enabled'}]
+            }
+            mock_s3_instance = Mock()
+            mock_s3_instance.pause_replication.return_value = original_config
+            mock_s3_instance.restore_replication.side_effect = RuntimeError("Restore failed")
+            mock_s3_class.return_value = mock_s3_instance
+            
+            plugin = AwsS3ReplicationScenarioPlugin("aws_s3_replication_scenarios")
+            result = plugin.run(
+                run_uuid='test-uuid',
+                scenario=scenario_config_file,
+                lib_telemetry=self.mock_telemetry,
+                scenario_telemetry=self.mock_scenario_telemetry
+            )
+            
+            self.assertEqual(result, 1)
+        finally:
+            if os.path.exists(scenario_config_file):
+                os.unlink(scenario_config_file)
+
+
+class TestRollbackFunction(unittest.TestCase):
+    """Tests for rollback_replication static method."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_telemetry = Mock()
+
+    @patch('krkn.scenario_plugins.aws_s3_replication.aws_s3_replication_scenario_plugin.AWSS3Replication')
+    def test_rollback_success(self, mock_s3_class):
+        """Test successful rollback execution."""
+        import base64
+        import json
+        from krkn.rollback.config import RollbackContent
+        
+        # Prepare rollback data
+        rollback_data = {
+            'bucket_name': 'test-bucket',
+            'region': 'us-east-1',
+            'original_config': {
+                'Role': 'arn:aws:iam::123456789012:role/test-role',
+                'Rules': [{'ID': 'rule-1', 'Status': 'Enabled'}]
+            }
+        }
+        json_str = json.dumps(rollback_data)
+        encoded_data = base64.b64encode(json_str.encode('utf-8')).decode('utf-8')
+        
+        rollback_content = RollbackContent(
+            namespace='aws-s3',
+            resource_identifier=encoded_data
+        )
+        
+        # Setup mock
+        mock_s3_instance = Mock()
+        mock_s3_class.return_value = mock_s3_instance
+        
+        # Execute rollback
+        AwsS3ReplicationScenarioPlugin.rollback_replication(
+            rollback_content,
+            self.mock_telemetry
+        )
+        
+        # Verify
+        mock_s3_instance.restore_replication.assert_called_once_with(
+            'test-bucket',
+            rollback_data['original_config']
+        )
+
+    @patch('krkn.scenario_plugins.aws_s3_replication.aws_s3_replication_scenario_plugin.AWSS3Replication')
+    def test_rollback_failure(self, mock_s3_class):
+        """Test rollback execution when restore fails."""
+        import base64
+        import json
+        from krkn.rollback.config import RollbackContent
+        
+        rollback_data = {
+            'bucket_name': 'test-bucket',
+            'region': 'us-east-1',
+            'original_config': {
+                'Role': 'arn:aws:iam::123456789012:role/test-role',
+                'Rules': [{'ID': 'rule-1', 'Status': 'Enabled'}]
+            }
+        }
+        json_str = json.dumps(rollback_data)
+        encoded_data = base64.b64encode(json_str.encode('utf-8')).decode('utf-8')
+        
+        rollback_content = RollbackContent(
+            namespace='aws-s3',
+            resource_identifier=encoded_data
+        )
+        
+        # Setup mock to raise exception
+        mock_s3_instance = Mock()
+        mock_s3_instance.restore_replication.side_effect = RuntimeError("Restore failed")
+        mock_s3_class.return_value = mock_s3_instance
+        
+        # Execute rollback (should not raise exception, just log error)
+        AwsS3ReplicationScenarioPlugin.rollback_replication(
+            rollback_content,
+            self.mock_telemetry
+        )
+        
+        # Verify restore was attempted
+        mock_s3_instance.restore_replication.assert_called_once()


### PR DESCRIPTION
### **User description**
# Type of change
- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description

This PR adds a new AWS S3 Replication chaos scenario plugin for Krkn. The plugin enables testing application resilience by temporarily pausing S3 bucket replication and then restoring it after a configured duration.

## Key Features:
- **Pause/Restore Operations**: Temporarily disables S3 replication rules and restores them after chaos period
- **Automatic Rollback**: Ensures replication is restored even if the scenario fails or is interrupted
- **Comprehensive Error Handling**: Detailed logging and error messages for common issues (missing permissions, non-existent buckets, etc.)
- **Flexible Configuration**: Supports custom AWS regions and configurable chaos duration
- **Status Verification**: Validates replication status after operations

## Implementation Details:
- Core functionality in `krkn/scenario_plugins/aws_s3_replication/aws_s3_scenarios.py`
- Plugin integration in `krkn/scenario_plugins/aws_s3_replication/aws_s3_replication_scenario_plugin.py`
- Comprehensive unit tests with mocking
- Documentation including IAM permissions guide

## Related Tickets & Documents
- Closes #701 

# Documentation

- [x] **Is documentation needed for this update?**


Documentation is included in the PR:
- i have added it to the krkn/website in the PR: https://github.com/krkn-chaos/website/pull/191

# Checklist before requesting a review
- [x] I have performed a self-review of my code by running krkn and specific scenario
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

## Testing Performed

### Unit Tests
Comprehensive unit tests have been created covering:
- `tests/aws_s3_replication/test_aws_s3_scenarios.py` - Tests for core AWS S3 operations
- `tests/aws_s3_replication/test_scenario_plugin.py` - Tests for plugin integration


## Output after running `python run_kraken.py` with aws s3 replication scenario

```
2026-01-20 11:49:57,070 [INFO] Executing scenarios for iteration 0
2026-01-20 11:49:57,073 [INFO] Signal handlers registered globally
2026-01-20 11:49:57,073 [INFO] Running AwsS3ReplicationScenarioPlugin: ['aws_s3_replication_scenarios'] -> scenarios/aws_s3_replication/s3_replication_test.yaml
2026-01-20 11:49:57,074 [INFO] Set rollback_context: 1768889997074107964-9b12188f-e6a5-4032-bd69-5c8ae0ff3d44 for scenario_type: aws_s3_replication_scenarios RollbackHandler
2026-01-20 11:49:57,075 [INFO] AWS S3 Replication Chaos Scenario - Input parameters:
  Bucket name: 'krkn-source-bucket-sypher'
  Duration: 30s
  Region: 'us-east-1'
2026-01-20 11:49:57,092 [INFO] Found credentials in shared credentials file: ~/.aws/credentials
2026-01-20 11:49:57,388 [INFO] AWS S3 Replication handler initialized
2026-01-20 11:49:57,388 [INFO] Step 1/3: Pausing replication for bucket 'krkn-source-bucket-sypher'...
2026-01-20 11:49:57,388 [INFO] Retrieving replication configuration for bucket: krkn-source-bucket-sypher
2026-01-20 11:49:58,346 [INFO] Successfully retrieved replication configuration with 1 rule(s)
2026-01-20 11:49:58,346 [INFO] Pausing replication for bucket 'krkn-source-bucket-sypher' (1 rule(s) will be disabled)
2026-01-20 11:49:58,764 [INFO] Successfully paused replication for bucket 'krkn-source-bucket-sypher'
2026-01-20 11:49:58,771 [INFO] Serialized callable written to /tmp/kraken-rollback/1768889997074107964-9b12188f-e6a5-4032-bd69-5c8ae0ff3d44/aws_s3_replication_scenarios_1768889993605587764_cqxyfmgh.py
2026-01-20 11:49:58,771 [INFO] Rollback callable serialized to /tmp/kraken-rollback/1768889997074107964-9b12188f-e6a5-4032-bd69-5c8ae0ff3d44/aws_s3_replication_scenarios_1768889993605587764_cqxyfmgh.py
2026-01-20 11:49:58,771 [INFO] Step 2/3: Replication paused. Waiting for 30s (chaos period)...
2026-01-20 11:50:28,778 [INFO] Chaos period completed (30s)
2026-01-20 11:50:28,778 [INFO] Step 3/3: Restoring replication for bucket 'krkn-source-bucket-sypher'...
2026-01-20 11:50:28,779 [INFO] Restoring replication for bucket 'krkn-source-bucket-sypher' (1 rule(s) will be re-enabled)
2026-01-20 11:50:29,833 [INFO] Successfully restored replication for bucket 'krkn-source-bucket-sypher'
2026-01-20 11:50:29,833 [INFO] Successfully restored replication for bucket 'krkn-source-bucket-sypher'
2026-01-20 11:50:29,833 [INFO] Retrieving replication configuration for bucket: krkn-source-bucket-sypher
2026-01-20 11:50:30,108 [INFO] Successfully retrieved replication configuration with 1 rule(s)
2026-01-20 11:50:30,109 [INFO] All replication rules for bucket 'krkn-source-bucket-sypher' are 'Enabled'
2026-01-20 11:50:30,109 [INFO] Replication status verification: all replication rules are currently 'Enabled'. This does not by itself guarantee the policy matches the original configuration.
2026-01-20 11:50:30,109 [INFO] AWS S3 Replication chaos scenario completed successfully in 33s
2026-01-20 11:50:30,111 [INFO] Cleaning up rollback version files for run_uuid=9b12188f-e6a5-4032-bd69-5c8ae0ff3d44, scenario_type=aws_s3_replication_scenarios
2026-01-20 11:50:30,111 [INFO] Removed /tmp/kraken-rollback/1768889997074107964-9b12188f-e6a5-4032-bd69-5c8ae0ff3d44/aws_s3_replication_scenarios_1768889993605587764_cqxyfmgh.py successfully.
2026-01-20 11:50:30,112 [INFO] wating 1 before running the next scenario
2026-01-20 11:50:31,113 [INFO] collecting Kubernetes cluster metadata....
2026-01-20 11:50:31,568 [INFO] Chaos data:
{
    "telemetry": {
        "scenarios": [
            {
                "start_timestamp": 1768889997,
                "end_timestamp": 1768890030,
                "scenario": "scenarios/aws_s3_replication/s3_replication_test.yaml",
                "scenario_type": "aws_s3_replication_scenarios",
                "exit_status": 0,
                "parameters_base64": "",
                "parameters": {
                    "aws_s3_replication_scenarios": {
                        "bucket_name": "krkn-source-bucket-sypher",
                        "duration": 30,
                        "region": "us-east-1"
                    }
                },
                "affected_pods": {
                    "recovered": [],
                    "unrecovered": [],
                    "error": null
                },
                "affected_nodes": [],
                "cluster_events": []
            }
        ],
        "node_summary_infos": [
            {
                "count": 3,
                "architecture": "amd64",
                "instance_type": "unknown",
                "nodes_type": "unknown",
                "kernel_version": "6.14.0-37-generic",
                "kubelet_version": "v1.35.0",
                "os_version": "Debian GNU/Linux 12 (bookworm)"
            }
        ],
        "node_taints": [
            {
                "node_name": "krkn-test-control-plane",
                "effect": "NoSchedule",
                "key": "node-role.kubernetes.io/control-plane",
                "value": null
            }
        ],
        "kubernetes_objects_count": {
            "ConfigMap": 13,
            "Pod": 16,
            "Deployment": 3
        },
        "network_plugins": [
            "Unknown"
        ],
        "timestamp": "2026-01-20T06:19:53Z",
        "health_checks": null,
        "virt_checks": null,
        "total_node_count": 3,
        "cloud_infrastructure": null,
        "cloud_type": null,
        "cluster_version": "1.35",
        "major_version": ".35",
        "run_uuid": "9b12188f-e6a5-4032-bd69-5c8ae0ff3d44",
        "post_virt_checks": null,
        "job_status": true,
        "build_url": "manual"
    },
    "critical_alerts": null
}
2026-01-20 11:50:31,568 [INFO] telemetry collection disabled, skipping.
2026-01-20 11:50:31,568 [INFO] Successfully finished running Kraken. UUID for the run: 9b12188f-e6a5-4032-bd69-5c8ae0ff3d44. Report generated at kraken.report. Exiting
```


___

### **PR Type**
Enhancement


___

### **Description**
- Adds AWS S3 Replication chaos scenario plugin for testing application resilience

- Implements pause/restore operations with automatic rollback on failure

- Includes comprehensive unit tests with moto mocking for AWS S3 operations

- Provides flexible configuration with custom regions and configurable chaos duration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["Scenario Config<br/>bucket_name, duration, region"]
  Plugin["AwsS3ReplicationScenarioPlugin<br/>run method"]
  S3Ops["AWSS3Replication<br/>pause/restore operations"]
  Rollback["Rollback Handler<br/>automatic restoration"]
  
  Config -->|loads| Plugin
  Plugin -->|initializes| S3Ops
  Plugin -->|registers| Rollback
  S3Ops -->|pause replication| S3["AWS S3 Bucket"]
  S3 -->|wait duration| S3
  S3Ops -->|restore replication| S3
  Rollback -->|on failure| S3Ops
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Package initialization for AWS S3 replication plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-5c8c2dab37066764e60384408ad4d72f7e6c27d837991decc49c3dc88b75224e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>s3_replication_pause.yaml</strong><dd><code>Primary scenario configuration with 5-minute pause</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-d9134a87645c744a50205e59af80cd27decd46011344f13abbd8402849b6a45d">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>s3_replication_extended.yaml</strong><dd><code>Extended scenario configuration with 30-minute pause</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-5bdb362e64e3f44b02fe2a972d6ec2395b1868824862ed1c82664b87d2930fd0">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>aws_s3_scenarios.py</strong><dd><code>Core AWS S3 replication pause/restore operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-932592da44d8334d35b023f81a1543cc335d7dbb2790f27305cd55356abb1e99">+295/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>aws_s3_replication_scenario_plugin.py</strong><dd><code>Plugin integration with rollback and telemetry support</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-80a558d4fa1e79a476956ff189b68c7fd55d1c3c44ee890af4d33096242b3103">+265/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Test package initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-5ec3f69f99ee5cb6c8092fe5827ef851ea0c6e39c6dadf36379d658156f09bb7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>conftest.py</strong><dd><code>Pytest fixtures for S3 mocking and test setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-34991eac43d24e4336990f43fe4ad1e876f2e0df5b24c984b0b6b3772c9d590f">+118/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_aws_s3_scenarios.py</strong><dd><code>Unit tests for core S3 replication operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-4004af1729cc10e9f824876ac61cfcee010d46b40408eaf6d41d9ffec7d3f328">+263/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_scenario_plugin.py</strong><dd><code>Unit tests for plugin execution and rollback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-88214838d1703a27789d1b68b529f726fd537611cb68d092c5dee46123b92fc3">+344/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config.yaml</strong><dd><code>Register AWS S3 replication scenario in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-38df760413887d0cc4ee5707919e6390456a863d326f6080644cc3d9c72e4bba">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>requirements.txt</strong><dd><code>Add moto dependency for AWS S3 testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1097/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

