### PR TITLE
fix: handle Alibaba request error logging

### DIFF
--- a/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
@@ -52,7 +52,7 @@ class Alibaba:
             response_detail = json.loads(response_str)
             return response_detail
         except Exception as e:
-            logging.error("ERROR sending request %s with message %S" % (request, e))
+            logging.error("ERROR sending request %s with message %s", request, e)
 
     # output the instance owned in current region.
     def list_instances(self):

--- a/tests/test_alibaba_node_scenarios.py
+++ b/tests/test_alibaba_node_scenarios.py
@@ -84,10 +84,16 @@ class TestAlibaba(unittest.TestCase):
         mock_request = Mock()
         alibaba.compute_client.do_action.side_effect = Exception("API error")
 
-        # The actual code has a bug in the format string (%S instead of %s)
-        # So we expect this to raise a ValueError
-        with self.assertRaises(ValueError):
-            alibaba._send_request(mock_request)
+        result = alibaba._send_request(mock_request)
+
+        self.assertIsNone(result)
+        mock_request.set_accept_format.assert_called_once_with('json')
+        alibaba.compute_client.do_action.assert_called_once_with(mock_request)
+        mock_logging.assert_called_once_with(
+            "ERROR sending request %s with message %s",
+            mock_request,
+            alibaba.compute_client.do_action.side_effect,
+        )
 
     @patch('krkn.scenario_plugins.node_actions.alibaba_node_scenarios.AcsClient')
     def test_list_instances_success(self, mock_acs_client):


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

Fix Alibaba `_send_request` error logging.

The exception handler was using `%S` in the log message format string. When an Alibaba SDK request fails, that typo raises a secondary `ValueError` while trying to log the original error.

The existing test already called this out as a bug and was expecting the `ValueError`. This updates the logging call to use `%s` and changes the test to check that the request failure is logged without raising the formatting error.

The existing behavior of returning `None` on request failure is preserved.

## Related Tickets & Documents

- Related Issue #: N/A
- Closes #: N/A

# Documentation

- [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)

N/A

# Checklist before requesting a review

[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.

- [ ] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python -c "request=object(); e=Exception('API error'); print('ERROR sending request %s with message %S' % (request, e))"
# ValueError: unsupported format character 'S' (0x53) at index 39

git diff --check
# passed

python -m py_compile krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py tests/test_alibaba_node_scenarios.py
# passed

# I also validated the targeted unit behavior locally with the external Alibaba/krkn-lib imports stubbed:
# TestAlibaba.test_send_request_failure ... ok
