### PR TITLE
feat(ci): extend stale workflow to manage inactive pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Close Stale Issues
+name: Manage Stale Issues and Pull Requests
 
 on:
   schedule:
@@ -8,13 +8,14 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   stale:
-    name: Mark and Close Stale Issues
+    name: Mark and Close Stale Issues and PRs
     runs-on: ubuntu-latest
     steps:
-      - name: Mark and close stale issues
+      - name: Mark and close stale issues and PRs
         uses: actions/stale@v9
         with:
           days-before-issue-stale: 60
@@ -31,10 +32,21 @@ jobs:
             Thank you for your understanding!
           close-issue-reason: 'not_planned'
 
-          days-before-pr-stale: -1
-          days-before-pr-close: -1
+          days-before-pr-stale: 90
+          days-before-pr-close: 14
+          stale-pr-label: 'stale'
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had any activity in the last 90 days.
+            It will be closed in 14 days if no further activity occurs.
+            If this PR is still relevant, please rebase it, address any pending reviews, or leave a comment.
+            Thank you for your contributions to krkn!
+          close-pr-message: |
+            This pull request has been automatically closed due to inactivity.
+            If you believe this PR is still relevant, please feel free to reopen it or create a new pull request with updated changes.
+            Thank you for your understanding!
 
-          # issues with these labels won't be marked stale
+          # Exempt labels
           exempt-issue-labels: 'bug,enhancement,good first issue'
+          exempt-pr-labels: 'pending discussions,hold'
 
           remove-stale-when-updated: true


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  

Extends the existing stale issues workflow to also manage stale pull requests. PRs older than 90 days without activity are automatically marked with the `stale` label and closed after 14 additional days of inactivity, matching the request in issue #1107

**Changes:**
- Extended workflow name to "Manage Stale Issues and Pull Requests"
- Added `pull-requests: write` permission
- Configured PR stale threshold to 90 days
- Configured PR close threshold to 14 days after stale
- Added appropriate stale/close messages for PRs
- Added exempt labels for PRs: `hold`, `pending discussions`

## Related Tickets & Documents

- Related Issue #: 1107
- Closes #1107
