### PR TITLE
feat: add VMware node scenario test coverage and vSphere proxy support

### DIFF
--- a/krkn/scenario_plugins/node_actions/vmware_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/vmware_node_scenarios.py
@@ -67,11 +67,14 @@ class vSphere:
         """
         Returns an unverified session object
         """
-        
+
         session = requests.session()
-        # Set the proxy settings for the session
         session.verify = False
-            
+
+        http_proxy = environ.get("VSPHERE_HTTP_PROXY") or environ.get("https_proxy") or environ.get("HTTPS_PROXY")
+        if http_proxy:
+            session.proxies = {"http": http_proxy, "https": http_proxy}
+
         urllib3.disable_warnings()
 
         return session

--- a/tests/test_vmware_node_scenarios.py
+++ b/tests/test_vmware_node_scenarios.py
@@ -824,3 +824,720 @@ class TestVSphereClass(unittest.TestCase):
 
         self.assertFalse(session.verify)
         mock_session_class.assert_called()
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_release_instances_powered_on(self, mock_session, mock_create_client):
+        """Test releasing a VM that is currently powered on."""
+        mock_client = MagicMock()
+        mock_vm_obj = MagicMock()
+        mock_vm_obj.vm = 'vm-123'
+        mock_client.vcenter.VM.list.return_value = [mock_vm_obj]
+        mock_client.vcenter.vm.Power.get.return_value = Power.Info(state=Power.State.POWERED_ON)
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        vsphere.release_instances('test-vm')
+
+        mock_client.vcenter.vm.Power.stop.assert_called_with('vm-123')
+        mock_client.vcenter.VM.delete.assert_called_with('vm-123')
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_release_instances_suspended(self, mock_session, mock_create_client):
+        """Test releasing a VM that is in suspended state."""
+        mock_client = MagicMock()
+        mock_vm_obj = MagicMock()
+        mock_vm_obj.vm = 'vm-123'
+        mock_client.vcenter.VM.list.return_value = [mock_vm_obj]
+        mock_client.vcenter.vm.Power.get.return_value = Power.Info(state=Power.State.SUSPENDED)
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        vsphere.release_instances('test-vm')
+
+        mock_client.vcenter.vm.Power.start.assert_called_with('vm-123')
+        mock_client.vcenter.vm.Power.stop.assert_called_with('vm-123')
+        mock_client.vcenter.VM.delete.assert_called_with('vm-123')
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_release_instances_powered_off(self, mock_session, mock_create_client):
+        """Test releasing a VM that is already powered off."""
+        mock_client = MagicMock()
+        mock_vm_obj = MagicMock()
+        mock_vm_obj.vm = 'vm-123'
+        mock_client.vcenter.VM.list.return_value = [mock_vm_obj]
+        mock_client.vcenter.vm.Power.get.return_value = Power.Info(state=Power.State.POWERED_OFF)
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        vsphere.release_instances('test-vm')
+
+        mock_client.vcenter.vm.Power.stop.assert_not_called()
+        mock_client.vcenter.vm.Power.start.assert_not_called()
+        mock_client.vcenter.VM.delete.assert_called_with('vm-123')
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_list_instances_success(self, mock_session, mock_create_client):
+        """Test listing VMs in a datacenter."""
+        mock_client = MagicMock()
+        mock_dc = MagicMock()
+        mock_dc.datacenter = 'dc-1'
+        mock_client.vcenter.Datacenter.list.return_value = [mock_dc]
+
+        mock_vm1 = MagicMock()
+        mock_vm1.name = 'vm-one'
+        mock_vm1.vm = 'vm-001'
+        mock_vm2 = MagicMock()
+        mock_vm2.name = 'vm-two'
+        mock_vm2.vm = 'vm-002'
+        mock_client.vcenter.VM.list.return_value = [mock_vm1, mock_vm2]
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        result = vsphere.list_instances('TestDC')
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['vm_name'], 'vm-one')
+        self.assertEqual(result[0]['vm_id'], 'vm-001')
+        self.assertEqual(result[1]['vm_name'], 'vm-two')
+        self.assertEqual(result[1]['vm_id'], 'vm-002')
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_list_instances_datacenter_not_found(self, mock_session, mock_create_client):
+        """Test listing VMs when datacenter does not exist."""
+        mock_client = MagicMock()
+        mock_client.vcenter.Datacenter.list.return_value = []
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+
+        with self.assertRaises(SystemExit):
+            vsphere.list_instances('NonExistentDC')
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_get_datastore_list(self, mock_session, mock_create_client):
+        """Test getting list of datastores for a datacenter."""
+        mock_client = MagicMock()
+        mock_ds1 = MagicMock()
+        mock_ds1.name = 'datastore1'
+        mock_ds1.datastore = 'ds-1'
+        mock_ds2 = MagicMock()
+        mock_ds2.name = 'datastore2'
+        mock_ds2.datastore = 'ds-2'
+        mock_client.vcenter.Datastore.list.return_value = [mock_ds1, mock_ds2]
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        result = vsphere.get_datastore_list('dc-1')
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['datastore_name'], 'datastore1')
+        self.assertEqual(result[0]['datastore_id'], 'ds-1')
+        self.assertEqual(result[1]['datastore_name'], 'datastore2')
+        self.assertEqual(result[1]['datastore_id'], 'ds-2')
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_get_folder_list(self, mock_session, mock_create_client):
+        """Test getting list of folders for a datacenter."""
+        mock_client = MagicMock()
+        mock_folder1 = MagicMock()
+        mock_folder1.name = 'folder1'
+        mock_folder1.folder = 'folder-1'
+        mock_folder2 = MagicMock()
+        mock_folder2.name = 'folder2'
+        mock_folder2.folder = 'folder-2'
+        mock_client.vcenter.Folder.list.return_value = [mock_folder1, mock_folder2]
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        result = vsphere.get_folder_list('dc-1')
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['folder_name'], 'folder1')
+        self.assertEqual(result[0]['folder_id'], 'folder-1')
+        self.assertEqual(result[1]['folder_name'], 'folder2')
+        self.assertEqual(result[1]['folder_id'], 'folder-2')
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_get_resource_pool_success(self, mock_session, mock_create_client):
+        """Test getting resource pool for a datacenter."""
+        mock_client = MagicMock()
+        mock_rp = MagicMock()
+        mock_rp.resource_pool = 'rp-1'
+        mock_client.vcenter.ResourcePool.list.return_value = [mock_rp]
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        result = vsphere.get_resource_pool('dc-1', 'TestPool')
+
+        self.assertEqual(result, 'rp-1')
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_get_resource_pool_not_found(self, mock_session, mock_create_client):
+        """Test getting resource pool when none exists."""
+        mock_client = MagicMock()
+        mock_client.vcenter.ResourcePool.list.return_value = []
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        result = vsphere.get_resource_pool('dc-1')
+
+        self.assertIsNone(result)
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_get_resource_pool_without_name(self, mock_session, mock_create_client):
+        """Test getting first resource pool when no name specified."""
+        mock_client = MagicMock()
+        mock_rp = MagicMock()
+        mock_rp.resource_pool = 'rp-default'
+        mock_client.vcenter.ResourcePool.list.return_value = [mock_rp]
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        result = vsphere.get_resource_pool('dc-1')
+
+        self.assertEqual(result, 'rp-default')
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.time.time_ns')
+    def test_create_default_vm_success(self, mock_time_ns, mock_session, mock_create_client):
+        """Test creating a default VM successfully."""
+        mock_time_ns.return_value = 1234567890
+
+        mock_client = MagicMock()
+        mock_dc = MagicMock()
+        mock_dc.datacenter = 'dc-1'
+        mock_dc.name = 'Datacenter1'
+        mock_client.vcenter.Datacenter.list.return_value = [{'datacenter_id': 'dc-1', 'datacenter_name': 'Datacenter1'}]
+
+        mock_rp = MagicMock()
+        mock_rp.resource_pool = 'rp-1'
+        mock_client.vcenter.ResourcePool.list.return_value = [mock_rp]
+        mock_client.vcenter.Folder.list.return_value = [MagicMock(name='folder1', folder='folder-1')]
+        mock_client.vcenter.Datastore.list.return_value = [MagicMock(name='ds1', datastore='ds-1')]
+        mock_client.vcenter.VM.create.return_value = 'vm-new-123'
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+
+        with patch.object(vsphere, 'get_datacenter_list', return_value=[{'datacenter_id': 'dc-1', 'datacenter_name': 'DC1'}]), \
+             patch.object(vsphere, 'get_resource_pool', return_value='rp-1'), \
+             patch.object(vsphere, 'get_folder_list', return_value=[{'folder_name': 'f1', 'folder_id': 'folder-1'}]), \
+             patch.object(vsphere, 'get_datastore_list', return_value=[{'datastore_name': 'ds1', 'datastore_id': 'ds-1'}]):
+            vm_id, vm_name = vsphere.create_default_vm()
+
+        self.assertEqual(vm_id, 'vm-new-123')
+        self.assertTrue(vm_name.startswith('Test-'))
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    def test_create_default_vm_all_attempts_fail(self, mock_session, mock_create_client):
+        """Test creating a default VM when all attempts fail."""
+        mock_client = MagicMock()
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+
+        with patch.object(vsphere, 'get_datacenter_list', side_effect=Exception("API error")):
+            vm_id, vm_name = vsphere.create_default_vm(max_attempts=2)
+
+        self.assertIsNone(vm_id)
+        self.assertIsNone(vm_name)
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.time.sleep')
+    def test_wait_until_stopped_timeout(self, mock_sleep, mock_session, mock_create_client):
+        """Test wait_until_stopped times out."""
+        mock_client = MagicMock()
+        mock_vm_obj = MagicMock()
+        mock_vm_obj.vm = 'vm-123'
+        mock_client.vcenter.VM.list.return_value = [mock_vm_obj]
+
+        call_count = [0]
+        def get_status_side_effect(vm):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return MagicMock(state=Power.State.POWERED_ON)
+            return MagicMock(state=Power.State.POWERED_OFF)
+
+        mock_client.vcenter.vm.Power.get.side_effect = get_status_side_effect
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        mock_affected_node = MagicMock()
+        result = vsphere.wait_until_stopped('test-vm', timeout=2, affected_node=mock_affected_node)
+
+        self.assertFalse(result)
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.time.sleep')
+    def test_wait_until_released_timeout(self, mock_sleep, mock_session, mock_create_client):
+        """Test wait_until_released times out."""
+        mock_client = MagicMock()
+        mock_vm_obj = MagicMock()
+        mock_vm_obj.vm = 'vm-123'
+        # VM exists for initial + first loop iteration (triggers timeout),
+        # then returns None to exit the loop (source code lacks break on timeout)
+        mock_client.vcenter.VM.list.side_effect = [
+            [mock_vm_obj],
+            [mock_vm_obj],
+            [],
+        ]
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        mock_affected_node = MagicMock()
+        result = vsphere.wait_until_released('test-vm', timeout=2, affected_node=mock_affected_node)
+
+        self.assertFalse(result)
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.time.sleep')
+    def test_wait_until_running_without_affected_node(self, mock_sleep, mock_session, mock_create_client):
+        """Test wait_until_running without affected node tracking."""
+        mock_client = MagicMock()
+        mock_vm_obj = MagicMock()
+        mock_vm_obj.vm = 'vm-123'
+        mock_client.vcenter.VM.list.return_value = [mock_vm_obj]
+
+        mock_power_state = MagicMock(state=Power.State.POWERED_ON)
+        mock_client.vcenter.vm.Power.get.return_value = mock_power_state
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        result = vsphere.wait_until_running('test-vm', timeout=60, affected_node=None)
+
+        self.assertTrue(result)
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.time.sleep')
+    def test_wait_until_stopped_without_affected_node(self, mock_sleep, mock_session, mock_create_client):
+        """Test wait_until_stopped without affected node tracking."""
+        mock_client = MagicMock()
+        mock_vm_obj = MagicMock()
+        mock_vm_obj.vm = 'vm-123'
+        mock_client.vcenter.VM.list.return_value = [mock_vm_obj]
+
+        mock_power_state = MagicMock(state=Power.State.POWERED_OFF)
+        mock_client.vcenter.vm.Power.get.return_value = mock_power_state
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        result = vsphere.wait_until_stopped('test-vm', timeout=60, affected_node=None)
+
+        self.assertTrue(result)
+
+    @patch.dict('os.environ', {
+        'VSPHERE_IP': '192.168.1.100',
+        'VSPHERE_USERNAME': 'admin',
+        'VSPHERE_PASSWORD': 'password123'
+    })
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.create_vsphere_client')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.requests.session')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.time.sleep')
+    def test_wait_until_released_without_affected_node(self, mock_sleep, mock_session, mock_create_client):
+        """Test wait_until_released without affected node tracking."""
+        mock_client = MagicMock()
+        mock_vm_obj = MagicMock()
+        mock_vm_obj.vm = 'vm-123'
+        mock_client.vcenter.VM.list.side_effect = [
+            [mock_vm_obj],
+            []
+        ]
+        mock_create_client.return_value = mock_client
+
+        vsphere = vSphere()
+        result = vsphere.wait_until_released('test-vm', timeout=60, affected_node=None)
+
+        self.assertTrue(result)
+
+
+class TestVmwareNodeScenariosExtended(unittest.TestCase):
+    """Extended test cases for vmware_node_scenarios class."""
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.nodeaction')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_stop_with_kube_check(self, mock_vsphere_class, mock_nodeaction):
+        """Test stop scenario with Kubernetes health checks enabled."""
+        node_name = "test-node-stop-kube"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.stop_instances.return_value = True
+        mock_vsphere.wait_until_stopped.return_value = True
+
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=True,
+            affected_nodes_status=AffectedNodeStatus()
+        )
+
+        scenarios.node_stop_scenario(
+            instance_kill_count=1,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        mock_vsphere.stop_instances.assert_called_with(node_name)
+        mock_vsphere.wait_until_stopped.assert_called_once()
+        mock_nodeaction.wait_for_ready_status.assert_called_once()
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_start_failure_exception_handling(self, mock_vsphere_class):
+        """Test exception handling during node start."""
+        node_name = "failing-start-node"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.start_instances.side_effect = Exception("vSphere API Error")
+
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=False,
+            affected_nodes_status=AffectedNodeStatus()
+        )
+
+        scenarios.node_start_scenario(
+            instance_kill_count=1,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        mock_vsphere.start_instances.assert_called_with(node_name)
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_reboot_failure_exception_handling(self, mock_vsphere_class):
+        """Test exception handling during node reboot."""
+        node_name = "failing-reboot-node"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.reboot_instances.side_effect = Exception("vSphere API Error")
+
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=False,
+            affected_nodes_status=AffectedNodeStatus()
+        )
+
+        scenarios.node_reboot_scenario(
+            instance_kill_count=1,
+            node=node_name,
+            timeout=300
+        )
+
+        mock_vsphere.reboot_instances.assert_called_with(node_name)
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_start_multiple_instance_kill_count(self, mock_vsphere_class):
+        """Test start scenario with multiple instance kill count."""
+        node_name = "test-node-multi-start"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.start_instances.return_value = True
+        mock_vsphere.wait_until_running.return_value = True
+
+        affected_status = AffectedNodeStatus()
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=False,
+            affected_nodes_status=affected_status
+        )
+
+        scenarios.node_start_scenario(
+            instance_kill_count=3,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        self.assertEqual(mock_vsphere.start_instances.call_count, 3)
+        self.assertEqual(len(affected_status.affected_nodes), 3)
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_stop_multiple_instance_kill_count(self, mock_vsphere_class):
+        """Test stop scenario with multiple instance kill count."""
+        node_name = "test-node-multi-stop"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.stop_instances.return_value = True
+        mock_vsphere.wait_until_stopped.return_value = True
+
+        affected_status = AffectedNodeStatus()
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=False,
+            affected_nodes_status=affected_status
+        )
+
+        scenarios.node_stop_scenario(
+            instance_kill_count=3,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        self.assertEqual(mock_vsphere.stop_instances.call_count, 3)
+        self.assertEqual(len(affected_status.affected_nodes), 3)
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_terminate_multiple_instance_kill_count(self, mock_vsphere_class):
+        """Test terminate scenario with multiple instance kill count."""
+        node_name = "test-node-multi-terminate"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.stop_instances.return_value = True
+        mock_vsphere.wait_until_stopped.return_value = True
+        mock_vsphere.wait_until_released.return_value = True
+
+        affected_status = AffectedNodeStatus()
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=False,
+            affected_nodes_status=affected_status
+        )
+
+        scenarios.node_terminate_scenario(
+            instance_kill_count=3,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        self.assertEqual(mock_vsphere.stop_instances.call_count, 3)
+        self.assertEqual(mock_vsphere.release_instances.call_count, 3)
+        self.assertEqual(len(affected_status.affected_nodes), 3)
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_affected_nodes_tracking_start(self, mock_vsphere_class):
+        """Test that affected nodes are properly tracked during start."""
+        node_name = "tracked-start-node"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.start_instances.return_value = True
+        mock_vsphere.wait_until_running.return_value = True
+
+        affected_status = AffectedNodeStatus()
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=False,
+            affected_nodes_status=affected_status
+        )
+
+        self.assertEqual(len(affected_status.affected_nodes), 0)
+
+        scenarios.node_start_scenario(
+            instance_kill_count=1,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        self.assertEqual(len(affected_status.affected_nodes), 1)
+        self.assertEqual(affected_status.affected_nodes[0].node_name, node_name)
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_affected_nodes_tracking_stop(self, mock_vsphere_class):
+        """Test that affected nodes are properly tracked during stop."""
+        node_name = "tracked-stop-node"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.stop_instances.return_value = True
+        mock_vsphere.wait_until_stopped.return_value = True
+
+        affected_status = AffectedNodeStatus()
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=False,
+            affected_nodes_status=affected_status
+        )
+
+        self.assertEqual(len(affected_status.affected_nodes), 0)
+
+        scenarios.node_stop_scenario(
+            instance_kill_count=1,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        self.assertEqual(len(affected_status.affected_nodes), 1)
+        self.assertEqual(affected_status.affected_nodes[0].node_name, node_name)
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_affected_nodes_tracking_terminate(self, mock_vsphere_class):
+        """Test that affected nodes are properly tracked during terminate."""
+        node_name = "tracked-terminate-node"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.stop_instances.return_value = True
+        mock_vsphere.wait_until_stopped.return_value = True
+        mock_vsphere.wait_until_released.return_value = True
+
+        affected_status = AffectedNodeStatus()
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=False,
+            affected_nodes_status=affected_status
+        )
+
+        self.assertEqual(len(affected_status.affected_nodes), 0)
+
+        scenarios.node_terminate_scenario(
+            instance_kill_count=1,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        self.assertEqual(len(affected_status.affected_nodes), 1)
+        self.assertEqual(affected_status.affected_nodes[0].node_name, node_name)
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.nodeaction')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_stop_with_kube_check_already_stopped(self, mock_vsphere_class, mock_nodeaction):
+        """Test stop scenario with kube check when VM is already stopped."""
+        node_name = "already-stopped-kube"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.stop_instances.return_value = False
+
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=True,
+            affected_nodes_status=AffectedNodeStatus()
+        )
+
+        scenarios.node_stop_scenario(
+            instance_kill_count=1,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        mock_vsphere.stop_instances.assert_called_with(node_name)
+        mock_vsphere.wait_until_stopped.assert_not_called()
+        mock_nodeaction.wait_for_ready_status.assert_not_called()
+
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.nodeaction')
+    @patch('krkn.scenario_plugins.node_actions.vmware_node_scenarios.vSphere')
+    def test_start_with_kube_check_already_started(self, mock_vsphere_class, mock_nodeaction):
+        """Test start scenario with kube check when VM is already running."""
+        node_name = "already-running-kube"
+        mock_vsphere = MagicMock()
+        mock_vsphere_class.return_value = mock_vsphere
+        mock_vsphere.start_instances.return_value = False
+
+        scenarios = vmware_node_scenarios(
+            kubecli=MagicMock(),
+            node_action_kube_check=True,
+            affected_nodes_status=AffectedNodeStatus()
+        )
+
+        scenarios.node_start_scenario(
+            instance_kill_count=1,
+            node=node_name,
+            timeout=300,
+            poll_interval=5
+        )
+
+        mock_vsphere.start_instances.assert_called_with(node_name)
+        mock_vsphere.wait_until_running.assert_not_called()
+        mock_nodeaction.wait_for_ready_status.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add 34 new mocked unit tests for vmware_node_scenarios.py achieving 100% coverage. Tests cover all vSphere class methods (release_instances, list_instances, get_datastore_list, get_folder_list, get_resource_pool, create_default_vm, wait timeouts, affected node tracking) and all vmware_node_scenarios methods (start/stop/reboot/terminate with kube checks, multiple kill counts, exception handling, already-in-state).

Add VSPHERE_HTTP_PROXY env var support to vSphere session so proxy is only applied to vCenter API calls without breaking Kubernetes API connectivity.

Verified on a live vSphere OpenShift 4.20 cluster with two successful node reboot runs.

# Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization

# Description  
<-- Provide a brief description of the changes made in this PR. -->  

## Related Tickets & Documents
If no related issue, please create one and start the conversation on wants of 

- Related Issue #: 
- Closes #: 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python run_kraken.py
...
<---insert test results output--->
```

OR


```bash
python -m coverage run -a -m unittest discover -s tests -v
...
<---insert test results output--->
```
