### PR TITLE
adding CLOMonitor badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![coverage](https://krkn-chaos.github.io/krkn-lib-docs/coverage_badge_krkn.svg)
 ![action](https://github.com/krkn-chaos/krkn/actions/workflows/tests.yml/badge.svg)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10548/badge)](https://www.bestpractices.dev/projects/10548)
+[![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/krkn/badge)](https://clomonitor.io/projects/cncf/krkn)
 
 ![Krkn logo](media/logo.png)
 


### PR DESCRIPTION
# Description  
Adding a CLOMonitor badge to readme

- Closes #1269

<img width="298" height="173" alt="image" src="https://github.com/user-attachments/assets/ba20fba3-bb49-4778-93cc-c94e0fca9b3d" />


I have manually tested and on clicking the badge, it is redirecting to the correct link, i.e., https://clomonitor.io/projects/cncf/krkn.