### PR TITLE
fix: resolve Python version mismatch in container entrypoint

### DIFF
--- a/containers/Dockerfile.template
+++ b/containers/Dockerfile.template
@@ -33,6 +33,8 @@ RUN go mod edit -go 1.24.9 &&\
 FROM fedora:40
 ARG PR_NUMBER
 ARG TAG
+ARG PYTHON_VERSION=3.11
+ENV PYTHON_CMD=python${PYTHON_VERSION}
 RUN groupadd -g 1001 krkn && useradd -m -u 1001 -g krkn krkn
 RUN dnf update -y
 
@@ -41,7 +43,7 @@ ENV KUBECONFIG /home/krkn/.kube/config
 
 # This overwrites any existing configuration in /etc/yum.repos.d/kubernetes.repo
 RUN dnf update && dnf install -y --setopt=install_weak_deps=False \
-    git python3.11 jq yq gettext wget which ipmitool openssh-server &&\
+    git python${PYTHON_VERSION} jq yq gettext wget which ipmitool openssh-server &&\
     dnf clean all
 
 # copy oc client binary from oc-build image
@@ -63,15 +65,15 @@ RUN if [ -n "$PR_NUMBER" ]; then git fetch origin pull/${PR_NUMBER}/head:pr-${PR
 # if it is a TAG trigger checkout the tag
 RUN if [ -n "$TAG" ]; then git checkout "$TAG";fi
 
-RUN python3.11 -m ensurepip --upgrade --default-pip
-RUN python3.11 -m pip install --upgrade pip setuptools==78.1.1
+RUN ${PYTHON_CMD} -m ensurepip --upgrade --default-pip
+RUN ${PYTHON_CMD} -m pip install --upgrade pip setuptools==78.1.1
 
 # removes the the vulnerable versions of setuptools and pip
 RUN rm -rf "$(pip cache dir)"
 RUN rm -rf /tmp/*
-RUN rm -rf /usr/local/lib/python3.11/ensurepip/_bundled
-RUN pip3.11 install -r requirements.txt
-RUN pip3.11 install jsonschema
+RUN rm -rf /usr/local/lib/${PYTHON_CMD}/ensurepip/_bundled
+RUN ${PYTHON_CMD} -m pip install -r requirements.txt
+RUN ${PYTHON_CMD} -m pip install jsonschema
 
 LABEL krknctl.title.global="Krkn Base Image"
 LABEL krknctl.description.global="This is the krkn base image."

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -5,4 +5,4 @@ set -e
 # Change to kraken directory
 
 # Execute the main command
-exec python3.9 run_kraken.py "$@"
+exec "${PYTHON_CMD:-python3}" run_kraken.py "$@"


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

`entrypoint.sh` invoked `python3.9` but the Dockerfile installs `python3.11`, causing the container to crash immediately on startup with `exec: python3.9: not found`.

**Fix:** Introduced `PYTHON_VERSION` build ARG and `PYTHON_CMD` ENV as a single source of truth. All hardcoded Python version references in the Dockerfile now use these variables, and `entrypoint.sh` reads `PYTHON_CMD` at runtime (with `python3` fallback). Python version can be changed in one place or overridden at build time via `--build-arg PYTHON_VERSION=3.12`.

# Documentation
- [ ] **Is documentation needed for this update?**

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
- [x] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

### Before fix
<img width="1470" height="956" alt="Screenshot 2026-04-01 at 5 18 06 PM" src="https://github.com/user-attachments/assets/cda8a567-eb2d-43d4-893b-eaec8e4a62fb" />

Container exits immediately on startup:
```bash
docker run --rm krkn:before 2>&1 | head -20
...
/home/krkn/kraken/containers/entrypoint.sh: line 8: exec: python3.9: not found
```

### After fix
<img width="1470" height="956" alt="Screenshot 2026-04-02 at 2 49 39 AM" src="https://github.com/user-attachments/assets/b44c9f6b-0420-496d-a30c-81e500d5b3ca" />

Container starts successfully:
```bash
docker run --rm \
  -v $(pwd)/containers/entrypoint.sh:/home/krkn/kraken/containers/entrypoint.sh:Z \
  krkn:after 2>&1 | head -20
...
2026-04-01 21:19:26,852 [INFO] Starting kraken
2026-04-01 21:19:26,859 [ERROR] Cannot read the kubeconfig file at /home/krkn/.kube/config, please check
```

Note: The kubeconfig error is expected, no cluster is mounted during local testing. The key result is that python3.9: not found is resolved and krkn starts.


