### PR TITLE
security: bump vulnerable dependencies to patched versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ azure-mgmt-compute==30.5.0
 azure-mgmt-network==27.0.0
 coverage==7.6.12
 datetime==5.4
-docker>=6.0,<7.0  # docker 7.0+ has breaking changes; works with requests<2.32
+docker>=6.0,<7.0  # docker 7.0+ has breaking changes; upgrade to 7.x to allow requests>=2.33.0
 gitpython==3.1.47
 google-auth==2.37.0
 google-cloud-compute==1.22.0
@@ -16,8 +16,8 @@ ibm_cloud_sdk_core>=3.20.0  # Requires urllib3>=2.1.0 (compatible with updated b
 ibm_vpc==0.26.3  # Requires ibm_cloud_sdk_core
 jinja2==3.1.6
 lxml==6.1.0
-kubernetes==34.1.0
-krkn-lib==6.0.6
+kubernetes>=35.0.0
+krkn-lib==6.0.7
 numpy==1.26.4
 pandas==2.2.0
 openshift-client==1.0.21
@@ -27,9 +27,9 @@ pyfiglet==1.0.2
 pytest==9.0.3
 python-ipmi==0.5.4
 python-openstackclient==6.5.0
-requests<2.32  # requests 2.32+ breaks Unix socket support (http+docker scheme)
+requests<2.32  # requests 2.32+ breaks docker Unix socket support; blocked until docker>=7.0
 requests-unixsocket>=0.4.0  # Required for Docker Unix socket support
-urllib3>=2.1.0,<2.4.0  # Compatible with all dependencies
+urllib3>=2.6.3  # CVE fixes; kubernetes>=35.0.0 allows urllib3>=2.x
 service_identity==24.1.0
 PyYAML==6.0.1
 setuptools==78.1.1
@@ -38,5 +38,5 @@ zope.interface==6.1
 colorlog==6.10.1
 
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
-cryptography>=42.0.4 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=46.0.7 # pinned to avoid multiple CVEs (subgroup attack, buffer overflow, DNS constraints)
 protobuf>=4.25.8 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary

Addresses open Dependabot/CVE alerts by updating transitive dependency pins in `requirements.txt`:

- **kubernetes**: `==34.1.0` → `>=35.0.0` — kubernetes 35.0.0 relaxes the urllib3 upper bound, enabling urllib3 v2.x
- **urllib3**: `>=2.1.0,<2.4.0` → `>=2.6.3` — fixes 4 high/medium CVEs (decompression bombs via streaming API and redirect chain, redirect bypass when retries disabled)
- **cryptography**: `>=42.0.4` → `>=46.0.7` — fixes 3 CVEs (SECT curve subgroup attack, buffer overflow for non-contiguous buffers, incomplete DNS name constraint enforcement)

## Known limitation

**`requests<2.32` remains unchanged** — updating to `>=2.33.0` requires upgrading `docker` from `6.x` to `7.x` (docker 6.x Unix socket transport breaks with requests 2.32+). That upgrade is tracked separately.

## Test plan

- [x] Verify `pip install -r requirements.txt` resolves without conflicts
- [x] Run existing CI test suite to confirm no regressions from kubernetes 35.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)