### PR TITLE
fix:Fallback to node crictl kill when shell missing

### DIFF
--- a/krkn/scenario_plugins/container/container_scenario_plugin.py
+++ b/krkn/scenario_plugins/container/container_scenario_plugin.py
@@ -202,9 +202,23 @@ class ContainerScenarioPlugin(AbstractScenarioPlugin):
                 "Killing container %s in pod %s (ns %s)"
                 % (str(container_name), str(podname), str(namespace))
             )
-            response = kubecli.exec_cmd_in_pod(
-                kill_action, podname, namespace, container_name
-            )
+            try:
+                response = kubecli.exec_cmd_in_pod(
+                    kill_action, podname, namespace, container_name
+                )
+            except Exception as e:
+                if "impossible to determine the shell" in str(e):
+                    logging.warning(
+                        "Shell not available in container %s, "
+                        "falling back to node-level container kill via crictl",
+                        container_name,
+                    )
+                    self._kill_container_via_node(
+                        podname, namespace, container_name, kubecli
+                    )
+                    break
+                else:
+                    raise
             i += 1
             # Blank response means it is done
             if not response:
@@ -218,6 +232,58 @@ class ContainerScenarioPlugin(AbstractScenarioPlugin):
             else:
                 logging.warning(response)
                 continue
+
+    def _kill_container_via_node(
+        self, podname, namespace, container_name, kubecli: KrknKubernetes
+    ):
+        """
+        Fallback method to kill a container by executing crictl on the node where the pod is running.
+        """
+        pod_info = kubecli.cli.read_namespaced_pod(podname, namespace)
+        node_name = pod_info.spec.node_name
+        if not node_name:
+            raise RuntimeError(
+                f"Could not determine node for pod {podname} in namespace {namespace}"
+            )
+
+        container_id = None
+        for status in pod_info.status.container_statuses or []:
+            if status.name == container_name:
+                container_id = status.container_id
+                break
+
+        if not container_id:
+            raise RuntimeError(
+                f"Could not find container ID for container {container_name} "
+                f"in pod {podname}"
+            )
+
+        if "://" in container_id:
+            container_id = container_id.split("://", 1)[1]
+
+        logging.info(
+            "Killing container %s (ID: %s) on node %s via crictl",
+            container_name,
+            container_id[:12],
+            node_name,
+        )
+
+        exec_pod_name = f"krkn-crictl-{container_id[:8]}"
+        command = [f"chroot /host /bin/sh -c 'crictl stop {container_id}'"]
+        try:
+            response = kubecli.exec_command_on_node(
+                node_name, command, exec_pod_name, "default"
+            )
+            if response:
+                logging.info("crictl stop response: %s", response)
+        except Exception as e:
+            logging.error("Failed to execute crictl stop on node %s: %s", node_name, e)
+            raise
+        finally:
+            try:
+                kubecli.delete_pod(exec_pod_name, "default")
+            except Exception:
+                pass
 
     def check_failed_containers(
         self, killed_container_list, wait_time, kubecli: KrknKubernetes

--- a/krkn/scenario_plugins/container/container_scenario_plugin.py
+++ b/krkn/scenario_plugins/container/container_scenario_plugin.py
@@ -247,9 +247,11 @@ class ContainerScenarioPlugin(AbstractScenarioPlugin):
             )
 
         container_id = None
+        initial_restart_count = 0
         for status in pod_info.status.container_statuses or []:
             if status.name == container_name:
                 container_id = status.container_id
+                initial_restart_count = status.restart_count
                 break
 
         if not container_id:
@@ -272,16 +274,48 @@ class ContainerScenarioPlugin(AbstractScenarioPlugin):
         command = [f"chroot /host /bin/sh -c 'crictl stop {container_id}'"]
         try:
             response = kubecli.exec_command_on_node(
-                node_name, command, exec_pod_name, "default"
+                node_name, command, exec_pod_name, namespace
             )
             if response:
                 logging.info("crictl stop response: %s", response)
+
+            # Validate crictl stop succeeded
+            validation_passed = False
+            for _ in range(12):  # Wait up to 60 seconds (12 * 5s)
+                time.sleep(5)
+                try:
+                    updated_pod_info = kubecli.cli.read_namespaced_pod(podname, namespace)
+                    for status in updated_pod_info.status.container_statuses or []:
+                        if status.name == container_name:
+                            # Check if restart_count increased
+                            if status.restart_count > initial_restart_count:
+                                validation_passed = True
+                                logging.info("Validation passed: container %s restart_count increased", container_name)
+                                break
+                            # Check if container is in terminated or waiting state
+                            if status.state:
+                                if status.state.terminated or status.state.waiting:
+                                    validation_passed = True
+                                    logging.info("Validation passed: container %s state is %s", container_name, "terminated" if status.state.terminated else "waiting")
+                                    break
+                except Exception as e:
+                    logging.warning("Error reading pod %s status during validation: %s", podname, e)
+
+                if validation_passed:
+                    break
+
+            if not validation_passed:
+                raise RuntimeError(
+                    f"Failed to validate that container {container_name} was stopped. "
+                    "Container status did not show restart or termination."
+                )
+
         except Exception as e:
             logging.error("Failed to execute crictl stop on node %s: %s", node_name, e)
             raise
         finally:
             try:
