### PR TITLE
fix(node_actions): prevent generic node scenarios from leaking into cloud actions

### DIFF
--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -45,7 +45,7 @@ from krkn.scenario_plugins.node_actions.ibmcloud_node_scenarios import (
 from krkn.scenario_plugins.node_actions.ibmcloud_power_node_scenarios import (
      ibmcloud_power_node_scenarios,
 )
-node_general = False
+
 
 
 class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
@@ -67,7 +67,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                             % (scenario, index)
                         )
                         return 1
-                    node_scenario_object = self.get_node_scenario_object(
+                    node_scenario_object, is_generic_node_scenario = self.get_node_scenario_object(
                         node_scenario, lib_telemetry.get_lib_kubernetes()
                     )
                     for action in actions:
@@ -76,6 +76,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                             action,
                             node_scenario,
                             node_scenario_object,
+                            is_generic_node_scenario,
                             lib_telemetry.get_lib_kubernetes(),
                             scenario_telemetry,
                         )
@@ -94,33 +95,46 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
             "cloud_type" not in node_scenario.keys()
             or node_scenario["cloud_type"] == "generic"
         ):
-            global node_general
-            node_general = True
-            return general_node_scenarios(
-                kubecli, node_action_kube_check, affected_nodes_status
+            return (
+                general_node_scenarios(
+                    kubecli, node_action_kube_check, affected_nodes_status
+                ),
+                True,
             )
         if node_scenario["cloud_type"].lower() == "aws":
-            return aws_node_scenarios(
-                kubecli, node_action_kube_check, affected_nodes_status
+            return (
+                aws_node_scenarios(
+                    kubecli, node_action_kube_check, affected_nodes_status
+                ),
+                False,
             )
         elif node_scenario["cloud_type"].lower() == "gcp":
-            return gcp_node_scenarios(
-                kubecli, node_action_kube_check, affected_nodes_status
+            return (
+                gcp_node_scenarios(
+                    kubecli, node_action_kube_check, affected_nodes_status
+                ),
+                False,
             )
         elif node_scenario["cloud_type"].lower() == "openstack":
             from krkn.scenario_plugins.node_actions.openstack_node_scenarios import (
                 openstack_node_scenarios,
             )
 
-            return openstack_node_scenarios(
-                kubecli, node_action_kube_check, affected_nodes_status
+            return (
+                openstack_node_scenarios(
+                    kubecli, node_action_kube_check, affected_nodes_status
+                ),
+                False,
             )
         elif (
             node_scenario["cloud_type"].lower() == "azure"
             or node_scenario["cloud_type"].lower() == "az"
         ):
-            return azure_node_scenarios(
-                kubecli, node_action_kube_check, affected_nodes_status
+            return (
+                azure_node_scenarios(
+                    kubecli, node_action_kube_check, affected_nodes_status
+                ),
+                False,
             )
         elif (
             node_scenario["cloud_type"].lower() == "alibaba"
@@ -130,45 +144,73 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                 alibaba_node_scenarios,
             )
 
-            return alibaba_node_scenarios(
-                kubecli, node_action_kube_check, affected_nodes_status
+            return (
+                alibaba_node_scenarios(
+                    kubecli, node_action_kube_check, affected_nodes_status
+                ),
+                False,
             )
         elif node_scenario["cloud_type"].lower() == "bm":
             from krkn.scenario_plugins.node_actions.bm_node_scenarios import (
                 bm_node_scenarios,
             )
 
-            return bm_node_scenarios(
-                node_scenario.get("bmc_info"),
-                node_scenario.get("bmc_user", None),
-                node_scenario.get("bmc_password", None),
-                kubecli,
-                node_action_kube_check,
-                affected_nodes_status,
+            return (
+                bm_node_scenarios(
+                    node_scenario.get("bmc_info"),
+                    node_scenario.get("bmc_user", None),
+                    node_scenario.get("bmc_password", None),
+                    kubecli,
+                    node_action_kube_check,
+                    affected_nodes_status,
+                ),
+                False,
             )
         elif node_scenario["cloud_type"].lower() == "docker":
-            return docker_node_scenarios(
-                kubecli, node_action_kube_check, affected_nodes_status
+            return (
+                docker_node_scenarios(
+                    kubecli, node_action_kube_check, affected_nodes_status
+                ),
+                False,
             )
         elif (
             node_scenario["cloud_type"].lower() == "vsphere"
             or node_scenario["cloud_type"].lower() == "vmware"
         ):
-            return vmware_node_scenarios(
-                kubecli, node_action_kube_check, affected_nodes_status
+            return (
+                vmware_node_scenarios(
+                    kubecli, node_action_kube_check, affected_nodes_status
+                ),
+                False,
             )
         elif (
             node_scenario["cloud_type"].lower() == "ibm"
             or node_scenario["cloud_type"].lower() == "ibmcloud"
         ):
             disable_ssl_verification = get_yaml_item_value(node_scenario, "disable_ssl_verification", True)
-            return ibm_node_scenarios(kubecli, node_action_kube_check, affected_nodes_status, disable_ssl_verification)
+            return (
+                ibm_node_scenarios(
+                    kubecli,
+                    node_action_kube_check,
+                    affected_nodes_status,
+                    disable_ssl_verification,
+                ),
+                False,
+            )
         elif (
             node_scenario["cloud_type"].lower() == "ibmpower"
             or node_scenario["cloud_type"].lower() == "ibmcloudpower"
         ):
             disable_ssl_verification = get_yaml_item_value(node_scenario, "disable_ssl_verification", True)
-            return ibmcloud_power_node_scenarios(kubecli, node_action_kube_check, affected_nodes_status, disable_ssl_verification)
+            return (
+                ibmcloud_power_node_scenarios(
+                    kubecli,
+                    node_action_kube_check,
+                    affected_nodes_status,
+                    disable_ssl_verification,
+                ),
+                False,
+            )
         else:
             logging.error(
                 "Cloud type "
@@ -190,6 +232,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         action,
         node_scenario,
         node_scenario_object,
+        is_generic_node_scenario: bool,
         kubecli: KrknKubernetes,
         scenario_telemetry: ScenarioTelemetry,
     ):
@@ -222,14 +265,33 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
 
         # GCP api doesn't support multiprocessing calls, will only actually run 1
         if parallel_nodes:
-            self.multiprocess_nodes(nodes, node_scenario_object, action, node_scenario)
+            self.multiprocess_nodes(
+                nodes,
+                node_scenario_object,
+                action,
+                node_scenario,
+                is_generic_node_scenario,
+            )
         else:
             for single_node in nodes:
-                self.run_node(single_node, node_scenario_object, action, node_scenario)
+                self.run_node(
+                    single_node,
+                    node_scenario_object,
+                    action,
+                    node_scenario,
+                    is_generic_node_scenario,
+                )
         affected_nodes_status = node_scenario_object.affected_nodes_status
         scenario_telemetry.affected_nodes.extend(affected_nodes_status.affected_nodes)
 
-    def multiprocess_nodes(self, nodes, node_scenario_object, action, node_scenario):
+    def multiprocess_nodes(
+        self,
+        nodes,
+        node_scenario_object,
+        action,
+        node_scenario,
+        is_generic_node_scenario,
+    ):
         try:
             # pool object with number of element
             pool = ThreadPool(processes=len(nodes))
@@ -241,6 +303,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                     repeat(node_scenario_object),
                     repeat(action),
                     repeat(node_scenario),
+                    repeat(is_generic_node_scenario),
                 ),
             )
 
@@ -248,7 +311,14 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         except Exception as e:
             logging.info("Error on pool multiprocessing: " + str(e))
 
-    def run_node(self, single_node, node_scenario_object, action, node_scenario):
+    def run_node(
+        self,
+        single_node,
+        node_scenario_object,
+        action,
+        node_scenario,
+        is_generic_node_scenario=False,
+    ):
         # Get the scenario specifics for running action nodes
         run_kill_count = get_yaml_item_value(node_scenario, "runs", 1)
         duration = get_yaml_item_value(node_scenario, "duration", 120)
@@ -261,7 +331,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         )
         generic_cloud_scenarios = ("stop_kubelet_scenario", "node_crash_scenario")
 
-        if node_general and action not in generic_cloud_scenarios:
+        if is_generic_node_scenario and action not in generic_cloud_scenarios:
             logging.info(
                 "Scenario: "
                 + action

--- a/tests/test_node_actions_scenario_plugin.py
+++ b/tests/test_node_actions_scenario_plugin.py
@@ -29,10 +29,6 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         """
         Set up test fixtures for NodeActionsScenarioPlugin
         """
-        # Reset node_general global variable before each test
-        import krkn.scenario_plugins.node_actions.node_actions_scenario_plugin as plugin_module
-        plugin_module.node_general = False
-
         self.plugin = NodeActionsScenarioPlugin()
         self.mock_kubecli = Mock(spec=KrknKubernetes)
         self.mock_lib_telemetry = Mock(spec=KrknTelemetryOpenshift)
@@ -58,9 +54,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_general_instance = Mock()
         mock_general_scenarios.return_value = mock_general_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_general_instance)
+        self.assertTrue(is_generic)
         mock_general_scenarios.assert_called_once()
         args = mock_general_scenarios.call_args[0]
         self.assertEqual(args[0], self.mock_kubecli)
@@ -76,9 +73,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_general_instance = Mock()
         mock_general_scenarios.return_value = mock_general_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_general_instance)
+        self.assertTrue(is_generic)
         mock_general_scenarios.assert_called_once()
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.aws_node_scenarios')
@@ -90,9 +88,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_aws_instance = Mock()
         mock_aws_scenarios.return_value = mock_aws_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_aws_instance)
+        self.assertFalse(is_generic)
         mock_aws_scenarios.assert_called_once()
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.gcp_node_scenarios')
@@ -104,9 +103,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_gcp_instance = Mock()
         mock_gcp_scenarios.return_value = mock_gcp_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_gcp_instance)
+        self.assertFalse(is_generic)
         mock_gcp_scenarios.assert_called_once()
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.azure_node_scenarios')
@@ -118,9 +118,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_azure_instance = Mock()
         mock_azure_scenarios.return_value = mock_azure_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_azure_instance)
+        self.assertFalse(is_generic)
         mock_azure_scenarios.assert_called_once()
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.azure_node_scenarios')
@@ -132,9 +133,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_azure_instance = Mock()
         mock_azure_scenarios.return_value = mock_azure_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_azure_instance)
+        self.assertFalse(is_generic)
         mock_azure_scenarios.assert_called_once()
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.docker_node_scenarios')
@@ -146,9 +148,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_docker_instance = Mock()
         mock_docker_scenarios.return_value = mock_docker_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_docker_instance)
