### PR TITLE
fix: correct spelling typos in log messages

### DIFF
--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -146,7 +146,7 @@ class AbstractScenarioPlugin(ABC):
             if scenario_telemetry.exit_status != 0:
                 failed_scenarios.append(scenario_config)
             scenario_telemetries.append(scenario_telemetry)
-            logging.info(f"wating {wait_duration} before running the next scenario")
+            logging.info(f"waiting {wait_duration} before running the next scenario")
             time.sleep(wait_duration)
         return failed_scenarios, scenario_telemetries
 

--- a/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
@@ -76,7 +76,7 @@ class abstract_node_scenarios:
                 nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
                 
                 logging.info("The kubelet of the node %s has been stopped" % (node))
-                logging.info("stop_kubelet_scenario has been successfuly injected!")
+                logging.info("stop_kubelet_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to stop the kubelet of the node. Encountered following "
@@ -108,7 +108,7 @@ class abstract_node_scenarios:
                 )
                 nodeaction.wait_for_ready_status(node, timeout, self.kubecli,affected_node)
                 logging.info("The kubelet of the node %s has been restarted" % (node))
-                logging.info("restart_kubelet_scenario has been successfuly injected!")
+                logging.info("restart_kubelet_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to restart the kubelet of the node. Encountered following "
@@ -128,7 +128,7 @@ class abstract_node_scenarios:
                     "oc debug node/" + node + " -- chroot /host "
                     "dd if=/dev/urandom of=/proc/sysrq-trigger"
                 )