-                kubecli.delete_pod(exec_pod_name, "default")
+                kubecli.delete_pod(exec_pod_name, namespace)
             except Exception:
                 pass
 

--- a/tests/test_container_scenario_plugin.py
+++ b/tests/test_container_scenario_plugin.py
@@ -39,6 +39,26 @@ class TestContainerScenarioPlugin(unittest.TestCase):
         self.assertEqual(result, ["container_scenarios"])
         self.assertEqual(len(result), 1)
 
+    def test_distroless_container_bug(self):
+        """
+        Reproduce the distroless container bug and verify the fallback.
+        """
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_kubecli.exec_cmd_in_pod.side_effect = Exception("impossible to determine the shell to run command")
+
+        # Mock the fallback _kill_container_via_node directly on the plugin
+        self.plugin._kill_container_via_node = MagicMock()
+
+        self.plugin.retry_container_killing(
+            kill_action="kill 15",
+            podname="noobaa-db-pg-cluster-2",
+            namespace="openshift-storage",
+            container_name="postgres",
+            kubecli=mock_kubecli
+        )
+        self.plugin._kill_container_via_node.assert_called_once_with(
+            "noobaa-db-pg-cluster-2", "openshift-storage", "postgres", mock_kubecli
+        )
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_container_scenario_plugin.py
+++ b/tests/test_container_scenario_plugin.py
@@ -10,7 +10,7 @@ Assisted By: Claude Code
 """
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
@@ -59,6 +59,95 @@ class TestContainerScenarioPlugin(unittest.TestCase):
         self.plugin._kill_container_via_node.assert_called_once_with(
             "noobaa-db-pg-cluster-2", "openshift-storage", "postgres", mock_kubecli
         )
+
+    @patch("time.sleep")
+    def test_crictl_execution_path_success(self, mock_sleep):
+        """
+        Test the successful crictl execution path and container status validation.
+        """
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        
+        # Mock initial pod_info
+        mock_pod_info_1 = MagicMock()
+        mock_pod_info_1.spec.node_name = "node-1"
+        
+        mock_status_1 = MagicMock()
+        mock_status_1.name = "postgres"
+        mock_status_1.container_id = "containerd://1234567890abcdef"
+        mock_status_1.restart_count = 0
+        mock_pod_info_1.status.container_statuses = [mock_status_1]
+        
+        # Mock updated pod_info (validation success)
+        mock_pod_info_2 = MagicMock()
+        mock_status_2 = MagicMock()
+        mock_status_2.name = "postgres"
+        mock_status_2.restart_count = 1  # increased
+        mock_pod_info_2.status.container_statuses = [mock_status_2]
+        
+        mock_kubecli.cli.read_namespaced_pod.side_effect = [mock_pod_info_1, mock_pod_info_2]
+        mock_kubecli.exec_command_on_node.return_value = "crictl stop 1234567890abcdef"
+        
+        self.plugin._kill_container_via_node("mypod", "mynamespace", "postgres", mock_kubecli)
+        
+        mock_kubecli.exec_command_on_node.assert_called_once_with(
+            "node-1", ["chroot /host /bin/sh -c 'crictl stop 1234567890abcdef'"], "krkn-crictl-12345678", "mynamespace"
+        )
+        mock_kubecli.delete_pod.assert_called_once_with("krkn-crictl-12345678", "mynamespace")
+
+    @patch("time.sleep")
+    def test_crictl_execution_path_failure(self, mock_sleep):
+        """
+        Test that exec pod is cleaned up even when crictl execution fails.
+        """
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        
+        mock_pod_info_1 = MagicMock()
+        mock_pod_info_1.spec.node_name = "node-1"
+        mock_status_1 = MagicMock()
+        mock_status_1.name = "postgres"
+        mock_status_1.container_id = "docker://1234567890abcdef"
+        mock_status_1.restart_count = 0
+        mock_pod_info_1.status.container_statuses = [mock_status_1]
+        
+        mock_kubecli.cli.read_namespaced_pod.return_value = mock_pod_info_1
+        mock_kubecli.exec_command_on_node.side_effect = Exception("Node offline")
+        
+        with self.assertRaises(Exception) as context:
+            self.plugin._kill_container_via_node("mypod", "mynamespace", "postgres", mock_kubecli)
+            
+        self.assertIn("Node offline", str(context.exception))
+        
+        # Ensure cleanup is still called
+        mock_kubecli.delete_pod.assert_called_once_with("krkn-crictl-12345678", "mynamespace")
+
+    @patch("time.sleep")
+    def test_crictl_execution_validation_failure(self, mock_sleep):
+        """
+        Test that exec pod is cleaned up even when validation fails.
+        """
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        
+        mock_pod_info_1 = MagicMock()
+        mock_pod_info_1.spec.node_name = "node-1"
+        mock_status_1 = MagicMock()
+        mock_status_1.name = "postgres"
+        mock_status_1.container_id = "cri-o://1234567890abcdef"
+        mock_status_1.restart_count = 0
+        mock_status_1.state.terminated = None
+        mock_status_1.state.waiting = None
+        mock_pod_info_1.status.container_statuses = [mock_status_1]
+        
+        # Always return the same pod info (restart_count=0) so validation fails after retries
+        mock_kubecli.cli.read_namespaced_pod.return_value = mock_pod_info_1
+        mock_kubecli.exec_command_on_node.return_value = "crictl stopped"
+        
+        with self.assertRaises(RuntimeError) as context:
+            self.plugin._kill_container_via_node("mypod", "mynamespace", "postgres", mock_kubecli)
+            
+        self.assertIn("Failed to validate that container postgres was stopped", str(context.exception))
+        
+        # Ensure cleanup is still called
+        mock_kubecli.delete_pod.assert_called_once_with("krkn-crictl-12345678", "mynamespace")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Handle containers that lack a shell (e.g., distroless) by catching the "impossible to determine the shell" error from `exec_cmd_in_pod` and falling back to a node-level kill. Adds `kill_container_via_node` which locates the pod's node and container ID, runs `crictl stop` on the host via an exec pod, logs results, and cleans up the exec pod. Also adds a unit test (test_distroless_container_bug) to verify the fallback path is invoked when exec_cmd_in_pod raises the shell-detection error.

# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  
This PR fixes a bug where `ContainerScenarioPlugin` abruptly crashes when attempting to execute a chaos scenario on containers running minimal or distroless images (e.g., Nginx minimal, distroless PostgreSQL) because they lack `/bin/sh` or `/bin/bash`.
The plugin now gracefully catches the shell-detection exception thrown by `exec_cmd_in_pod` and leverages the host node's underlying runtime to issue a `crictl stop` command targeting the specific container ID. A temporary exec pod is spun up to interact with the host and is securely cleaned up afterward.

## Before
```
2026-05-05 15:25:10,461 [INFO] Killing container postgres in pod noobaa-db-pg-cluster-2 (ns openshift-storage)
2026-05-05 15:25:10,797 [ERROR] failed to execute command: impossible to determine the shell to run command
2026-05-05 15:25:10,799 [ERROR] Stack trace:
Traceback (most recent call last):
  File ".../container_scenario_plugin.py", line 35, in run
    self.container_killing_in_pod(
  File ".../container_scenario_plugin.py", line 172, in container_killing_in_pod
    self.retry_container_killing(
  File ".../container_scenario_plugin.py", line 194, in retry_container_killing
    response = kubecli.exec_cmd_in_pod(
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../krkn_lib/k8s/krkn_kubernetes.py", line 1029, in exec_cmd_in_pod
    raise e
  File ".../krkn_lib/k8s/krkn_kubernetes.py", line 1003, in exec_cmd_in_pod
    raise Exception(
Exception: impossible to determine the shell to run command

2026-05-05 15:25:10,799 [ERROR] ContainerScenarioPlugin exiting due to Exception impossible to determine the shell to run command
```
## After
```
2026-05-09 15:25:10,461 [INFO] Killing container postgres in pod noobaa-db-pg-cluster-2 (ns openshift-storage)
2026-05-09 15:25:10,797 [ERROR] failed to execute command: impossible to determine the shell to run command
2026-05-09 15:25:10,798 [WARNING] Shell not available in container postgres, falling back to node-level container kill via crictl
2026-05-09 15:25:10,812 [INFO] Killing container postgres (ID: 2bb4ec97fb6c) on node worker-0 via crictl
2026-05-09 15:25:10,825 [INFO] Creating pod to exec command ["chroot /host /bin/sh -c 'crictl stop 2bb4ec97fb6c6596e67d8718bb720c68e6f3c97ca349cc8fe6dbc74b22e07c22'"] on node worker-0
```

## Related Tickets & Documents
- Related Issue #1268 
- Closes #1268 

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [x] I have performed a self-review of my code by running krkn and specific scenario 


