### PR TITLE
Changing order to have redhat-chaos login when pushing

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,6 +28,7 @@ jobs:
         docker buildx build --no-cache \
           --platform linux/${{ matrix.platform }} \
           -t quay.io/krkn-chaos/krkn \
+          -t quay.io/redhat-chaos/krkn  \
           containers/ \
           --build-arg PR_NUMBER=${{ github.event.pull_request.number }}
 
@@ -39,15 +40,7 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
-    - name: Login to redhat-chaos quay
-      if: startsWith(github.ref, 'refs/tags')
-      uses: docker/login-action@v3
-      with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_USER_1 }}
-        password: ${{ secrets.QUAY_TOKEN_1 }}
-
-    - name: Build and push arch-specific images
+    - name: Build and push krkn-chaos images
       if: startsWith(github.ref, 'refs/tags')
       run: |
         ./containers/compile_dockerfile.sh
@@ -56,6 +49,24 @@ jobs:
           --platform linux/${{ matrix.platform }} \
           -t quay.io/krkn-chaos/krkn:latest-${{ matrix.platform }} \
           -t quay.io/krkn-chaos/krkn:${TAG}-${{ matrix.platform }} \
+          containers/ \
+          --build-arg TAG=${TAG} \
+          --push
+
+    - name: Login to redhat-chaos quay
+      if: startsWith(github.ref, 'refs/tags')
+      uses: docker/login-action@v3
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USER_1 }}
+        password: ${{ secrets.QUAY_TOKEN_1 }}
+
+    - name: Push redhat-chaos images
+      if: startsWith(github.ref, 'refs/tags')
+      run: |
+        TAG=${GITHUB_REF#refs/tags/}
+        docker buildx build --no-cache \
+          --platform linux/${{ matrix.platform }} \
           -t quay.io/redhat-chaos/krkn:latest-${{ matrix.platform }} \
           -t quay.io/redhat-chaos/krkn:${TAG}-${{ matrix.platform }} \
           containers/ \


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization

# Description  
Changing the login user details when redhat-chaos quay images to be pushed

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: 
- Closes #: 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python run_kraken.py
...
<---insert test results output--->
```

OR


```bash
python -m coverage run -a -m unittest discover -s tests -v
...
<---insert test results output--->
```
