### PR TITLE
Ibm version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,23 @@
 aliyun-python-sdk-core==2.13.36
 aliyun-python-sdk-ecs==4.24.25
 arcaflow-plugin-sdk==0.14.0
-boto3==1.28.61
+boto3>=1.34.0  # Updated to support urllib3 2.x
 azure-identity==1.16.1
 azure-keyvault==4.2.0
 azure-mgmt-compute==30.5.0
 azure-mgmt-network==27.0.0
 coverage==7.6.12
 datetime==5.4
-docker>=6.0,<7.0  # docker 7.0+ has breaking changes with Unix sockets
+docker>=6.0,<7.0  # docker 7.0+ has breaking changes; works with requests<2.32
 gitpython==3.1.41
 google-auth==2.37.0
 google-cloud-compute==1.22.0
-ibm_cloud_sdk_core==3.18.0
-ibm_vpc==0.20.0
+ibm_cloud_sdk_core>=3.20.0  # Requires urllib3>=2.1.0 (compatible with updated boto3)
+ibm_vpc==0.26.3  # Requires ibm_cloud_sdk_core
 jinja2==3.1.6
-krkn-lib==6.0.1
 lxml==5.1.0
 kubernetes==34.1.0
+krkn-lib==6.0.2
 numpy==1.26.4
 pandas==2.2.0
 openshift-client==1.0.21
@@ -29,6 +29,7 @@ python-ipmi==0.5.4
 python-openstackclient==6.5.0
 requests<2.32  # requests 2.32+ breaks Unix socket support (http+docker scheme)
 requests-unixsocket>=0.4.0  # Required for Docker Unix socket support
+urllib3>=2.1.0,<2.4.0  # Compatible with all dependencies
 service_identity==24.1.0
 PyYAML==6.0.1
 setuptools==78.1.1


### PR DESCRIPTION
### **User description**
# Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization

# Description  
Need to update ibm sdk core version with python3.11 updates. As the current version is not able to install 

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: https://github.com/krkn-chaos/krkn/issues/1154
- Closes #: 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

Tested with our opensearch requirements and working as expected 

