### PR TITLE
fix(needs-rebase): retry mergeable check on push to catch stale conflicting PRs

### DIFF
--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -168,7 +168,7 @@ jobs:
               for (let i = 0; i < prs.length; i += CONCURRENCY) {
                 const batch = prs.slice(i, i + CONCURRENCY);
                 await Promise.all(batch.map(pr =>
-                  handlePR(pr.number, pr.user.login, 1).catch(e =>
+                  handlePR(pr.number, pr.user.login, 3).catch(e =>
                     core.warning(`PR #${pr.number}: unexpected error — ${e.message}`)
                   )
                 ));


### PR DESCRIPTION
## Summary

- Changes `maxAttempts` from `1` to `3` in the push-to-main handler of `needs-rebase.yml`
- With `maxAttempts=1`, every PR returns `mergeable: null` immediately after a push (GitHub computes this asynchronously) and all PRs are skipped
- PRs that are never subsequently updated (no new commits, no re-opens) never get a `pull_request_target` event to recheck them — they miss the needs-rebase comment entirely
- `maxAttempts=3` adds a 5s + 10s retry window (~15s total) per batch of 5 PRs, giving GitHub enough time to compute mergeability for most PRs

## Root Cause

PR #1209 (`fix(license): add missing Apache 2.0 license headers`) had `"mergeable": "CONFLICTING"` but never received the needs-rebase bot comment. The push event run skipped all 46 open PRs because `mergeable` was `null` for all of them right after the triggering merge. Since PR #1209 was not updated after that, no `pull_request_target` event fired to recheck it.

## Test plan

- [ ] Merge a PR into main that conflicts with another open PR
- [ ] Verify the conflicting PR receives the `needs-rebase` label and bot comment within the workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)