### PR TITLE
fix: raise descriptive error on empty pod list in get_job_pods

### DIFF
--- a/krkn/scenario_plugins/network_chaos/network_chaos_scenario_plugin.py
+++ b/krkn/scenario_plugins/network_chaos/network_chaos_scenario_plugin.py
@@ -192,6 +192,12 @@ class NetworkChaosScenarioPlugin(AbstractScenarioPlugin):
         pods_list = kubecli.list_pods(
             label_selector=pod_label_selector, namespace="default"
         )
+        if not pods_list:
+            raise Exception(
+                f"No pods found matching label selector '{pod_label_selector}' "
+                f"in namespace 'default'. The job pod may not have started or "
+                f"the label selector may be incorrect."
+            )
         return pods_list[0]
 
     # krkn_lib
@@ -231,8 +237,8 @@ class NetworkChaosScenarioPlugin(AbstractScenarioPlugin):
                     )
                     pod_log = pod_log_response.data.decode("utf-8")
                     logging.error(pod_log)
-            except Exception:
-                logging.warning("Exception in getting job status")
+            except Exception as e:
+                logging.warning(f"Exception in getting job status: {e}")
             kubecli.delete_job(name=jobname, namespace="default")
 
     def get_egress_cmd(self, execution, test_interface, mod, vallst, duration=30):

--- a/tests/test_network_chaos_scenario_plugin.py
+++ b/tests/test_network_chaos_scenario_plugin.py
@@ -35,6 +35,39 @@ class TestNetworkChaosScenarioPlugin(unittest.TestCase):
         self.assertEqual(result, ["network_chaos_scenarios"])
         self.assertEqual(len(result), 1)
 
+    def test_get_job_pods_empty_list_raises_exception(self):
+        """
+        Test get_job_pods raises descriptive error when no pods match the label selector
+        """
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_kubecli.list_pods.return_value = []
+
+        mock_api_response = MagicMock()
+        mock_api_response.metadata.labels = {"controller-uid": "test-uid-123"}
+
+        with self.assertRaises(Exception) as context:
+            self.plugin.get_job_pods(mock_api_response, mock_kubecli)
+
+        self.assertIn("No pods found matching label selector", str(context.exception))
+        self.assertIn("controller-uid=test-uid-123", str(context.exception))
+
+    def test_get_job_pods_returns_first_pod(self):
+        """
+        Test get_job_pods returns the first pod when pods are found
+        """
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_kubecli.list_pods.return_value = ["pod-1", "pod-2"]
+
+        mock_api_response = MagicMock()
+        mock_api_response.metadata.labels = {"controller-uid": "test-uid-456"}
+
+        result = self.plugin.get_job_pods(mock_api_response, mock_kubecli)
+
+        self.assertEqual(result, "pod-1")
+        mock_kubecli.list_pods.assert_called_once_with(
+            label_selector="controller-uid=test-uid-456", namespace="default"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  
`get_job_pods` in `network_chaos_scenario_plugin.py` accessed `pods_list[0]` without checking if the list was empty. When no pods match the label selector (wrong namespace, pod not started, label mismatch), this raised a bare `IndexError` with no context. Now raises a descriptive `Exception` including the label selector and namespace. Added unit tests for both the empty and non-empty cases.

# Documentation  
- [ ] **Is documentation needed for this update?**

# Checklist before requesting a review
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

```bash
python -m unittest tests.test_network_chaos_scenario_plugin -v
...
test_get_job_pods_empty_list_raises_exception ... ok
test_get_job_pods_returns_first_pod ... ok
test_get_scenario_types ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.003s

OK
```