### PR TITLE
feat: add HTTP load testing scenario plugin

### DIFF
--- a/CI/config/common_test_config.yaml
+++ b/CI/config/common_test_config.yaml
@@ -72,3 +72,5 @@ health_checks:                                              # Utilizing health c
           bearer_token:                                     # Bearer token for authentication if any
           auth:                                             # Provide authentication credentials (username , password) in tuple format if any, ex:("admin","secretpassword")
           exit_on_failure:                                  # If value is True exits when health check failed for application, values can be True/False
+
+

--- a/krkn/scenario_plugins/http_load/http_load_scenario_plugin.py
+++ b/krkn/scenario_plugins/http_load/http_load_scenario_plugin.py
@@ -1,0 +1,331 @@
+import logging
+import os
+import time
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+from kubernetes import client
+from krkn_lib.k8s import KrknKubernetes
+from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+from krkn_lib.utils import get_yaml_item_value
+
+from krkn.cerberus import setup as cerberus
+from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+
+
+class HttpLoadScenarioPlugin(AbstractScenarioPlugin):
+    def run(
+        self,
+        run_uuid: str,
+        scenario: str,
+        krkn_config: dict[str, any],
+        lib_telemetry: KrknTelemetryOpenshift,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        try:
+            with open(scenario, "r") as file:
+                config = yaml.safe_load(file)
+                http_load_config = config["http_load"]
+
+                target_url = get_yaml_item_value(http_load_config, "target_url", "")
+                target_service = get_yaml_item_value(http_load_config, "target_service", "")
+                target_ingress = get_yaml_item_value(http_load_config, "target_ingress", "")
+                target_route = get_yaml_item_value(http_load_config, "target_route", "")
+                target_port = get_yaml_item_value(http_load_config, "target_port", 80)
+                target_path = get_yaml_item_value(http_load_config, "target_path", "")
+                namespace = get_yaml_item_value(http_load_config, "namespace", "default")
+
+                duration = int(get_yaml_item_value(http_load_config, "duration", 30))
+                concurrency = int(get_yaml_item_value(http_load_config, "concurrency", 10))
+                requests_per_second = int(get_yaml_item_value(http_load_config, "requests_per_second", 0))
+                http_method = get_yaml_item_value(http_load_config, "http_method", "GET")
+                number_of_pods = int(get_yaml_item_value(http_load_config, "number_of_pods", 1))
+                image = get_yaml_item_value(
+                    http_load_config, "image", "williamyeh/hey:latest"
+                )
+
+                request_body = get_yaml_item_value(http_load_config, "request_body", "")
+                headers = get_yaml_item_value(http_load_config, "headers", {})
+                content_type = get_yaml_item_value(http_load_config, "content_type", "")
+
+                kubecli = lib_telemetry.get_lib_kubernetes()
+
+                resolved_url = self.resolve_target_url(
+                    kubecli, target_url, target_service, target_ingress,
+                    target_route, target_port, target_path, namespace
+                )
+
+                if not resolved_url:
+                    logging.error(
+                        "HttpLoadScenarioPlugin: Could not resolve target URL. "
+                        "Specify one of: target_url, target_service, target_ingress, or target_route"
+                    )
+                    return 1
+
+                logging.info(f"HttpLoadScenarioPlugin: Target URL: {resolved_url}")
+                logging.info(
+                    f"HttpLoadScenarioPlugin: Duration: {duration}s, Concurrency: {concurrency}, "
+                    f"Pods: {number_of_pods}, Method: {http_method}"
+                )
+
+                file_loader = FileSystemLoader(os.path.abspath(os.path.dirname(__file__)))
+                env = Environment(loader=file_loader, autoescape=True)
+                job_template = env.get_template("job.j2")
+
+                cmd = self.build_load_command(
+                    resolved_url, duration, concurrency, requests_per_second,
+                    http_method, request_body, headers, content_type
+                )
+
+                job_list = []
+                start_time = int(time.time())
+                try:
+                    for i in range(number_of_pods):
+                        jobname = f"{run_uuid[:8]}-{i}"
+                        job_body = yaml.safe_load(
+                            job_template.render(
+                                jobname=jobname,
+                                namespace=namespace,
+                                image=image,
+                                cmd=cmd,
+                            )
+                        )
+                        job_list.append(job_body["metadata"]["name"])
+                        api_response = kubecli.create_job(job_body, namespace=namespace)
+                        if api_response is None:
+                            logging.error("HttpLoadScenarioPlugin: Error creating job")
+                            return 1
+                        logging.info(f"HttpLoadScenarioPlugin: Created job {job_body['metadata']['name']}")
+
+                    logging.info("HttpLoadScenarioPlugin: Waiting for jobs to complete")
+                    self.wait_for_jobs(job_list[:], kubecli, namespace, duration + 300)
+                    self.collect_job_metrics(job_list[:], kubecli, namespace)
+
+                except Exception as e:
+                    logging.error(f"HttpLoadScenarioPlugin: Exception during execution: {e}")
+                    return 1
+                finally:
+                    end_time = int(time.time())
+                    cerberus.publish_kraken_status(krkn_config, [], start_time, end_time)
+                    logging.info("HttpLoadScenarioPlugin: Cleaning up jobs")
+                    self.delete_jobs(job_list[:], kubecli, namespace)
+
+        except Exception as e:
+            logging.error(f"HttpLoadScenarioPlugin: Exception: {e}")
+            return 1
+        else:
+            return 0
+
+    def resolve_target_url(
+        self, kubecli, target_url, target_service, target_ingress,
+        target_route, target_port, target_path, namespace
+    ):
+        if target_url:
+            return target_url
+
+        if target_service:
+            if not kubecli.service_exists(target_service, namespace):
+                logging.error(
+                    f"HttpLoadScenarioPlugin: Service {target_service} not found in namespace {namespace}"
+                )
+                return None
+            url = f"http://{target_service}.{namespace}.svc.cluster.local:{target_port}"
+            if target_path:
+                url += f"/{target_path.lstrip('/')}"
+            return url
+
+        if target_ingress:
+            return self.resolve_ingress_url(kubecli, target_ingress, namespace, target_path)
+
+        if target_route:
+            return self.resolve_route_url(kubecli, target_route, namespace, target_path)
+
+        return None
+
+    def resolve_ingress_url(self, kubecli, ingress_name, namespace, target_path):
+        try:
+            networking_v1 = client.NetworkingV1Api(kubecli.api_client)
+            ingress = networking_v1.read_namespaced_ingress(name=ingress_name, namespace=namespace)
+
+            if not ingress.spec.rules or len(ingress.spec.rules) == 0:
+                logging.error(f"HttpLoadScenarioPlugin: Ingress {ingress_name} has no rules defined")
+                return None
+
+            rule = ingress.spec.rules[0]
+            host = rule.host if rule.host else "localhost"
+
+            protocol = "http"
+            if ingress.spec.tls:
+                for tls in ingress.spec.tls:
+                    if tls.hosts and host in tls.hosts:
+                        protocol = "https"
+                        break
+
+            path = target_path
+            if not path and rule.http and rule.http.paths:
+                path = rule.http.paths[0].path or ""
+
+            url = f"{protocol}://{host}"
+            if path:
+                url += f"/{path.lstrip('/')}"
+
+            logging.info(f"HttpLoadScenarioPlugin: Resolved Ingress {ingress_name} to {url}")
+            return url
+
+        except client.ApiException as e:
+            if e.status == 404:
+                logging.error(f"HttpLoadScenarioPlugin: Ingress {ingress_name} not found in namespace {namespace}")
+            else:
+                logging.error(f"HttpLoadScenarioPlugin: Error reading Ingress {ingress_name}: {e}")
+            return None
+
+    def resolve_route_url(self, kubecli, route_name, namespace, target_path):
+        try:
+            custom_api = client.CustomObjectsApi(kubecli.api_client)
+            route = custom_api.get_namespaced_custom_object(
+                group="route.openshift.io",
+                version="v1",
+                namespace=namespace,
+                plural="routes",
+                name=route_name,
+            )
+
+            spec = route.get("spec", {})
+            host = spec.get("host", "")
+
+            if not host:
+                logging.error(f"HttpLoadScenarioPlugin: Route {route_name} has no host defined")
+                return None
+
+            tls = spec.get("tls")
+            protocol = "https" if tls else "http"
+
+            path = target_path or spec.get("path", "")
+
+            url = f"{protocol}://{host}"
+            if path:
+                url += f"/{path.lstrip('/')}"
+
+            logging.info(f"HttpLoadScenarioPlugin: Resolved Route {route_name} to {url}")
+            return url
+
+        except client.ApiException as e:
+            if e.status == 404:
+                logging.error(
+                    f"HttpLoadScenarioPlugin: Route {route_name} not found in namespace {namespace}. "
+                    "Note: Routes are only available on OpenShift clusters."
+                )
+            else:
+                logging.error(f"HttpLoadScenarioPlugin: Error reading Route {route_name}: {e}")
+            return None
+
+    def build_load_command(
+        self, target_url, duration, concurrency, requests_per_second,
+        http_method, request_body="", headers=None, content_type=""
+    ):
+        cmd = f"hey -c {concurrency} -z {duration}s -m {http_method}"
+
+        if requests_per_second > 0:
+            cmd += f" -q {requests_per_second}"
+
+        if content_type:
+            cmd += f" -T '{content_type}'"
+
+        if headers:
+            for key, value in headers.items():
+                escaped_value = str(value).replace("'", "'\"'\"'")
+                cmd += f" -H '{key}: {escaped_value}'"
+
+        if request_body:
+            escaped_body = request_body.replace("'", "'\"'\"'")
+            cmd += f" -d '{escaped_body}'"
+
+        cmd += f" '{target_url}'"
+        return cmd
+
+    def wait_for_jobs(self, job_list, kubecli, namespace, timeout=300):
+        wait_time = time.time() + timeout
+        completed_count = 0
+        total_jobs = len(job_list)
+        pending_jobs = job_list[:]
+
+        while completed_count != total_jobs:
+            for jobname in pending_jobs[:]:
+                try:
+                    api_response = kubecli.get_job_status(jobname, namespace=namespace)
+                    if api_response.status.succeeded is not None or api_response.status.failed is not None:
+                        completed_count += 1
+                        pending_jobs.remove(jobname)
+                        status = "succeeded" if api_response.status.succeeded else "failed"
+                        logging.info(f"HttpLoadScenarioPlugin: Job {jobname} {status}")
+                except Exception:
+                    logging.warning(f"HttpLoadScenarioPlugin: Exception getting job status for {jobname}")
+
+                if time.time() > wait_time:
+                    raise Exception("HttpLoadScenarioPlugin: Timeout waiting for jobs to complete")
+
+            time.sleep(5)
+
+    def collect_job_metrics(self, job_list, kubecli, namespace):
+        for jobname in job_list:
+            try:
+                api_response = kubecli.get_job_status(jobname, namespace=namespace)
+                pod_name = self.get_job_pod(api_response, kubecli, namespace)
+
+                if pod_name:
+                    pod_log_response = kubecli.get_pod_log(name=pod_name, namespace=namespace)
+                    if pod_log_response:
+                        pod_log = pod_log_response.data.decode("utf-8")
+
+                        if api_response.status.succeeded:
+                            logging.info(f"HttpLoadScenarioPlugin: Metrics from job {jobname}:")
+                            for line in pod_log.strip().split("\n"):
+                                logging.info(f"  {line}")
+                        else:
+                            logging.error(f"HttpLoadScenarioPlugin: Job {jobname} failed. Output:")
+                            logging.error(pod_log)
+
+            except Exception as e:
+                logging.warning(f"HttpLoadScenarioPlugin: Could not collect metrics for job {jobname}: {e}")
+
+    def get_job_pod(self, api_response, kubecli, namespace):
+        try:
+            controller_uid = api_response.metadata.labels.get("controller-uid")
+            if not controller_uid:
+                return None
+
+            pod_label_selector = f"controller-uid={controller_uid}"
+            pods_list = kubecli.list_pods(
+                label_selector=pod_label_selector, namespace=namespace
+            )
+            return pods_list[0] if pods_list else None
+        except Exception:
+            return None
+
+    def delete_jobs(self, job_list, kubecli, namespace):
+        for jobname in job_list:
+            try:
+                api_response = kubecli.get_job_status(jobname, namespace=namespace)
+                if api_response.status.failed is not None:
+                    pod_name = self.get_job_pod(api_response, kubecli, namespace)
+                    if pod_name:
+                        pod_stat = kubecli.read_pod(name=pod_name, namespace=namespace)
+                        logging.error(
+                            f"HttpLoadScenarioPlugin: Job {jobname} failed. "
+                            f"Container status: {pod_stat.status.container_statuses}"
+                        )
+                        pod_log_response = kubecli.get_pod_log(name=pod_name, namespace=namespace)
+                        if pod_log_response:
+                            pod_log = pod_log_response.data.decode("utf-8")
+                            logging.error(f"HttpLoadScenarioPlugin: Pod logs:\n{pod_log}")
+            except Exception:
+                logging.warning(f"HttpLoadScenarioPlugin: Exception getting job status for {jobname}")
+
+            try:
+                kubecli.delete_job(name=jobname, namespace=namespace)
+            except Exception as e:
+                logging.warning(f"HttpLoadScenarioPlugin: Failed to delete job {jobname}: {e}")
+
+    def get_scenario_types(self) -> list[str]:
+        return ["http_load_scenarios"]

--- a/krkn/scenario_plugins/http_load/job.j2
+++ b/krkn/scenario_plugins/http_load/job.j2
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: http-load-{{jobname}}
+  namespace: {{namespace}}
+  labels:
+    app: http-load
+    krkn: chaos
+    scenario: http-load-testing
+spec:
+  template:
+    metadata:
+      labels:
+        app: http-load
+        job-name: http-load-{{jobname}}
+    spec:
+      containers:
+      - name: http-load
+        image: {{image}}
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c", "{{cmd}}"]
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+      restartPolicy: Never
+  backoffLimit: 0

--- a/scenarios/kube/http_load.yaml
+++ b/scenarios/kube/http_load.yaml
@@ -1,0 +1,17 @@
+http_load:
+  target_url: ""
+  target_service: "my-service"
+  target_port: 80
+  target_ingress: ""
+  target_route: ""
+  target_path: ""
+  namespace: "default"
+  duration: 30
+  concurrency: 10
+  requests_per_second: 0
+  http_method: "GET"
+  number_of_pods: 1
+  request_body: ""
+  content_type: ""
+  headers: {}
+  image: "williamyeh/hey:latest"

--- a/tests/test_http_load_scenario_plugin.py
+++ b/tests/test_http_load_scenario_plugin.py
@@ -1,0 +1,503 @@
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+import yaml
+
+from krkn.scenario_plugins.http_load.http_load_scenario_plugin import HttpLoadScenarioPlugin
+
+
+class TestHttpLoadScenarioPlugin(unittest.TestCase):
+
+    def setUp(self):
+        self.plugin = HttpLoadScenarioPlugin("http_load_scenarios")
+        self.mock_telemetry = Mock()
+        self.mock_kubernetes = Mock()
+        self.mock_telemetry.get_lib_kubernetes.return_value = self.mock_kubernetes
+        self.mock_scenario_telemetry = Mock()
+
+    def test_get_scenario_types(self):
+        result = self.plugin.get_scenario_types()
+        self.assertEqual(result, ["http_load_scenarios"])
+
+    def test_build_load_command_basic(self):
+        cmd = self.plugin.build_load_command(
+            target_url="http://example.com",
+            duration=30,
+            concurrency=10,
+            requests_per_second=0,
+            http_method="GET",
+        )
+        self.assertEqual(cmd, "hey -c 10 -z 30s -m GET 'http://example.com'")
+
+    def test_build_load_command_with_rps(self):
+        cmd = self.plugin.build_load_command(
+            target_url="http://example.com",
+            duration=60,
+            concurrency=20,
+            requests_per_second=100,
+            http_method="POST",
+        )
+        self.assertEqual(cmd, "hey -c 20 -z 60s -m POST -q 100 'http://example.com'")
+
+    def test_build_load_command_with_body_and_headers(self):
+        cmd = self.plugin.build_load_command(
+            target_url="http://example.com/api",
+            duration=30,
+            concurrency=10,
+            requests_per_second=0,
+            http_method="POST",
+            request_body='{"key": "value"}',
+            headers={"Authorization": "Bearer token123", "X-Custom": "header"},
+            content_type="application/json",
+        )
+        self.assertIn("-c 10", cmd)
+        self.assertIn("-z 30s", cmd)
+        self.assertIn("-m POST", cmd)
+        self.assertIn("-T 'application/json'", cmd)
+        self.assertIn("-H 'Authorization: Bearer token123'", cmd)
+        self.assertIn("-H 'X-Custom: header'", cmd)
+        self.assertIn("-d '{\"key\": \"value\"}'", cmd)
+        self.assertIn("'http://example.com/api'", cmd)
+
+    def test_build_load_command_with_content_type_only(self):
+        cmd = self.plugin.build_load_command(
+            target_url="http://example.com",
+            duration=10,
+            concurrency=5,
+            requests_per_second=0,
+            http_method="POST",
+            content_type="text/plain",
+        )
+        self.assertIn("-T 'text/plain'", cmd)
+
+    def test_resolve_target_url_direct(self):
+        result = self.plugin.resolve_target_url(
+            kubecli=self.mock_kubernetes,
+            target_url="http://direct.example.com",
+            target_service="",
+            target_ingress="",
+            target_route="",
+            target_port=80,
+            target_path="",
+            namespace="default",
+        )
+        self.assertEqual(result, "http://direct.example.com")
+
+    def test_resolve_target_url_service(self):
+        self.mock_kubernetes.service_exists.return_value = True
+
+        result = self.plugin.resolve_target_url(
+            kubecli=self.mock_kubernetes,
+            target_url="",
+            target_service="my-service",
+            target_ingress="",
+            target_route="",
+            target_port=8080,
+            target_path="api/v1",
+            namespace="test-ns",
+        )
+
+        self.mock_kubernetes.service_exists.assert_called_once_with("my-service", "test-ns")
+        self.assertEqual(result, "http://my-service.test-ns.svc.cluster.local:8080/api/v1")
+
+    def test_resolve_target_url_service_not_found(self):
+        self.mock_kubernetes.service_exists.return_value = False
+
+        result = self.plugin.resolve_target_url(
+            kubecli=self.mock_kubernetes,
+            target_url="",
+            target_service="nonexistent",
+            target_ingress="",
+            target_route="",
+            target_port=80,
+            target_path="",
+            namespace="default",
+        )
+
+        self.assertIsNone(result)
+
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.client.NetworkingV1Api")
+    def test_resolve_ingress_url(self, mock_networking_api):
+        mock_api = Mock()
+        mock_networking_api.return_value = mock_api
+
+        mock_ingress = Mock()
+        mock_ingress.spec.rules = [Mock(host="ingress.example.com", http=Mock(paths=[Mock(path="/api")]))]
+        mock_ingress.spec.tls = None
+        mock_api.read_namespaced_ingress.return_value = mock_ingress
+
+        result = self.plugin.resolve_ingress_url(
+            kubecli=self.mock_kubernetes,
+            ingress_name="my-ingress",
+            namespace="default",
+            target_path="",
+        )
+
+        self.assertEqual(result, "http://ingress.example.com/api")
+
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.client.NetworkingV1Api")
+    def test_resolve_ingress_url_with_tls(self, mock_networking_api):
+        mock_api = Mock()
+        mock_networking_api.return_value = mock_api
+
+        mock_ingress = Mock()
+        mock_ingress.spec.rules = [Mock(host="secure.example.com", http=None)]
+        mock_ingress.spec.tls = [Mock(hosts=["secure.example.com"])]
+        mock_api.read_namespaced_ingress.return_value = mock_ingress
+
+        result = self.plugin.resolve_ingress_url(
+            kubecli=self.mock_kubernetes,
+            ingress_name="secure-ingress",
+            namespace="default",
+            target_path="/health",
+        )
+
+        self.assertEqual(result, "https://secure.example.com/health")
+
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.client.CustomObjectsApi")
+    def test_resolve_route_url(self, mock_custom_api):
+        mock_api = Mock()
+        mock_custom_api.return_value = mock_api
+
+        mock_api.get_namespaced_custom_object.return_value = {
+            "spec": {
+                "host": "route.apps.example.com",
+                "tls": {"termination": "edge"},
+                "path": "/app",
+            }
+        }
+
+        result = self.plugin.resolve_route_url(
+            kubecli=self.mock_kubernetes,
+            route_name="my-route",
+            namespace="openshift-project",
+            target_path="",
+        )
+
+        self.assertEqual(result, "https://route.apps.example.com/app")
+
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.client.CustomObjectsApi")
+    def test_resolve_route_url_no_tls(self, mock_custom_api):
+        mock_api = Mock()
+        mock_custom_api.return_value = mock_api
+
+        mock_api.get_namespaced_custom_object.return_value = {
+            "spec": {
+                "host": "route.apps.example.com",
+            }
+        }
+
+        result = self.plugin.resolve_route_url(
+            kubecli=self.mock_kubernetes,
+            route_name="my-route",
+            namespace="openshift-project",
+            target_path="/api",
+        )
+
+        self.assertEqual(result, "http://route.apps.example.com/api")
+
+    def test_run_missing_target(self):
+        config = {"http_load": {"namespace": "default"}}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            temp_file = f.name
+
+        result = self.plugin.run(
+            run_uuid="test-uuid",
+            scenario=temp_file,
+            krkn_config={"cerberus": {"cerberus_enabled": False}},
+            lib_telemetry=self.mock_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry,
+        )
+        self.assertEqual(result, 1)
+
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.cerberus")
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.Environment")
+    def test_run_success_with_service(self, mock_env_class, mock_cerberus):
+        config = {
+            "http_load": {
+                "target_service": "my-service",
+                "target_port": 80,
+                "namespace": "default",
+                "duration": 10,
+                "concurrency": 5,
+                "number_of_pods": 1,
+                "image": "test-image",
+            }
+        }
+
+        mock_template = Mock()
+        mock_template.render.return_value = """
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: http-load-test
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: http-load
+        image: test-image
+        command: ["/bin/sh", "-c", "hey -c 5 -z 10s -m GET 'http://my-service.default.svc.cluster.local:80'"]
+      restartPolicy: Never
+  backoffLimit: 0
+"""
+        mock_env = Mock()
+        mock_env.get_template.return_value = mock_template
+        mock_env_class.return_value = mock_env
+
+        self.mock_kubernetes.service_exists.return_value = True
+        self.mock_kubernetes.create_job.return_value = Mock()
+
+        mock_job_status = Mock()
+        mock_job_status.status.succeeded = 1
+        mock_job_status.status.failed = None
+        mock_job_status.metadata.labels = {"controller-uid": "test-uid"}
+        self.mock_kubernetes.get_job_status.return_value = mock_job_status
+        self.mock_kubernetes.list_pods.return_value = ["test-pod"]
+
+        mock_log_response = Mock()
+        mock_log_response.data = b"Summary:\n  Requests/sec: 100\n"
+        self.mock_kubernetes.get_pod_log.return_value = mock_log_response
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            temp_file = f.name
+
+        result = self.plugin.run(
+            run_uuid="test-uuid-1234",
+            scenario=temp_file,
+            krkn_config={"cerberus": {"cerberus_enabled": False}},
+            lib_telemetry=self.mock_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry,
+        )
+
+        self.assertEqual(result, 0)
+        self.mock_kubernetes.service_exists.assert_called_once_with("my-service", "default")
+        self.mock_kubernetes.create_job.assert_called_once()
+        self.mock_kubernetes.delete_job.assert_called()
+        mock_cerberus.publish_kraken_status.assert_called_once()
+
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.cerberus")
+    def test_run_service_not_found(self, mock_cerberus):
+        config = {
+            "http_load": {
+                "target_service": "nonexistent-service",
+                "namespace": "default",
+            }
+        }
+
+        self.mock_kubernetes.service_exists.return_value = False
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            temp_file = f.name
+
+        result = self.plugin.run(
+            run_uuid="test-uuid",
+            scenario=temp_file,
+            krkn_config={"cerberus": {"cerberus_enabled": False}},
+            lib_telemetry=self.mock_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry,
+        )
+
+        self.assertEqual(result, 1)
+        self.mock_kubernetes.service_exists.assert_called_once_with("nonexistent-service", "default")
+
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.cerberus")
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.Environment")
+    def test_run_create_job_failure(self, mock_env_class, mock_cerberus):
+        config = {
+            "http_load": {
+                "target_url": "http://example.com",
+                "namespace": "default",
+                "duration": 10,
+                "concurrency": 5,
+                "number_of_pods": 1,
+            }
+        }
+
+        mock_template = Mock()
+        mock_template.render.return_value = """
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: http-load-test
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: http-load
+        image: williamyeh/hey:latest
+        command: ["/bin/sh", "-c", "hey"]
+      restartPolicy: Never
+  backoffLimit: 0
+"""
+        mock_env = Mock()
+        mock_env.get_template.return_value = mock_template
+        mock_env_class.return_value = mock_env
+
+        self.mock_kubernetes.create_job.return_value = None
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            temp_file = f.name
+
+        result = self.plugin.run(
+            run_uuid="test-uuid",
+            scenario=temp_file,
+            krkn_config={"cerberus": {"cerberus_enabled": False}},
+            lib_telemetry=self.mock_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry,
+        )
+        self.assertEqual(result, 1)
+
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.cerberus")
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.client.NetworkingV1Api")
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.Environment")
+    def test_run_with_ingress_target(self, mock_env_class, mock_networking_api, mock_cerberus):
+        config = {
+            "http_load": {
+                "target_ingress": "my-ingress",
+                "namespace": "default",
+                "duration": 10,
+                "concurrency": 5,
+                "number_of_pods": 1,
+            }
+        }
+
+        mock_api = Mock()
+        mock_networking_api.return_value = mock_api
+        mock_ingress = Mock()
+        mock_ingress.spec.rules = [Mock(host="ingress.example.com", http=Mock(paths=[Mock(path="/api")]))]
+        mock_ingress.spec.tls = None
+        mock_api.read_namespaced_ingress.return_value = mock_ingress
+
+        mock_template = Mock()
+        mock_template.render.return_value = """
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: http-load-test
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: http-load
+        image: williamyeh/hey:latest
+        command: ["/bin/sh", "-c", "hey"]
+      restartPolicy: Never
+  backoffLimit: 0
+"""
+        mock_env = Mock()
+        mock_env.get_template.return_value = mock_template
+        mock_env_class.return_value = mock_env
+
+        self.mock_kubernetes.create_job.return_value = Mock()
+        mock_job_status = Mock()
+        mock_job_status.status.succeeded = 1
+        mock_job_status.status.failed = None
+        mock_job_status.metadata.labels = {"controller-uid": "test-uid"}
+        self.mock_kubernetes.get_job_status.return_value = mock_job_status
+        self.mock_kubernetes.list_pods.return_value = ["test-pod"]
+        mock_log_response = Mock()
+        mock_log_response.data = b"Summary: OK"
+        self.mock_kubernetes.get_pod_log.return_value = mock_log_response
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            temp_file = f.name
+
+        result = self.plugin.run(
+            run_uuid="test-uuid-1234",
+            scenario=temp_file,
+            krkn_config={"cerberus": {"cerberus_enabled": False}},
+            lib_telemetry=self.mock_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry,
+        )
+
+        self.assertEqual(result, 0)
+        mock_api.read_namespaced_ingress.assert_called_once()
+
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.cerberus")
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.client.CustomObjectsApi")
+    @patch("krkn.scenario_plugins.http_load.http_load_scenario_plugin.Environment")
+    def test_run_with_route_target(self, mock_env_class, mock_custom_api, mock_cerberus):
+        config = {
+            "http_load": {
+                "target_route": "my-route",
+                "namespace": "openshift-project",
+                "duration": 10,
+                "concurrency": 5,
+                "number_of_pods": 1,
+            }
+        }
+
+        mock_api = Mock()
+        mock_custom_api.return_value = mock_api
+        mock_api.get_namespaced_custom_object.return_value = {
+            "spec": {
+                "host": "route.apps.example.com",
+                "tls": {"termination": "edge"},
+            }
+        }
+
+        mock_template = Mock()
+        mock_template.render.return_value = """
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: http-load-test
+  namespace: openshift-project
+spec:
+  template:
+    spec:
+      containers:
+      - name: http-load
+        image: williamyeh/hey:latest
+        command: ["/bin/sh", "-c", "hey"]
+      restartPolicy: Never
+  backoffLimit: 0
+"""
+        mock_env = Mock()
+        mock_env.get_template.return_value = mock_template
+        mock_env_class.return_value = mock_env
+
+        self.mock_kubernetes.create_job.return_value = Mock()
+        mock_job_status = Mock()
+        mock_job_status.status.succeeded = 1
+        mock_job_status.status.failed = None
+        mock_job_status.metadata.labels = {"controller-uid": "test-uid"}
+        self.mock_kubernetes.get_job_status.return_value = mock_job_status
+        self.mock_kubernetes.list_pods.return_value = ["test-pod"]
+        mock_log_response = Mock()
+        mock_log_response.data = b"Summary: OK"
+        self.mock_kubernetes.get_pod_log.return_value = mock_log_response
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(config, f)
+            temp_file = f.name
+
+        result = self.plugin.run(
+            run_uuid="test-uuid-1234",
+            scenario=temp_file,
+            krkn_config={"cerberus": {"cerberus_enabled": False}},
+            lib_telemetry=self.mock_telemetry,
+            scenario_telemetry=self.mock_scenario_telemetry,
+        )
+
+        self.assertEqual(result, 0)
+        mock_api.get_namespaced_custom_object.assert_called_once_with(
+            group="route.openshift.io",
+            version="v1",
+            namespace="openshift-project",
+            plural="routes",
+            name="my-route",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### **User description**
# Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
Implements HTTP load testing scenario plugin to simulate heavy HTTP load on Kubernetes Services, Ingress, or OpenShift Routes. Uses the `hey` HTTP load generator (chosen over Gatling/Goku for its lightweight single-binary design, existing Docker image, and simpler CLI-based configuration suitable for K8s Jobs).

**Features:**
- Target Kubernetes Services (with cluster DNS)
- Target Ingress resources (with TLS detection)
- Target OpenShift Routes (with TLS detection)
- Direct URL targeting
- Configurable concurrency, duration, RPS limit
- Custom HTTP headers, request body, content-type
- Metrics collection from hey output
- Multiple load generator pods support

## Related Tickets & Documents

- Related Issue #: 993
- Closes #993

# Documentation  
- [x] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)  


# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python -m unittest tests.test_http_load_scenario_plugin -v

test_build_load_command_basic (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_build_load_command_with_body_and_headers (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_build_load_command_with_content_type_only (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_build_load_command_with_rps (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_get_scenario_types (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_resolve_ingress_url (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_resolve_ingress_url_with_tls (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_resolve_route_url (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_resolve_route_url_no_tls (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_resolve_target_url_direct (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_resolve_target_url_service (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_resolve_target_url_service_not_found (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_run_create_job_failure (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_run_missing_target (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_run_service_not_found (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_run_success_with_service (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_run_with_ingress_target (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok
test_run_with_route_target (tests.test_http_load_scenario_plugin.TestHttpLoadScenarioPlugin) ... ok

----------------------------------------------------------------------
Ran 18 tests in 15.048s

OK
```


___

### **PR Type**
Enhancement


___

### **Description**
- Implements HTTP load testing scenario plugin using `hey` load generator

- Supports multiple target types: Services, Ingress, Routes, direct URLs

- Configurable concurrency, duration, RPS limit, and HTTP parameters

- Automatic TLS detection for Ingress and OpenShift Routes

- Comprehensive test coverage with 18 unit tests (80%+ coverage)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Config["Load Test Config<br/>YAML"] -->|Parse| Plugin["HttpLoadScenarioPlugin"]
  Plugin -->|Resolve| Target["Target URL<br/>Service/Ingress/Route"]
  Plugin -->|Build| Command["hey Load Command"]
  Command -->|Create| Jobs["K8s Jobs<br/>Multiple Pods"]
  Jobs -->|Execute| Load["HTTP Load Test"]
  Load -->|Collect| Metrics["Metrics & Logs"]
  Metrics -->|Report| Status["Kraken Status"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_load_scenario_plugin.py</strong><dd><code>HTTP load testing plugin implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/http_load/http_load_scenario_plugin.py

<ul><li>Main plugin implementation with 331 lines of code<br> <li> Supports targeting Kubernetes Services, Ingress, OpenShift Routes, and <br>direct URLs<br> <li> Automatic TLS detection for Ingress and Routes<br> <li> Builds <code>hey</code> load test commands with configurable parameters <br>(concurrency, duration, RPS, headers, body)<br> <li> Creates and manages multiple Kubernetes Jobs for distributed load <br>testing<br> <li> Collects metrics and logs from completed jobs<br> <li> Includes error handling and cleanup logic</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1144/files#diff-f8b2a35f41122ddc375b8b06350a6a4abd9327c979eb8fe52aa34fef9fc2b51e">+331/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_http_load_scenario_plugin.py</strong><dd><code>Unit tests for HTTP load scenario plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_http_load_scenario_plugin.py

<ul><li>Comprehensive unit test suite with 18 test cases<br> <li> Tests URL resolution for all target types (Service, Ingress, Route, <br>direct URL)<br> <li> Tests load command building with various parameter combinations<br> <li> Tests job creation, execution, and cleanup workflows<br> <li> Tests error handling for missing services and failed jobs<br> <li> Achieves 80%+ code coverage with mocked Kubernetes API calls</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1144/files#diff-f333406a77970f7272309734cd926a607ff6e610b5b8809ad814837ac79c8d77">+503/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>job.j2</strong><dd><code>Kubernetes Job template for load testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/http_load/job.j2

<ul><li>Jinja2 template for Kubernetes Job manifest generation<br> <li> Configures container with <code>hey</code> image and load test command<br> <li> Sets resource requests/limits (64Mi-256Mi memory, 100m-500m CPU)<br> <li> Applies labels for tracking and identification<br> <li> Disables restart policy and sets backoff limit to 0</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1144/files#diff-aa40e8a25c666e8cfca83578b475766bd4b1f9a430ee4eecdad722bb30b3ec18">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http_load.yaml</strong><dd><code>Example HTTP load testing scenario configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scenarios/kube/http_load.yaml

<ul><li>Example scenario configuration file with all supported parameters<br> <li> Demonstrates Service targeting with configurable port and path<br> <li> Includes optional parameters for Ingress and Route targeting<br> <li> Configurable load parameters: duration, concurrency, RPS, HTTP method<br> <li> Support for custom headers, request body, and content-type<br> <li> Specifies container image and number of parallel load pods</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1144/files#diff-fd0e16619b8ac986ec67c07980e3a78aafc460fb79c3b72464c30910a09fba0a">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

