### PR TITLE
fix: use sorted() instead of sort() (#1182)

### DIFF
--- a/krkn/prometheus/client.py
+++ b/krkn/prometheus/client.py
@@ -46,7 +46,7 @@ def alerts(
             sys.exit(1)
 
         for alert in profile_yaml:
-            if list(alert.keys()).sort() != ["expr", "description", "severity"].sort():
+            if sorted(alert.keys()) != sorted(["expr", "description", "severity"]):
                 logging.error(f"wrong alert {alert}, skipping")
                 continue
 
@@ -205,7 +205,7 @@ def metrics(
                    query
                 )
             elif (
-                list(metric_query.keys()).sort()
+                sorted(metric_query.keys())
                 == ["query", "metricName"].sort()
             ):
                 metrics_result = prom_cli.process_prom_query_in_range(


### PR DESCRIPTION
## Summary

Fixed Python pitfall in `krkn/prometheus/client.py`:

- `.sort()` returns `None`, not the sorted list
- Changed to `sorted()` for actual key comparison

### Before
```python
if list(alert.keys()).sort() != [...].sort():
```

### After
```python
if sorted(alert.keys()) != sorted([...]):
```

Fixes #1182

**PrimeFix Tech**