### PR TITLE
fix: prevent PromQL injection in chaos_recommender prometheus queries

### DIFF
--- a/krkn/chaos_recommender/prometheus.py
+++ b/krkn/chaos_recommender/prometheus.py
@@ -17,6 +17,11 @@ from prometheus_api_client import PrometheusConnect
 import pandas as pd
 import urllib3
 
+from krkn.chaos_recommender.validators import (
+    validate_namespace,
+    validate_pod_name,
+    validate_scrape_duration,
+)
 
 saved_metrics_path = "./utilisation.txt"
 
@@ -54,6 +59,7 @@ def convert_data_limits(data, node_data, service, prometheus):
 def get_node_capacity(node_data, pod_name, prometheus):
 
     # Get the node name on which the pod is running
+    validate_pod_name(pod_name)
     query = f'kube_pod_info{{pod="{pod_name}"}}'
     result = prometheus.custom_query(query)
     if not result:
@@ -130,6 +136,11 @@ def fetch_utilization_from_prometheus(
     prometheus_endpoint, auth_token, namespaces, scrape_duration
 ):
     urllib3.disable_warnings()
+
+    validate_scrape_duration(scrape_duration)
+    for ns in namespaces:
+        validate_namespace(ns)
+
     prometheus = PrometheusConnect(
         url=prometheus_endpoint,
         headers={"Authorization": "Bearer {}".format(auth_token)},

--- a/krkn/chaos_recommender/validators.py
+++ b/krkn/chaos_recommender/validators.py
@@ -1,0 +1,45 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+# Kubernetes namespace: lowercase alphanumeric and hyphens, 1-63 chars
+_NAMESPACE_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?$")
+# Kubernetes pod name: lowercase alphanumeric, hyphens, and dots, 1-253 chars
+_POD_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9\-\.]{0,251}[a-z0-9])?$")
+# Prometheus duration: digits followed by a time unit
+_PROM_DURATION_RE = re.compile(r"^\d+[smhdwy]$")
+
+
+def validate_namespace(namespace):
+    if not _NAMESPACE_RE.match(namespace):
+        raise ValueError(
+            f"Invalid namespace name: {namespace!r}. "
+            "Must match Kubernetes naming rules (lowercase alphanumeric and hyphens, 1-63 chars)."
+        )
+
+
+def validate_scrape_duration(duration):
+    if not _PROM_DURATION_RE.match(duration):
+        raise ValueError(
+            f"Invalid scrape duration: {duration!r}. "
+            "Must be a Prometheus duration (e.g. '5m', '1h', '30s')."
+        )
+
+
+def validate_pod_name(pod_name):
+    if not _POD_NAME_RE.match(pod_name):
+        raise ValueError(
+            f"Invalid pod name: {pod_name!r}. "
+            "Must match Kubernetes naming rules (lowercase alphanumeric, hyphens, and dots, 1-253 chars)."
+        )