```bash
 % python run_kraken.py --config config/es_config.yaml                        
 _              _              
| | ___ __ __ _| | _____ _ __  
| |/ / '__/ _` | |/ / _ \ '_ \ 
|   <| | | (_| |   <  __/ | | |
|_|\_\_|  \__,_|_|\_\___|_| |_|
                               

2026-02-09 12:22:28,160 [INFO] Starting kraken
2026-02-09 12:22:28,165 [INFO] Initializing client to talk to the Kubernetes cluster
2026-02-09 12:22:28,165 [INFO] Generated a uuid for the run: a425b489-8833-435b-80b9-4279aef910ee
2026-02-09 12:22:28,279 [INFO] Detected distribution openshift
2026-02-09 12:22:29,492 [INFO] Publishing kraken status at http://0.0.0.0:8081
2026-02-09 12:22:29,497 [INFO] Starting http server at http://0.0.0.0:8081

2026-02-09 12:22:29,497 [INFO] Fetching cluster info
2026-02-09 12:22:29,829 [INFO] 4.20.4
2026-02-09 12:22:29,830 [INFO] Elastic collection enabled at: ...
2026-02-09 12:22:30,003 [INFO] Server URL: https://api.prubenda1111.chaos.perfscale.devcluster.openshift.com:6443
2026-02-09 12:22:30,003 [INFO] Daemon mode not enabled, will run through 1 iterations

2026-02-09 12:22:31,099 [INFO] 📣 `ScenarioPluginFactory`: types from config.yaml mapped to respective classes for execution:
2026-02-09 12:22:31,099 [INFO]   ✅ type: application_outages_scenarios ➡️ `ApplicationOutageScenarioPlugin` 
2026-02-09 12:22:31,099 [INFO]   ✅ type: container_scenarios ➡️ `ContainerScenarioPlugin` 
2026-02-09 12:22:31,099 [INFO]   ✅ type: hog_scenarios ➡️ `HogsScenarioPlugin` 
2026-02-09 12:22:31,099 [INFO]   ✅ type: kubevirt_vm_outage ➡️ `KubevirtVmOutageScenarioPlugin` 
2026-02-09 12:22:31,099 [INFO]   ✅ type: managedcluster_scenarios ➡️ `ManagedClusterScenarioPlugin` 
2026-02-09 12:22:31,099 [INFO]   ✅ types: [pod_network_scenarios, ingress_node_scenarios] ➡️ `NativeScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: network_chaos_scenarios ➡️ `NetworkChaosScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: network_chaos_ng_scenarios ➡️ `NetworkChaosNgScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: node_scenarios ➡️ `NodeActionsScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: pod_disruption_scenarios ➡️ `PodDisruptionScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: pvc_scenarios ➡️ `PvcScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: service_disruption_scenarios ➡️ `ServiceDisruptionScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: service_hijacking_scenarios ➡️ `ServiceHijackingScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: cluster_shut_down_scenarios ➡️ `ShutDownScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: syn_flood_scenarios ➡️ `SynFloodScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: time_scenarios ➡️ `TimeActionsScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO]   ✅ type: zone_outages_scenarios ➡️ `ZoneOutageScenarioPlugin` 
2026-02-09 12:22:31,100 [INFO] 

2026-02-09 12:22:31,100 [INFO] health checks config is not defined, skipping them
2026-02-09 12:22:31,100 [INFO] kube virt checks config is not defined, skipping them
2026-02-09 12:22:31,100 [INFO] Executing scenarios for iteration 0
2026-02-09 12:22:31,101 [INFO] connection set up
127.0.0.1 - - [09/Feb/2026 12:22:31] "GET / HTTP/1.1" 200 -
2026-02-09 12:22:31,102 [INFO] response RUN
2026-02-09 12:22:31,103 [INFO] Signal handlers registered globally
2026-02-09 12:22:31,103 [INFO] Running PodDisruptionScenarioPlugin: ['pod_disruption_scenarios'] -> scenarios/openshift/etcd.yml
2026-02-09 12:22:31,373 [INFO] waiting up to 20 seconds for pod recovery, pod label pattern: k8s-app=etcd namespace pattern: ^openshift-etcd$
2026-02-09 12:22:31,598 [INFO] ('etcd-prubenda1111-ck5s7-master-0.c.chaos-438115.internal', 'openshift-etcd')
2026-02-09 12:22:31,598 [INFO] Deleting pod etcd-prubenda1111-ck5s7-master-0.c.chaos-438115.internal
2026-02-09 12:22:51,413 [INFO] Watch stream completed normally
2026-02-09 12:22:51,418 [WARNING] Skip cleanup for run_uuid=a425b489-8833-435b-80b9-4279aef910ee, scenario_type=pod_disruption_scenarios
2026-02-09 12:22:51,883 [INFO] Find cluster events in file /tmp/events.json
2026-02-09 12:22:51,883 [INFO] waiting 1 before running the next scenario
2026-02-09 12:22:52,888 [INFO] collecting OCP cluster metadata, this may take few minutes....
2026-02-09 12:23:06,751 [INFO] Chaos data:
{
    "telemetry": {
        "scenarios": [
            {
                "start_timestamp": 1770657751,
                "end_timestamp": 1770657771,
                "scenario": "scenarios/openshift/etcd.yml",
                "scenario_type": "pod_disruption_scenarios",
                "exit_status": 0,
                "parameters_base64": "",
                "parameters": [
                    {
                        "config": {
                            "exclude_label": "",
                            "krkn_pod_recovery_time": 20,
                            "label_selector": "k8s-app=etcd",
                            "namespace_pattern": "^openshift-etcd$"
                        },
                        "id": "kill-pods"
                    }
                ],
                "affected_pods": {
                    "recovered": [
                        {
                            "pod_name": "etcd-prubenda1111-ck5s7-master-0.c.chaos-438115.internal",
                            "namespace": "openshift-etcd",
                            "total_recovery_time": 2.1510441303253174,
                            "pod_readiness_time": 2.0687081813812256,
                            "pod_rescheduling_time": 0.0823359489440918
                        }
                    ],
                    "unrecovered": [],
                    "error": null
                },
                "affected_nodes": [],
                "cluster_events": []
            }
        ],
....
        "timestamp": "2026-02-09T17:22:30Z",
        "health_checks": null,
        "virt_checks": null,
        "total_node_count": 6,
        "cloud_infrastructure": "GCP",
        "cloud_type": "self-managed",
        "cluster_version": "4.20.4",
        "major_version": "4.20",
        "run_uuid": "a425b489-8833-435b-80b9-4279aef910ee",
        "post_virt_checks": null,
        "job_status": true,
        "build_url": "manual"
    },
    "critical_alerts": null
}
2026-02-09 12:23:06,928 [INFO] telemetry collection disabled, skipping.
2026-02-09 12:23:06,928 [INFO] Capturing metrics using file config/metrics-report.yaml
adding pod{'metricName': 'affected_pods_recovery', 'type': 'recovered', 'pod_name': 'etcd-prubenda1111-ck5s7-master-0.c.chaos-438115.internal', 'timestamp': '2026-02-09 12:23:09.514207', 'namespace': 'openshift-etcd', 'total_recovery_time': 2.1510441303253174, 'pod_readiness_time': 2.0687081813812256, 'pod_rescheduling_time': 0.0823359489440918}
2026-02-09 12:23:11,858 [INFO] Successfully finished running Kraken. UUID for the run: a425b489-8833-435b-80b9-4279aef910ee. Report generated at kraken.report. Exiting
```

OR


```bash
python -m coverage run -a -m unittest discover -s tests -v
...
<---insert test results output--->
```


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Update IBM Cloud SDK Core to version 3.20.0+ for Python 3.11 compatibility

- Upgrade boto3 to 1.34.0+ and add urllib3 2.1.0+ constraint for dependency alignment

- Update IBM VPC to 0.26.3 and add OpenSearch/Elasticsearch support

- Replace krkn-lib with git-based opensearch branch for enhanced functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IBM Cloud SDK Core<br/>3.18.0 → 3.20.0+"] --> D["urllib3 2.1.0+<br/>compatibility layer"]
  B["boto3<br/>1.28.61 → 1.34.0+"] --> D
  C["IBM VPC<br/>0.20.0 → 0.26.3"] --> A
  E["krkn-lib<br/>6.0.1 → git opensearch"] --> F["OpenSearch/Elasticsearch<br/>support added"]
  D --> G["Python 3.11<br/>compatibility achieved"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>IBM SDK and dependency version updates for Python 3.11</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

<ul><li>Updated IBM Cloud SDK Core from 3.18.0 to >=3.20.0 for Python 3.11 <br>support with urllib3 2.x compatibility<br> <li> Upgraded boto3 from 1.28.61 to >=1.34.0 with urllib3 2.x support<br> <li> Updated IBM VPC from 0.20.0 to 0.26.3 aligned with new SDK version<br> <li> Added explicit urllib3>=2.1.0,<2.4.0 constraint for dependency <br>consistency<br> <li> Replaced krkn-lib 6.0.1 with git-based opensearch branch for enhanced <br>functionality<br> <li> Added elasticsearch 7.17.13 and opensearch-py 2.0.0-2.8.0 for <br>OpenSearch compatibility<br> <li> Updated docker constraint comment and requests constraint to <2.32 for <br>Unix socket support</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn/pull/1155/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

