### PR TITLE
fix(run_kraken): replace bare except with proper error handling for kubecli init

### DIFF
--- a/run_kraken.py
+++ b/run_kraken.py
@@ -170,8 +170,9 @@ def main(options, command: Optional[str]) -> int:
             # krkn-lib-kubernetes init
             kubecli = KrknKubernetes(kubeconfig_path=kubeconfig_path)
             ocpcli = KrknOpenshift(kubeconfig_path=kubeconfig_path)
-        except:
-            kubecli.initialize_clients(None)
+        except Exception as e:
+            logging.error(f"Failed to initialize Kubernetes client: {e}")
+            return -1
 
         distribution = "kubernetes"
         if ocpcli.is_openshift():


### PR DESCRIPTION
# fix(run_kraken): replace bare except with proper error handling for kubecli init

# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  

The bare `except` block at line 173 attempted to call `kubecli.initialize_clients(None)`, but `kubecli` is undefined at this point since the exception occurs during its initialization. This causes a `NameError` crash on top of the original exception.


## Related Tickets & Documents

- Related Issue #: 1069
- Closes #1069  (split from #1072)

# Documentation  
- [ ] **Is documentation needed for this update?**

No — this is an internal bug fix with no user-facing changes.

# Checklist before requesting a review

- [x] Ensure the changes and proposed solution have been discussed in the relevant issue
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:

Verified module imports cleanly:

```bash
python -c "import run_kraken"
# OK - no import errors
```

This is a single-line fix for exception handling - no runtime test required as it only affects error path behavior.