+        self.assertFalse(is_generic)
         mock_docker_scenarios.assert_called_once()
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.vmware_node_scenarios')
@@ -160,9 +163,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_vmware_instance = Mock()
         mock_vmware_scenarios.return_value = mock_vmware_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_vmware_instance)
+        self.assertFalse(is_generic)
         mock_vmware_scenarios.assert_called_once()
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.vmware_node_scenarios')
@@ -174,9 +178,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_vmware_instance = Mock()
         mock_vmware_scenarios.return_value = mock_vmware_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_vmware_instance)
+        self.assertFalse(is_generic)
         mock_vmware_scenarios.assert_called_once()
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.ibm_node_scenarios')
@@ -188,9 +193,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_ibm_instance = Mock()
         mock_ibm_scenarios.return_value = mock_ibm_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_ibm_instance)
+        self.assertFalse(is_generic)
         mock_ibm_scenarios.assert_called_once()
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.ibm_node_scenarios')
@@ -202,9 +208,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_ibm_instance = Mock()
         mock_ibm_scenarios.return_value = mock_ibm_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_ibm_instance)
+        self.assertFalse(is_generic)
         args = mock_ibm_scenarios.call_args[0]
         self.assertFalse(args[3])  # disable_ssl_verification should be False
 
@@ -217,9 +224,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         mock_ibmpower_instance = Mock()
         mock_ibmpower_scenarios.return_value = mock_ibmpower_instance
 
