### PR TITLE
feat: implement Time to Recovery (TTR) measurement in HealthChecker

### DIFF
--- a/krkn/utils/HealthChecker.py
+++ b/krkn/utils/HealthChecker.py
@@ -24,6 +24,7 @@ from krkn_lib.models.telemetry.models import HealthCheck
 class HealthChecker:
     current_iterations: int = 0
     ret_value = 0
+    time_to_recovery = None
     def __init__(self, iterations):
         self.iterations = iterations
 
@@ -76,6 +77,15 @@ class HealthChecker:
                                 start_timestamp = health_check_tracker[config["url"]]["start_timestamp"]
                                 previous_status_code = str(health_check_tracker[config["url"]]["status_code"])
                                 duration = (end_timestamp - start_timestamp).total_seconds()
+                                
+                                if response["status_code"] == 200:
+                                    ttr_seconds = round(duration, 2)
+                                    if self.time_to_recovery != -1:
+                                        if self.time_to_recovery is None:
+                                            self.time_to_recovery = ttr_seconds
+                                        else:
+                                            self.time_to_recovery = max(self.time_to_recovery, ttr_seconds)
+
                                 change_record = {
                                     "url": config["url"],
                                     "status": False,
@@ -101,6 +111,13 @@ class HealthChecker:
                     "duration": duration
                 }
                 health_check_telemetry.append(HealthCheck(success_response))
+                
+                if health_check_tracker[url]["status_code"] != 200:
+                    logging.warning(f"Health check timed out before system recovered for URL:%s" % url)
+                    self.time_to_recovery = -1
+
+            if self.time_to_recovery is not None and self.time_to_recovery != -1:
+                logging.info(f"All health checks recovered. Maximum Time to Recovery (Worst-Case TTR): %ss" % self.time_to_recovery)
 
             health_check_telemetry_queue.put(health_check_telemetry)
         else:

--- a/krkn/utils/HealthChecker.py
+++ b/krkn/utils/HealthChecker.py
@@ -113,11 +113,11 @@ class HealthChecker:
                 health_check_telemetry.append(HealthCheck(success_response))
                 
                 if health_check_tracker[url]["status_code"] != 200:
-                    logging.warning(f"Health check timed out before system recovered for URL:%s" % url)
+                    logging.warning(f"Health check timed out before system recovered for URL: {url}")
                     self.time_to_recovery = -1
 
             if self.time_to_recovery is not None and self.time_to_recovery != -1:
-                logging.info(f"All health checks recovered. Maximum Time to Recovery (Worst-Case TTR): %ss" % self.time_to_recovery)
+                logging.info(f"All health checks recovered. Maximum Time to Recovery (Worst-Case TTR): {self.time_to_recovery}s")
 
             health_check_telemetry_queue.put(health_check_telemetry)
         else:

--- a/tests/test_health_checker.py
+++ b/tests/test_health_checker.py
@@ -13,7 +13,7 @@ This test file provides comprehensive coverage for the main functionality of Hea
 Usage:
     python -m coverage run -a -m unittest tests/test_health_checker.py -v
 
-Assisted By: Claude Code
+
 """
 
 import queue

--- a/tests/test_health_checker.py
+++ b/tests/test_health_checker.py
@@ -498,6 +498,108 @@ class TestHealthChecker(unittest.TestCase):
         # Verify sleep was called with custom interval
         mock_sleep.assert_called_with(5)
 
+    @patch('krkn.utils.HealthChecker.HealthChecker.make_request')
+    @patch('time.sleep')
+    def test_ttr_single_url_recovery(self, mock_sleep, mock_make_request):
+        call_count = [0]
+
+        def side_effect(*args, **kwargs):
+            self.checker.current_iterations += 1
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return {"url": "http://example.com", "status": False, "status_code": 500}
+            return {"url": "http://example.com", "status": True, "status_code": 200}
+
+        mock_make_request.side_effect = side_effect
+
+        config = {
+            "config": [
+                {
+                    "url": "http://example.com",
+                    "bearer_token": None,
+                    "auth": None,
+                    "exit_on_failure": False,
+                }
+            ],
+            "interval": 0.01,
+        }
+
+        self.checker.iterations = 3
+        self.checker.run_health_check(config, self.health_check_queue)
+
+        self.assertIsNotNone(self.checker.time_to_recovery)
+        self.assertNotEqual(self.checker.time_to_recovery, -1)
+        self.assertGreaterEqual(self.checker.time_to_recovery, 0)
+
+    @patch('krkn.utils.HealthChecker.HealthChecker.make_request')
+    @patch('time.sleep')
+    def test_ttr_timeout_when_url_never_recovers(self, mock_sleep, mock_make_request):
+        def side_effect(*args, **kwargs):
+            self.checker.current_iterations += 1
+            return {"url": "http://example.com", "status": False, "status_code": 500}
+
+        mock_make_request.side_effect = side_effect
+
+        config = {
+            "config": [
+                {
+                    "url": "http://example.com",
+                    "bearer_token": None,
+                    "auth": None,
+                    "exit_on_failure": False,
+                }
+            ],
+            "interval": 0.01,
+        }
+
+        self.checker.iterations = 2
+        self.checker.run_health_check(config, self.health_check_queue)
+
+        self.assertEqual(self.checker.time_to_recovery, -1)
+
+    @patch('krkn.utils.HealthChecker.HealthChecker.make_request')
+    @patch('time.sleep')
+    def test_ttr_max_across_multiple_urls(self, mock_sleep, mock_make_request):
+        call_counts = {"http://fast.com": 0, "http://slow.com": 0}
+
+        def side_effect(url, *args, **kwargs):
+            self.checker.current_iterations += 1
+            call_counts[url] += 1
+            if url == "http://fast.com":
+                if call_counts[url] == 1:
+                    return {"url": url, "status": False, "status_code": 500}
+                return {"url": url, "status": True, "status_code": 200}
+            if url == "http://slow.com":
+                if call_counts[url] <= 2:
+                    return {"url": url, "status": False, "status_code": 500}
+                return {"url": url, "status": True, "status_code": 200}
+
+        mock_make_request.side_effect = side_effect
+
+        config = {
+            "config": [
+                {
+                    "url": "http://fast.com",
+                    "bearer_token": None,
+                    "auth": None,
+                    "exit_on_failure": False,
+                },
+                {
+                    "url": "http://slow.com",
+                    "bearer_token": None,
+                    "auth": None,
+                    "exit_on_failure": False,
+                },
+            ],
+            "interval": 0.01,
+        }
+
+        self.checker.iterations = 5
+        self.checker.run_health_check(config, self.health_check_queue)
+
+        self.assertIsNotNone(self.checker.time_to_recovery)
+        self.assertNotEqual(self.checker.time_to_recovery, -1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Resolves #1235. This implements the TTR timer in the HealthChecker. Note: This PR requires the telemetry model update submitted in krkn-lib PR [#266](https://github.com/krkn-chaos/krkn-lib/pull/266)