### PR TITLE
collect ERROR and CRITICAL logs and send to elastic search (#1147)

### DIFF
--- a/krkn/utils/ErrorCollectionHandler.py
+++ b/krkn/utils/ErrorCollectionHandler.py
@@ -1,0 +1,71 @@
+import logging
+import threading
+from datetime import datetime, timezone
+from krkn.utils.ErrorLog import ErrorLog
+
+
+class ErrorCollectionHandler(logging.Handler):
+    """
+    Custom logging handler that captures ERROR and CRITICAL level logs
+    in structured format for telemetry collection.
+
+    Stores logs in memory as ErrorLog objects for later retrieval.
+    Thread-safe for concurrent logging operations.
+    """
+
+    def __init__(self, level=logging.ERROR):
+        """
+        Initialize the error collection handler.
+
+        Args:
+            level: Minimum log level to capture (default: ERROR)
+        """
+        super().__init__(level)
+        self.error_logs: list[ErrorLog] = []
+        self._lock = threading.Lock()
+
+    def emit(self, record: logging.LogRecord):
+        """
+        Capture ERROR and CRITICAL logs and store as ErrorLog objects.
+
+        Args:
+            record: LogRecord from Python logging framework
+        """
+        try:
+            # Only capture ERROR (40) and CRITICAL (50) levels
+            if record.levelno < logging.ERROR:
+                return
+
+            # Format timestamp as ISO 8601 UTC
+            timestamp = datetime.fromtimestamp(
+                record.created, tz=timezone.utc
+            ).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+            # Create ErrorLog object
+            error_log = ErrorLog(
+                timestamp=timestamp,
+                message=record.getMessage()
+            )
+
+            # Thread-safe append
+            with self._lock:
+                self.error_logs.append(error_log)
+
+        except Exception:
+            # Handler should never raise exceptions (logging best practice)
+            self.handleError(record)
+
+    def get_error_logs(self) -> list[dict]:
+        """
+        Retrieve all collected error logs as list of dictionaries.
+
+        Returns:
+            List of error log dictionaries with timestamp and message
+        """
+        with self._lock:
+            return [log.to_dict() for log in self.error_logs]
+
+    def clear(self):
+        """Clear all collected error logs (useful for testing)"""
+        with self._lock:
+            self.error_logs.clear()

--- a/krkn/utils/ErrorLog.py
+++ b/krkn/utils/ErrorLog.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass, asdict
+
+
+@dataclass
+class ErrorLog:
+    """
+    Represents a single error log entry for telemetry collection.
+
+    Attributes:
+        timestamp: ISO 8601 formatted timestamp (UTC)
+        message: Full error message text
+    """
+    timestamp: str
+    message: str
+
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization"""
+        return asdict(self)

--- a/krkn/utils/__init__.py
+++ b/krkn/utils/__init__.py
@@ -1,2 +1,4 @@
 from .TeeLogHandler import TeeLogHandler
+from .ErrorLog import ErrorLog
+from .ErrorCollectionHandler import ErrorCollectionHandler
 from .functions import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ ibm_vpc==0.26.3  # Requires ibm_cloud_sdk_core
 jinja2==3.1.6
 lxml==5.1.0
 kubernetes==34.1.0
-krkn-lib==6.0.2
+krkn-lib==6.0.3
 numpy==1.26.4
 pandas==2.2.0
 openshift-client==1.0.21

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -669,8 +669,8 @@ if __name__ == "__main__":
     error_collection_handler = ErrorCollectionHandler(level=logging.ERROR)
 
     handlers = [
-        logging.FileHandler(report_file, mode="w"),
-        logging.StreamHandler(),
+        file_handler,
+        stream_handler,
         tee_handler,
         error_collection_handler,
     ]

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -28,7 +28,7 @@ from krkn_lib.models.telemetry import ChaosRunTelemetry
 from krkn_lib.utils import SafeLogger
 from krkn_lib.utils.functions import get_yaml_item_value, get_junit_test_case
 
-from krkn.utils import TeeLogHandler
+from krkn.utils import TeeLogHandler, ErrorCollectionHandler
 from krkn.utils.HealthChecker import HealthChecker
 from krkn.utils.VirtChecker import VirtChecker
 from krkn.scenario_plugins.scenario_plugin_factory import (
@@ -426,16 +426,22 @@ def main(options, command: Optional[str]) -> int:
             logging.info("collecting Kubernetes cluster metadata....")
             telemetry_k8s.collect_cluster_metadata(chaos_telemetry)
 
+        # Collect error logs from handler
+        error_logs = error_collection_handler.get_error_logs()
+        if error_logs:
+            logging.info(f"Collected {len(error_logs)} error logs for telemetry")
+            chaos_telemetry.error_logs = error_logs
+        else:
+            logging.info("No error logs collected during chaos run")
+            chaos_telemetry.error_logs = []
+
         telemetry_json = chaos_telemetry.to_json()
         decoded_chaos_run_telemetry = ChaosRunTelemetry(json.loads(telemetry_json))
         chaos_output.telemetry = decoded_chaos_run_telemetry
         logging.info(f"Chaos data:\n{chaos_output.to_json()}")
         if enable_elastic:
-            elastic_telemetry = ElasticChaosRunTelemetry(
-                chaos_run_telemetry=decoded_chaos_run_telemetry
-            )
             result = elastic_search.push_telemetry(
-                elastic_telemetry, elastic_telemetry_index
+                decoded_chaos_run_telemetry, elastic_telemetry_index
             )
             if result == -1:
                 safe_logger.error(
@@ -660,7 +666,14 @@ if __name__ == "__main__":
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(colored)
     tee_handler.setFormatter(plain)
-    handlers = [file_handler, stream_handler, tee_handler]
+    error_collection_handler = ErrorCollectionHandler(level=logging.ERROR)
+
+    handlers = [
+        logging.FileHandler(report_file, mode="w"),
+        logging.StreamHandler(),
+        tee_handler,
+        error_collection_handler,
+    ]
 
     logging.basicConfig(
         level=logging.DEBUG if options.debug else logging.INFO,


### PR DESCRIPTION
### **User description**
# Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  

Currently, when chaos scenarios fail or errors occur during execution, the only way to investigate is by manually reviewing log. This feature enables automatic collection and indexing of all ERROR and CRITICAL logs in Elasticsearch alongside other telemetry data.


## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Closes #:  #1147 

# Documentation  
- [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)  
This PR Need to be merged first https://github.com/krkn-chaos/krkn-lib/pull/247

# Checklist before requesting a review
- [X] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [X] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

I have Executed simple scenario on local pointing to local krkn-lib changes and verified in elastic search

```json
{
  "_index": "krkn-telemetry",
  "_id": "ZApgIpwBmDwu1hNAuLJk",
  "_version": 1,
  "_score": 1,
  "_source": {
    "scenarios": [
      {
        "start_timestamp": 1770103273,
        "end_timestamp": 1770103288,
        "scenario": "example/telemetry/pod_scenario.yaml",
        "scenario_type": "pod_disruption_scenarios",
        "exit_status": 1,
        "parameters_base64": "",
        "parameters": [
          {
            "config": {
              "kill": 5,
              "krkn_pod_recovery_time": 2,
              "label_selector": "app=nginx-demo",
              "namespace_pattern": "default"
            },
            "id": "kill-nginx-pod"
          }
        ],
        "affected_pods": {
          "unrecovered": [
            {
              "pod_name": "nginx-demo-5c68fc4647-r55vh",
              "namespace": "default"
            },
            {
              "pod_name": "nginx-demo-5c68fc4647-kt2lw",
              "namespace": "default"
            }
          ]
        }
      }
    ],
    "node_summary_infos": [
      {
        "count": 3,
        "nodes_type": "unknown",
        "architecture": "arm64",
        "instance_type": "unknown",
        "kernel_version": "6.12.54-linuxkit",
        "kubelet_version": "v1.35.0",
        "os_version": "Debian GNU/Linux 12 (bookworm)"
      }
    ],
    "node_taints": [
      {
        "key": "node-role.kubernetes.io/control-plane",
        "effect": "NoSchedule"
      }
    ],
    "kubernetes_objects_count": {
      "ConfigMap": 13,
      "Pod": 23,
      "Deployment": 3
    },
    "network_plugins": [
      "Unknown"
    ],
    "timestamp": "2026-02-03T07:21:12Z",
    "total_node_count": 3,
    "cluster_version": "1.35",
    "run_uuid": "eca85bdc-4ec7-45fb-b6b6-287e10e646cb",
    "job_status": false,
    "major_version": ".35",
    "build_url": "manual",
    "error_logs": [
      {
        "timestamp": "2026-02-03T07:21:12.446Z",
        "message": "I AM SAMPLE ERROR V4"
      },
      {
        "timestamp": "2026-02-03T07:21:12.446Z",
        "message": "I AM SAMPLE CRITICAL ERROR V4"
      }
    ]
  }
}
```


___

### **PR Type**
Enhancement


___

### **Description**
- Automatically collect ERROR and CRITICAL logs during chaos execution

- Store logs in structured format with ISO 8601 timestamps

- Include error logs in telemetry data sent to Elasticsearch

- Implement thread-safe error collection handler for concurrent logging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Python Logging Framework"] -->|"ERROR/CRITICAL records"| B["ErrorCollectionHandler"]
  B -->|"Captures and formats"| C["ErrorLog objects"]
  C -->|"Stored in memory"| D["error_logs list"]
  D -->|"Retrieved during run"| E["ChaosRunTelemetry"]
  E -->|"Pushed to Elasticsearch"| F["Elasticsearch Index"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ErrorLog.py</strong><dd><code>Create ErrorLog dataclass for structured error representation</code></dd></summary>
<hr>

krkn/utils/ErrorLog.py

<ul><li>New dataclass to represent individual error log entries<br> <li> Contains timestamp in ISO 8601 UTC format and error message<br> <li> Provides <code>to_dict()</code> method for JSON serialization</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1150/files#diff-06a0329056084a69d3f4424a81883c7a033da7d603b17d58a2cb295c7b539973">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ErrorCollectionHandler.py</strong><dd><code>Implement thread-safe error log collection handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/utils/ErrorCollectionHandler.py

<ul><li>Custom logging handler that captures ERROR and CRITICAL level logs<br> <li> Thread-safe collection using locks for concurrent operations<br> <li> Formats timestamps as ISO 8601 UTC strings<br> <li> Provides <code>get_error_logs()</code> method to retrieve collected logs as <br>dictionaries<br> <li> Implements <code>clear()</code> method for testing purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1150/files#diff-247a87683285becb94432dd0c9b21eebcf8fb487ae22fe7934b9a49eef814c41">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Export error collection utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn/utils/__init__.py

<ul><li>Export new <code>ErrorLog</code> class<br> <li> Export new <code>ErrorCollectionHandler</code> class</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1150/files#diff-3f1f63242e1ea61820d283f7b4547bc0e2d7f32075f06eac8bf4bfdcacec8c01">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run_kraken.py</strong><dd><code>Integrate error collection into chaos run telemetry pipeline</code></dd></summary>
<hr>

run_kraken.py

<ul><li>Import <code>ErrorCollectionHandler</code> from krkn.utils<br> <li> Initialize <code>ErrorCollectionHandler</code> with ERROR level logging<br> <li> Add handler to logging configuration handlers list<br> <li> Retrieve collected error logs after chaos run completes<br> <li> Attach error logs to <code>chaos_telemetry</code> object for Elasticsearch<br> <li> Simplify Elasticsearch telemetry push by removing intermediate <br><code>ElasticChaosRunTelemetry</code> wrapper</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1150/files#diff-2219b910ebc424a2f189a7be011d52196e2082631eb36cbecc66e853fbbfaea7">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