-        result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+        result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
         self.assertEqual(result, mock_ibmpower_instance)
+        self.assertFalse(is_generic)
         mock_ibmpower_scenarios.assert_called_once()
 
     def test_get_node_scenario_object_openstack(self):
@@ -231,9 +239,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             mock_openstack_instance = Mock()
             mock_openstack.return_value = mock_openstack_instance
 
-            result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+            result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
             self.assertEqual(result, mock_openstack_instance)
+            self.assertFalse(is_generic)
             mock_openstack.assert_called_once()
 
     def test_get_node_scenario_object_alibaba(self):
@@ -245,9 +254,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             mock_alibaba_instance = Mock()
             mock_alibaba.return_value = mock_alibaba_instance
 
-            result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+            result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
             self.assertEqual(result, mock_alibaba_instance)
+            self.assertFalse(is_generic)
             mock_alibaba.assert_called_once()
 
     def test_get_node_scenario_object_alicloud(self):
@@ -259,9 +269,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             mock_alibaba_instance = Mock()
             mock_alibaba.return_value = mock_alibaba_instance
 
-            result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+            result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
             self.assertEqual(result, mock_alibaba_instance)
+            self.assertFalse(is_generic)
             mock_alibaba.assert_called_once()
 
     def test_get_node_scenario_object_bm(self):