--- a/tests/test_chaos_recommender_prometheus.py
+++ b/tests/test_chaos_recommender_prometheus.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for PromQL injection prevention in chaos_recommender/prometheus.py
+
+Validates that namespace, scrape_duration, and pod_name inputs are
+sanitized before interpolation into PromQL query strings.
+
+Usage:
+    python -m unittest tests.test_chaos_recommender_prometheus -v
+"""
+
+import importlib.util
+import os
+import unittest
+
+# Import validators directly to avoid triggering the chaos_recommender
+# __init__.py which pulls in pandas/prometheus_api_client.
+_validators_path = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "krkn",
+        "chaos_recommender",
+        "validators.py",
+    )
+)
+_spec = importlib.util.spec_from_file_location("validators", _validators_path)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Cannot load validators module from {_validators_path}")
+_validators = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_validators)
+
+validate_namespace = _validators.validate_namespace
+validate_pod_name = _validators.validate_pod_name
+validate_scrape_duration = _validators.validate_scrape_duration
+
+
+class TestValidateNamespace(unittest.TestCase):
+    """Tests for PromQL injection prevention via namespace validation."""
+
+    def test_valid_namespaces(self):
+        valid = ["default", "kube-system", "my-namespace", "ns1", "a"]
+        for ns in valid:
+            validate_namespace(ns)  # should not raise
+
+    def test_injection_closing_brace(self):
+        with self.assertRaises(ValueError):
+            validate_namespace('default"}[1m]) + sum(something_else{x="')
+
+    def test_injection_special_chars(self):
+        with self.assertRaises(ValueError):
+            validate_namespace('ns"; drop table')
+
+    def test_empty_string(self):
+        with self.assertRaises(ValueError):
+            validate_namespace("")
+
+    def test_uppercase_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_namespace("Default")
+
+    def test_underscores_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_namespace("my_namespace")
+
+    def test_dots_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_namespace("my.namespace")
+
+    def test_too_long_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_namespace("a" * 64)
+
+    def test_max_length_accepted(self):
+        validate_namespace("a" * 63)  # should not raise
+
+    def test_starts_with_hyphen_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_namespace("-invalid")
+
+    def test_ends_with_hyphen_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_namespace("invalid-")
+
+
+class TestValidateScrapeDuration(unittest.TestCase):
+    """Tests for PromQL injection prevention via scrape_duration validation."""
+
+    def test_valid_durations(self):
+        valid = ["5m", "1h", "30s", "7d", "2w", "1y"]
+        for d in valid:
+            validate_scrape_duration(d)  # should not raise
+
+    def test_injection_attempt(self):
+        with self.assertRaises(ValueError):
+            validate_scrape_duration('1m]) + sum(evil_metric{x="')
+
+    def test_empty_string(self):
+        with self.assertRaises(ValueError):
+            validate_scrape_duration("")
+
+    def test_missing_unit(self):
+        with self.assertRaises(ValueError):
+            validate_scrape_duration("100")
+
+    def test_missing_number(self):
+        with self.assertRaises(ValueError):
+            validate_scrape_duration("m")
+
+    def test_invalid_unit(self):
+        with self.assertRaises(ValueError):
+            validate_scrape_duration("5x")
+
+    def test_float_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_scrape_duration("5.5m")
+
+
+class TestValidatePodName(unittest.TestCase):
+    """Tests for PromQL injection prevention via pod name validation."""
+
+    def test_valid_pod_names(self):
+        valid = [
+            "nginx-deployment-5d8b6bf8b-abcde",
+            "my-pod",
+            "pod1",
+            "a",
+            "my-app.instance-0",
+        ]
+        for name in valid:
+            validate_pod_name(name)  # should not raise
+
+    def test_injection_attempt(self):
+        with self.assertRaises(ValueError):
+            validate_pod_name('pod-name"})} + vector(1){__name__="')
+
+    def test_empty_string(self):
+        with self.assertRaises(ValueError):
+            validate_pod_name("")
+
+    def test_uppercase_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_pod_name("MyPod")
+
+    def test_starts_with_hyphen_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_pod_name("-invalid-pod")
+
+    def test_ends_with_hyphen_rejected(self):
+        with self.assertRaises(ValueError):
+            validate_pod_name("invalid-pod-")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  
Namespace, `scrape_duration`, and pod name values are interpolated directly into PromQL query strings via `%s` in `chaos_recommender/prometheus.py`. A malicious or malformed value like `default"}[1m]) + sum(something_else{x="` could break query syntax or probe data from other namespaces.

This PR adds input validation using regex allowlisting based on Kubernetes and Prometheus naming rules:
- `_validate_namespace()` — enforces K8s namespace format
- `_validate_scrape_duration()` — enforces Prometheus duration format (e.g. `5m`, `1h`)
- `_validate_pod_name()` — enforces K8s pod name format

Invalid inputs are rejected with a `ValueError` before reaching any PromQL query.

# Documentation  
- [ ] **Is documentation needed for this update?**

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:

```bash
python -m unittest tests.test_chaos_recommender_prometheus -v

test_dots_rejected (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_dots_rejected) ... ok
test_empty_string (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_empty_string) ... ok
test_ends_with_hyphen_rejected (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_ends_with_hyphen_rejected) ... ok
test_injection_closing_brace (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_injection_closing_brace) ... ok
test_injection_special_chars (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_injection_special_chars) ... ok
test_max_length_accepted (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_max_length_accepted) ... ok
test_starts_with_hyphen_rejected (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_starts_with_hyphen_rejected) ... ok
test_too_long_rejected (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_too_long_rejected) ... ok
test_underscores_rejected (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_underscores_rejected) ... ok
test_uppercase_rejected (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_uppercase_rejected) ... ok
test_valid_namespaces (tests.test_chaos_recommender_prometheus.TestValidateNamespace.test_valid_namespaces) ... ok
test_empty_string (tests.test_chaos_recommender_prometheus.TestValidatePodName.test_empty_string) ... ok
test_ends_with_hyphen_rejected (tests.test_chaos_recommender_prometheus.TestValidatePodName.test_ends_with_hyphen_rejected) ... ok
test_injection_attempt (tests.test_chaos_recommender_prometheus.TestValidatePodName.test_injection_attempt) ... ok
test_starts_with_hyphen_rejected (tests.test_chaos_recommender_prometheus.TestValidatePodName.test_starts_with_hyphen_rejected) ... ok
test_uppercase_rejected (tests.test_chaos_recommender_prometheus.TestValidatePodName.test_uppercase_rejected) ... ok
test_valid_pod_names (tests.test_chaos_recommender_prometheus.TestValidatePodName.test_valid_pod_names) ... ok
test_empty_string (tests.test_chaos_recommender_prometheus.TestValidateScrapeDuration.test_empty_string) ... ok
test_float_rejected (tests.test_chaos_recommender_prometheus.TestValidateScrapeDuration.test_float_rejected) ... ok
test_injection_attempt (tests.test_chaos_recommender_prometheus.TestValidateScrapeDuration.test_injection_attempt) ... ok
test_invalid_unit (tests.test_chaos_recommender_prometheus.TestValidateScrapeDuration.test_invalid_unit) ... ok
test_missing_number (tests.test_chaos_recommender_prometheus.TestValidateScrapeDuration.test_missing_number) ... ok
test_missing_unit (tests.test_chaos_recommender_prometheus.TestValidateScrapeDuration.test_missing_unit) ... ok
test_valid_durations (tests.test_chaos_recommender_prometheus.TestValidateScrapeDuration.test_valid_durations) ... ok

----------------------------------------------------------------------
Ran 24 tests in 0.000s

OK
```