-                logging.info("node_crash_scenario has been successfuly injected!")
+                logging.info("node_crash_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to crash the node. Encountered following exception: %s. "

--- a/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
@@ -379,7 +379,7 @@ class aws_node_scenarios(abstract_node_scenarios):
                 logging.info(
                     "Node with instance ID: %s has been terminated" % (instance_id)
                 )
-                logging.info("node_termination_scenario has been successfuly injected!")
+                logging.info("node_termination_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to terminate node instance. Encountered following exception:"
@@ -408,7 +408,7 @@ class aws_node_scenarios(abstract_node_scenarios):
                 logging.info(
                     "Node with instance ID: %s has been rebooted" % (instance_id)
                 )
-                logging.info("node_reboot_scenario has been successfuly injected!")
+                logging.info("node_reboot_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to reboot node instance. Encountered following exception:"

--- a/krkn/scenario_plugins/node_actions/bm_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/bm_node_scenarios.py
@@ -229,7 +229,7 @@ class bm_node_scenarios(abstract_node_scenarios):
                     nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
                     nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info("Node with bmc address: %s has been rebooted" % (bmc_addr))
-                logging.info("node_reboot_scenario has been successfuly injected!")
+                logging.info("node_reboot_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to reboot node instance. Encountered following exception:"

--- a/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/docker_node_scenarios.py
@@ -237,7 +237,7 @@ class docker_node_scenarios(abstract_node_scenarios):
                 logging.info(
                     "Node with container ID: %s has been terminated" % (container_id)
                 )
-                logging.info("node_termination_scenario has been successfuly injected!")
+                logging.info("node_termination_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to terminate node instance. Encountered following exception:"
@@ -264,7 +264,7 @@ class docker_node_scenarios(abstract_node_scenarios):
                 logging.info(
                     "Node with container ID: %s has been rebooted" % (container_id)
                 )
-                logging.info("node_reboot_scenario has been successfuly injected!")
+                logging.info("node_reboot_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to reboot node instance. Encountered following exception:"

--- a/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/gcp_node_scenarios.py
@@ -309,7 +309,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.info(
                     "Node with instance ID: %s has been terminated" % instance_id
                 )
-                logging.info("node_termination_scenario has been successfuly injected!")
+                logging.info("node_termination_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to terminate node instance. Encountered following exception:"
@@ -341,7 +341,7 @@ class gcp_node_scenarios(abstract_node_scenarios):
                 logging.info(
                     "Node with instance ID: %s has been rebooted" % instance_id
                 )
-                logging.info("node_reboot_scenario has been successfuly injected!")
+                logging.info("node_reboot_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to reboot node instance. Encountered following exception:"

--- a/krkn/scenario_plugins/node_actions/openstack_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/openstack_node_scenarios.py
@@ -184,7 +184,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                     nodeaction.wait_for_unknown_status(node, timeout, self.kubecli, affected_node)
                     nodeaction.wait_for_ready_status(node, timeout, self.kubecli, affected_node)
                 logging.info("Node with instance name: %s has been rebooted" % (node))
-                logging.info("node_reboot_scenario has been successfuly injected!")
+                logging.info("node_reboot_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
                     "Failed to reboot node instance. Encountered following exception:"
@@ -249,7 +249,7 @@ class openstack_node_scenarios(abstract_node_scenarios):
                 node_ip.strip(), service, ssh_private_key, timeout
             )
             logging.info("Service status checked on %s" % (node_ip))
-            logging.info("Check service status is successfuly injected!")
+            logging.info("Check service status is successfully injected!")
         except Exception as e:
             logging.error(
                 "Failed to check service status. Encountered following exception:"

--- a/krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py
+++ b/krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py
@@ -140,7 +140,7 @@ class ZoneOutageScenarioPlugin(AbstractScenarioPlugin):
                 network_association_ids[0], acl_id
             )
 
-            # capture the orginal_acl_id, created_acl_id and
+            # capture the original_acl_id, created_acl_id and
             # new association_id to use during the recovery
             ids[new_association_id] = original_acl_id
 
@@ -156,7 +156,7 @@ class ZoneOutageScenarioPlugin(AbstractScenarioPlugin):
                 new_association_id, original_acl_id
             )
         logging.info(
-            "Wating for 60 seconds to make sure " "the changes are in place"
+            "Waiting for 60 seconds to make sure " "the changes are in place"
         )
         time.sleep(60)
 


### PR DESCRIPTION
### **User description**
## Summary
This PR fixes spelling typos in log messages and code comments across the codebase.

## Changes
Fixed the following typos across 7 files:

### "wating" → "waiting" (2 occurrences)
- `krkn/scenario_plugins/abstract_scenario_plugin.py:149`
- `krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py:159`

### "successfuly" → "successfully" (12 occurrences)
- `krkn/scenario_plugins/node_actions/abstract_node_scenarios.py` (lines 79, 111, 131)
- `krkn/scenario_plugins/node_actions/aws_node_scenarios.py` (lines 382, 411)
- `krkn/scenario_plugins/node_actions/gcp_node_scenarios.py` (lines 312, 344)
- `krkn/scenario_plugins/node_actions/bm_node_scenarios.py` (line 232)
- `krkn/scenario_plugins/node_actions/openstack_node_scenarios.py` (lines 187, 252)
- `krkn/scenario_plugins/node_actions/docker_node_scenarios.py` (lines 240, 267)

### "orginal" → "original" (1 occurrence)
- `krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py:143` (code comment)

## Impact
- Improves professionalism of log output
- Enhances code readability
- No functional changes

## Testing
- No tests affected (string literals only)
- Verified with `git diff` that only spelling was changed
- All affected files compile without errors:
```bash
python -m py_compile krkn/scenario_plugins/abstract_scenario_plugin.py
python -m py_compile krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py
python -m py_compile krkn/scenario_plugins/node_actions/*.py
```

## Related
While exploring the codebase for #1051 (natural language scenario discovery), I noticed these typos and wanted to contribute a quick cleanup.

cc: @tsebastiani @chaitanyaenr @paigerube14

---

## Type of change
- [x] Bug fix

## Documentation  
- [ ] **Is documentation needed for this update?**

No - cosmetic string fixes only

## Checklist before requesting a review
- [x] I have performed a self-review of my code by running `git diff`
- [x] Changes verified to be spelling-only with no functional modifications


___

### **PR Type**
Bug fix


___

### **Description**
- Fix spelling typo "wating" to "waiting" (2 occurrences)

- Fix spelling typo "successfuly" to "successfully" (12 occurrences)

- Fix spelling typo "orginal" to "original" (1 occurrence in comment)

- Improves professionalism and readability of log messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Spelling Errors in Logs"] -->|"wating → waiting"| B["2 files fixed"]
  A -->|"successfuly → successfully"| C["6 files fixed"]
  A -->|"orginal → original"| D["1 file fixed"]
  B --> E["Improved Code Quality"]
  C --> E
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>abstract_scenario_plugin.py</strong><dd><code>Fix wating typo in log message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/abstract_scenario_plugin.py

- Fixed "wating" to "waiting" in log message at line 149


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1145/files#diff-561d78699f6d7a35a4262b9209e3da7d1d7a64cb14e8d70d4ac744b2467b6eab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>abstract_node_scenarios.py</strong><dd><code>Fix successfuly typos in node scenario logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/node_actions/abstract_node_scenarios.py

<ul><li>Fixed "successfuly" to "successfully" in 3 log messages<br> <li> Changes in stop_kubelet_scenario, restart_kubelet_scenario, and <br>node_crash_scenario methods</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1145/files#diff-7695e07ca8d0efc1f8afc755eaefc83950d16e4e2e97b86c5928a1d6890c16c5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>aws_node_scenarios.py</strong><dd><code>Fix successfuly typos in AWS node scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/node_actions/aws_node_scenarios.py

<ul><li>Fixed "successfuly" to "successfully" in 2 log messages<br> <li> Changes in node_termination_scenario and node_reboot_scenario methods</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1145/files#diff-2e92309fd080f5983fa3341fcc51a2bbb98d7a0a620dad06467aad6ac1752feb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bm_node_scenarios.py</strong><dd><code>Fix successfuly typo in bare metal scenario</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/node_actions/bm_node_scenarios.py

<ul><li>Fixed "successfuly" to "successfully" in log message<br> <li> Change in node_reboot_scenario method</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1145/files#diff-06e8732531e541bdbfd67cf01b60cae235bb933087da2306b73376637c86f6d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker_node_scenarios.py</strong><dd><code>Fix successfuly typos in Docker node scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/node_actions/docker_node_scenarios.py

<ul><li>Fixed "successfuly" to "successfully" in 2 log messages<br> <li> Changes in node_termination_scenario and node_reboot_scenario methods</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1145/files#diff-caa80156bae35fac0295e9a3f255def2e98e5f7a800c0f2a283de47e1c7f557f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gcp_node_scenarios.py</strong><dd><code>Fix successfuly typos in GCP node scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/node_actions/gcp_node_scenarios.py

<ul><li>Fixed "successfuly" to "successfully" in 2 log messages<br> <li> Changes in node_termination_scenario and node_reboot_scenario methods</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1145/files#diff-0757a57e4e0b448c922af0c0b138b466f3d5fa982de8ecf35238fd1636dfdc75">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>openstack_node_scenarios.py</strong><dd><code>Fix successfuly typos in OpenStack node scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/node_actions/openstack_node_scenarios.py

<ul><li>Fixed "successfuly" to "successfully" in 2 log messages<br> <li> Changes in node_reboot_scenario and helper_node_service_status methods</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1145/files#diff-a0e3dd88c7633b58f3b30ea98cb7346dab0703f679b093610db185bde5941e2c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>zone_outage_scenario_plugin.py</strong><dd><code>Fix orginal and Wating typos in zone outage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py

<ul><li>Fixed "orginal" to "original" in code comment at line 143<br> <li> Fixed "Wating" to "Waiting" in log message at line 159</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1145/files#diff-cd96cc981510dee5319279c50119f027dae2f5815b5ac1dbb9ca22ae515c1e99">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