@@ -278,9 +289,10 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             mock_bm_instance = Mock()
             mock_bm.return_value = mock_bm_instance
 
-            result = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
+            result, is_generic = self.plugin.get_node_scenario_object(node_scenario, self.mock_kubecli)
 
             self.assertEqual(result, mock_bm_instance)
+            self.assertFalse(is_generic)
             args = mock_bm.call_args[0]
             self.assertEqual(args[0], "192.168.1.1")
             self.assertEqual(args[1], "admin")
@@ -322,6 +334,7 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             action,
             node_scenario,
             mock_scenario_object,
+            False,
             self.mock_kubecli,
             self.mock_scenario_telemetry
         )
@@ -349,6 +362,7 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             action,
             node_scenario,
             mock_scenario_object,
+            False,
             self.mock_kubecli,
             self.mock_scenario_telemetry
         )
@@ -380,6 +394,7 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             action,
             node_scenario,
             mock_scenario_object,
+            False,
             self.mock_kubecli,
             self.mock_scenario_telemetry
         )
@@ -409,6 +424,7 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
                 action,
                 node_scenario,
                 mock_scenario_object,
+                False,
                 self.mock_kubecli,
                 self.mock_scenario_telemetry
             )
@@ -607,18 +623,57 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         """
         Test run_node skips unsupported actions for generic cloud type
         """
-        # Set node_general to True for this test
-        import krkn.scenario_plugins.node_actions.node_actions_scenario_plugin as plugin_module
-        plugin_module.node_general = True
-
         node_scenario = {}
         action = "node_stop_scenario"
         mock_scenario_object = Mock()
 
-        self.plugin.run_node("test-node", mock_scenario_object, action, node_scenario)
+        self.plugin.run_node(
+            "test-node",
+            mock_scenario_object,
+            action,
+            node_scenario,
+            is_generic_node_scenario=True,
+        )
 
         mock_logging.assert_called()
         self.assertIn("not set up for generic cloud type", str(mock_logging.call_args))
+
+    @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.aws_node_scenarios')
+    @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.general_node_scenarios')
+    def test_generic_scenario_does_not_leak_into_later_cloud_scenario(
+        self,
+        mock_general_scenarios,
+        mock_aws_scenarios,
+    ):
+        generic_object = Mock()
+        aws_object = Mock()
+        mock_general_scenarios.return_value = generic_object
+        mock_aws_scenarios.return_value = aws_object
+
+        generic_obj, generic_flag = self.plugin.get_node_scenario_object(
+            {"cloud_type": "generic"}, self.mock_kubecli
+        )
+        aws_obj, aws_flag = self.plugin.get_node_scenario_object(
+            {"cloud_type": "aws"}, self.mock_kubecli
+        )
+
+        self.plugin.run_node(
+            "test-node",
+            generic_obj,
+            "stop_kubelet_scenario",
+            {"cloud_type": "generic"},
+            generic_flag,
+        )
+        self.plugin.run_node(
+            "test-node",
+            aws_obj,
+            "node_stop_scenario",
+            {"cloud_type": "aws"},
+            aws_flag,
+        )
+
+        generic_object.stop_kubelet_scenario.assert_called_once()
+        aws_object.node_stop_scenario.assert_called_once()
 
     @patch('logging.info')
     def test_run_node_unknown_action(self, mock_logging):
