### PR TITLE
Chaos ai obsolelte

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,31 @@
+# ⚠️ DEPRECATED
+
+This directory is **no longer actively maintained** and will not accept new changes.
+
+## Migration Notice
+
+All development efforts have been moved to:
+
+**[github.com/krkn-chaos/krkn-ai](https://github.com/krkn-chaos/krkn-ai)**
+
+## What This Means
+
+- ❌ No new features will be added here
+- ❌ Bug fixes will not be accepted
+- ❌ Pull requests will be closed and redirected
+- ℹ️ Existing code remains for historical reference only
+
+## Next Steps
+
+If you're looking to:
+- **Use** chaos engineering AI features → Visit [krkn-chaos/krkn-ai](https://github.com/krkn-chaos/krkn-ai)
+- **Contribute** improvements → Submit to [krkn-chaos/krkn-ai](https://github.com/krkn-chaos/krkn-ai)
+- **Report issues** → Open issues at [krkn-chaos/krkn-ai](https://github.com/krkn-chaos/krkn-ai/issues)
+
+## Questions?
+
+Please visit the new repository for documentation, examples, and community support.
+
+---
+
+**Last Updated:** January 2026

--- a/utils/chaos_ai/README.md
+++ b/utils/chaos_ai/README.md
@@ -1,3 +1,17 @@
+# ⚠️ DEPRECATED - This project has moved
+
+> **All development has moved to [github.com/krkn-chaos/krkn-ai](https://github.com/krkn-chaos/krkn-ai)**
+>
+> This directory is no longer maintained. Please visit the new repository for:
+> - Latest features and updates
+> - Active development and support
+> - Bug fixes and improvements
+> - Documentation and examples
+>
+> See [../README.md](../README.md) for more information.
+
+---
+
 # aichaos
 Enhancing Chaos Engineering with AI-assisted fault injection for better resiliency and non-functional testing.
 

--- a/utils/chaos_recommender/README.md
+++ b/utils/chaos_recommender/README.md
@@ -1,3 +1,17 @@
+# ⚠️ DEPRECATED - This project has moved
+
+> **All development has moved to [github.com/krkn-chaos/krkn-ai](https://github.com/krkn-chaos/krkn-ai)**
+>
+> This directory is no longer maintained. Please visit the new repository for:
+> - Latest features and updates
+> - Active development and support
+> - Bug fixes and improvements
+> - Documentation and examples
+>
+> See [../README.md](../README.md) for more information.
+
+---
+
 # Chaos Recommendation Tool
 
 This tool, designed for Redhat Kraken, operates through the command line and offers recommendations for chaos testing. It suggests probable chaos test cases that can disrupt application services by analyzing their behavior and assessing their susceptibility to specific fault types.


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization

# Description  
Adding details that chaos ai is obsolete and efforts moved to github.com/krkn-chaos/krkn-ai

Assisted By: Claude Code

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: 
- Closes #: 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python run_kraken.py
...
<---insert test results output--->
```

OR


```bash
python -m coverage run -a -m unittest discover -s tests -v
...
<---insert test results output--->
```