### PR TITLE
fix(hogs): correct off-by-one error in random node selection

### DIFF
--- a/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
+++ b/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
@@ -53,7 +53,7 @@ class HogsScenarioPlugin(AbstractScenarioPlugin):
                     raise Exception("no available nodes to schedule workload")
 
                 if not has_selector:
-                    available_nodes = [available_nodes[random.randint(0, len(available_nodes))]]
+                    available_nodes = [available_nodes[random.randint(0, len(available_nodes) - 1)]]
 
             if scenario_config.number_of_nodes and len(available_nodes) > scenario_config.number_of_nodes:
                 available_nodes = random.sample(available_nodes, scenario_config.number_of_nodes)


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  

Fixed an off-by-one error in `hogs_scenario_plugin.py` at line 56. `random.randint(a, b)` returns a random integer N such that `a <= N <= b` (inclusive). Using `len(available_nodes)` as upper bound causes an `IndexError` when the random value equals the list length.

**Before:**
```python
available_nodes = [available_nodes[random.randint(0, len(available_nodes))]]
# IndexError when randint returns len(available_nodes)
```

**After:**
```python
available_nodes = [available_nodes[random.randint(0, len(available_nodes) - 1)]]
```

This aligns with the correct pattern already used elsewhere in the codebase:
- `common_node_functions.py`: `random.randint(0, len(nodes) - 1)`
- `kubevirt_vm_outage_scenario_plugin.py`: `random.randint(0, len(self.vmis_list) - 1)`

## Related Tickets & Documents

- Related Issue #: 1069
- Closes #1069(split from #1072 )

# Documentation  
- [ ] **Is documentation needed for this update?**

No — this is an internal bug fix with no user-facing changes.

# Checklist before requesting a review

- [x] Ensure the changes and proposed solution have been discussed in the relevant issue
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:

```bash
python -m pytest tests/test_hogs_scenario_plugin.py -v

==================== test session starts ====================
collected 1 item

test_get_scenario_types PASSED [100%]
==================== 1 passed in 2.60s ======================
```

Module import verification:
```bash
python -c "from krkn.scenario_plugins.hogs.hogs_scenario_plugin import HogsScenarioPlugin"
# OK - no errors
```
