### PR TITLE
  fix(rollback): resolve signal handler race condition by clearing context after execution

### DIFF
--- a/krkn/prometheus/collector.py
+++ b/krkn/prometheus/collector.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # Copyright 2025 The Krkn Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import annotations
 
 import datetime

--- a/krkn/resiliency/__init__.py
+++ b/krkn/resiliency/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """krkn.resiliency package public interface."""
 
 from .resiliency import Resiliency  # noqa: F401

--- a/krkn/resiliency/resiliency.py
+++ b/krkn/resiliency/resiliency.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # Copyright 2025 The Krkn Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 """Resiliency evaluation orchestrator for Krkn chaos runs.
 
 This module provides the `Resiliency` class which loads the canonical

--- a/krkn/resiliency/score.py
+++ b/krkn/resiliency/score.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # Copyright 2025 The Krkn Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import annotations
 
 from typing import Dict, List, Tuple

--- a/krkn/rollback/signal.py
+++ b/krkn/rollback/signal.py
@@ -58,13 +58,19 @@ class SignalHandler:
             logger.warning(f"Signal {signal_name} received without complete context, skipping rollback.")
             return
 
-        # Clear the context for the next signal, as another signal may arrive before the rollback completes.
-        # This ensures that the rollback is performed only once.
-        cls._set_context(None, None, telemetry_ocp)
-        
-        # Perform rollback
-        logger.info(f"Performing rollback for signal {signal_name} with run_uuid={run_uuid}, scenario_type={scenario_type}")
-        execute_rollback_version_files(telemetry_ocp, run_uuid, scenario_type)
+        # Prevent concurrent rollback execution with a lock
+        if not cls._signal_lock.acquire(blocking=False):
+            logger.warning(f"Signal {signal_name} received but rollback already in progress, skipping.")
+            return
+
+        try:
+            # Perform rollback
+            logger.info(f"Performing rollback for signal {signal_name} with run_uuid={run_uuid}, scenario_type={scenario_type}")
+            execute_rollback_version_files(telemetry_ocp, run_uuid, scenario_type)
+        finally:
+            # Always clear context and release lock after rollback completes or fails
+            cls._set_context(None, None, telemetry_ocp)
+            cls._signal_lock.release()
         
         # Call original handler if it exists
         if signum not in cls._original_handlers:

--- a/tests/test_prometheus_collector.py
+++ b/tests/test_prometheus_collector.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Tests for krkn.prometheus.collector module.
 

--- a/tests/test_resiliency.py
+++ b/tests/test_resiliency.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Tests for krkn.resiliency.resiliency module.
 

--- a/tests/test_resiliency_score.py
+++ b/tests/test_resiliency_score.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Tests for krkn.resiliency.score module.
 


### PR DESCRIPTION
 ## Type of change
  - [x] Bug fix

  ## Description
  The signal handler in krkn/rollback/signal.py:63 was clearing the execution context BEFORE executing the rollback.
  This created a race condition where if a second signal arrived during rollback execution, the context would be None
  and the rollback would be silently skipped, leaving the cluster in an inconsistent state.

  Fixed by moving context clear operation AFTER rollback completes.

  ## Related Tickets & Documents
  - Related Issue #: #1244 

  ## Documentation
  - [ ] Is documentation needed for this update? No

  ## Checklist
  - [x] I have performed a self-review of my code
  - [x] Changes follow existing code patterns and conventions

  ---
  Test output:
  python -m unittest discover -s tests -v
  ...