### PR TITLE
added community meeting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,8 @@ We are always looking for more enhancements, fixes to make it better, any contri
 Key Members(slack_usernames/full name): paigerube14/Paige Rubendall, mffiedler/Mike Fiedler, tsebasti/Tullio Sebastiani, yogi/Yogananth Subramanian, sahil/Sahil Shah, pradeep/Pradeep Surisetty and ravielluri/Naga Ravi Chaitanya Elluri.
 * [**#krkn on Kubernetes Slack**](https://kubernetes.slack.com/messages/C05SFMHRWK1)
 
+
+### Community Meeting
+If you have any questions that you think could be better discussed on a meeting, we have [monthly office hours](https://zoom-lfx.platform.linuxfoundation.org/meetings/krkn?view=month). Please add items to the agenda beforehand so we can best prepare to help you.
+
 The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [Trademark Usage](https://www.linuxfoundation.org/legal/trademark-usage).


### PR DESCRIPTION
I have tried to copy what was written in the documentation site to avoid confusion.
<img width="882" height="104" alt="image" src="https://github.com/user-attachments/assets/3735a984-75a0-457f-92a0-dc9bde0ab1e1" />

This text matches the regex stated in the CLOMonitor checks documentation.
Link -> https://clomonitor.io/docs/topics/checks/#legal
<img width="952" height="332" alt="image" src="https://github.com/user-attachments/assets/389527ea-1c00-4c56-877f-d7a733de2187" />



Fixes #1281 