@@ -632,12 +687,7 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         self.plugin.run_node("test-node", mock_scenario_object, action, node_scenario)
 
         mock_logging.assert_called()
-        # Could be either message depending on node_general state
-        call_str = str(mock_logging.call_args)
-        self.assertTrue(
-            "no node action that matches" in call_str or
-            "not set up for generic cloud type" in call_str
-        )
+        self.assertIn("no node action that matches", str(mock_logging.call_args))
 
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.cerberus')
     @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.common_node_functions')
@@ -785,7 +835,13 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             mock_pool_instance = Mock()
             mock_pool.return_value = mock_pool_instance
 
-            self.plugin.multiprocess_nodes(nodes, mock_scenario_object, action, node_scenario)
+            self.plugin.multiprocess_nodes(
+                nodes,
+                mock_scenario_object,
+                action,
+                node_scenario,
+                False,
+            )
 
             mock_pool.assert_called_once_with(processes=3)
             mock_pool_instance.starmap.assert_called_once()
@@ -804,7 +860,13 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
         with patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin.ThreadPool') as mock_pool:
             mock_pool.side_effect = Exception("Pool error")
 
-            self.plugin.multiprocess_nodes(nodes, mock_scenario_object, action, node_scenario)
+            self.plugin.multiprocess_nodes(
+                nodes,
+                mock_scenario_object,
+                action,
+                node_scenario,
+                False,
+            )
 
             mock_logging.assert_called()
             self.assertIn("Error on pool multiprocessing", str(mock_logging.call_args))
@@ -835,6 +897,7 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             action,
             node_scenario,
             mock_scenario_object,
+            False,
             self.mock_kubecli,
             self.mock_scenario_telemetry
         )


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

## Summary

Fixed an issue in node actions where running one generic node scenario could make later cloud-specific scenarios like AWS/GCP/Azure get skipped by mistake.

## Problem

I found that `node_general` was a global variable in `node_actions_scenario_plugin.py`.

When a scenario had `cloud_type: generic` or no `cloud_type`, this global value was set to `True`.

But it was never reset back to `False`.

Because of this, if a generic scenario ran first and an AWS/GCP/Azure scenario ran after that, the later cloud scenario could also be treated like a generic scenario.

The old check was:

```python
if node_general and action not in generic_cloud_scenarios:
```

So valid cloud actions could get skipped silently.

## Fix

I removed this dependency on global state.

Now `get_node_scenario_object()` returns two things:

```python
(node_scenario_object, is_generic_node_scenario)
```

The `is_generic_node_scenario` value is passed through:

- `run()`
- `inject_node_scenario()`
- `multiprocess_nodes()`
- `run_node()`

Now `run_node()` checks the current scenario only:

```python
if is_generic_node_scenario and action not in generic_cloud_scenarios:
```

So the generic scenario behavior stays limited to that scenario only and does not affect the next cloud scenario.

## Related Tickets & Documents

- Related Issue #: N/A
- Closes #: N/A

# Documentation

- [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)

N/A

# Checklist before requesting a review

- [ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
- [ ] I have performed a self-review of my code by running krkn and specific scenario
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

I updated the node action unit tests for the new return value and function arguments.

I also added a regression test where:

- first a generic scenario object is created
- then an AWS scenario object is created
- then I verified that AWS `node_stop_scenario` still runs correctly

This confirms that the generic scenario state is not leaking into the AWS scenario.

```bash
conda run -n conda-krkn python -m unittest tests.test_node_actions_scenario_plugin -v
```

Output:

```text
Ran 44 tests in 0.255s

OK
```

I also ran compile checks:

```bash
conda run -n conda-krkn python -m py_compile krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
conda run -n conda-krkn python -m py_compile tests/test_node_actions_scenario_plugin.py
```
