### PR TITLE
docs: align Python requirement with 3.11

### DIFF
--- a/CI/templates/mock_cerberus.yaml
+++ b/CI/templates/mock_cerberus.yaml
@@ -50,7 +50,7 @@ metadata:
 spec:
   containers:
   - name: mock-cerberus
-    image: python:3.9-slim
+    image: python:3.11-slim
     command: ["python3", "/app/server.py"]
     ports:
     - containerPort: 8080

--- a/CI/templates/mock_cerberus_unhealthy.yaml
+++ b/CI/templates/mock_cerberus_unhealthy.yaml
@@ -56,7 +56,7 @@ metadata:
 spec:
   containers:
   - name: mock-cerberus-unhealthy
-    image: python:3.9-slim
+    image: python:3.11-slim
     command: ["python3", "/app/server.py"]
     ports:
     - containerPort: 8080

--- a/CI/tests_v2/Makefile
+++ b/CI/tests_v2/Makefile
@@ -19,7 +19,7 @@ help:
 	@echo "  setup         Create venv (if missing), install Python deps, create KinD cluster (kind-config-dev.yml)."
 	@echo "               Run once before first test. Override cluster config: KIND_CONFIG=path make setup"
 	@echo ""
-	@echo "  preflight     Check Python 3.9+, kind, kubectl, Docker, cluster reachability, test deps."
+	@echo "  preflight     Check Python 3.11+, kind, kubectl, Docker, cluster reachability, test deps."
 	@echo "               Invoked automatically by test targets; run standalone to validate environment."
 	@echo ""
 	@echo "  test         Full run: retries (2), timeout 300s, HTML report, JUnit XML, coverage."
@@ -60,7 +60,7 @@ $(VENV)/.installed: $(REPO_ROOT)/requirements.txt $(TESTS_DIR)/requirements.txt
 preflight:
 	@echo "Preflight: checking Python, tools, and cluster..."
 	@command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not found."; exit 1; }
-	@python3 -c "import sys; exit(0 if sys.version_info >= (3, 9) else 1)" || { echo "Error: Python 3.9+ required."; exit 1; }
+	@python3 -c "import sys; exit(0 if sys.version_info >= (3, 11) else 1)" || { echo "Error: Python 3.11+ required."; exit 1; }
 	@command -v kind >/dev/null 2>&1 || { echo "Error: kind not installed."; exit 1; }
 	@command -v kubectl >/dev/null 2>&1 || { echo "Error: kubectl not installed."; exit 1; }
 	@docker info >/dev/null 2>&1 || { echo "Error: Docker not running (required for KinD)."; exit 1; }

--- a/CI/tests_v2/README.md
+++ b/CI/tests_v2/README.md
@@ -9,7 +9,7 @@ Each test runs in its **own ephemeral Kubernetes namespace** (`krkn-test-<uuid>`
 Without a cluster, tests that need one will **skip** with a clear message (e.g. *"Could not load kube config"*). No manual workload deployment is required; workloads are deployed automatically into ephemeral namespaces per test.
 
 - **KinD cluster** (or any Kubernetes cluster) running with `kubectl` configured (e.g. `KUBECONFIG` or default `~/.kube/config`).
-- **Python 3.9+** and main repo deps: `pip install -r requirements.txt`.
+- **Python 3.11+** and main repo deps: `pip install -r requirements.txt`.
 
 ### Supported clusters
 

--- a/CI/tests_v2/setup_env.sh
+++ b/CI/tests_v2/setup_env.sh
@@ -19,8 +19,8 @@ cd "$REPO_ROOT"
 command -v kind >/dev/null 2>&1 || { echo "Error: kind is not installed. Install from https://kind.sigs.k8s.io/docs/user/quick-start/"; exit 1; }
 command -v kubectl >/dev/null 2>&1 || { echo "Error: kubectl is not installed."; exit 1; }
 
-# Python 3.9+
-python3 -c "import sys; exit(0 if sys.version_info >= (3, 9) else 1)" 2>/dev/null || { echo "Error: Python 3.9+ required. Check: python3 --version"; exit 1; }
+# Python 3.11+
+python3 -c "import sys; exit(0 if sys.version_info >= (3, 11) else 1)" 2>/dev/null || { echo "Error: Python 3.11+ required. Check: python3 --version"; exit 1; }
 
 # Docker running (required for KinD)
 docker info >/dev/null 2>&1 || { echo "Error: Docker is not running. Start Docker Desktop or run: systemctl start docker"; exit 1; }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ python -m coverage run -a -m unittest discover -s tests -v
 ## Critical Requirements
 
 ### Python Environment
-- **Python 3.9+** required
+- **Python 3.11+** required
 - **NEVER install packages globally** - always use virtual environment
 - **CRITICAL**: `docker` must be <7.0 and `requests` must be <2.32 (Unix socket compatibility)
 

--- a/utils/chaos_recommender/README.md
+++ b/utils/chaos_recommender/README.md
@@ -22,21 +22,21 @@ This tool profiles an application and gathers telemetry data such as CPU, Memory
 
 - Openshift Or Kubernetes Environment where the application is hosted
 - Access to the metrics via the exposed Prometheus endpoint
-- Python3.9
+- Python3.11
 
 ## Usage
 
 1. To run
 
     ```
-    $ python3.9 -m venv chaos
+    $ python3.11 -m venv chaos
     $ source chaos/bin/activate
     $ git clone https://github.com/krkn-chaos/krkn.git 
     $ cd krkn
     $ pip3 install -r requirements.txt
     Edit configuration file:
     $ vi config/recommender_config.yaml 
-    $ python3.9 utils/chaos_recommender/chaos_recommender.py -c utils/chaos_recommender/recommender_config.yaml
+    $ python3.11 utils/chaos_recommender/chaos_recommender.py -c utils/chaos_recommender/recommender_config.yaml
     ```
 
 2. Follow the prompts to provide the required information.


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

Update stale Python 3.9 references to Python 3.11.

The repo already runs CI with Python 3.11, the container image defaults to Python 3.11, and `krkn-lib==6.0.6` requires Python >=3.11. This PR aligns the in-repo docs, tests_v2 preflight checks, and mock Cerberus test images with that requirement.

## Related Tickets & Documents

- Related Issue #: N/A
- Closes #: N/A

# Documentation

- [ ] **Is documentation needed for this update?**

This only updates stale in-repo documentation/test helper references. Website docs can be handled separately if maintainers want that included.

# Checklist before requesting a review

[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)

See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes

- [ ] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
git diff --check
# passed

rg -n "3\\.9|Python 3\\.9|python3\\.9|python:3\\.9" -S .
# no matches

bash -n CI/tests_v2/setup_env.sh
# passed

python3 -m compileall -q run_kraken.py krkn tests CI/tests_v2
# passed

kubectl apply --dry-run=client --validate=false -f CI/templates/mock_cerberus.yaml
# passed

kubectl apply --dry-run=client --validate=false -f CI/templates/mock_cerberus_unhealthy.yaml
# passed

docker manifest inspect python:3.11-slim
# passed

make -f CI/tests_v2/Makefile help
# passed
