### PR TITLE
implemented the fix for service hijacking along with modifying tests

### DIFF
--- a/krkn/scenario_plugins/service_hijacking/service_hijacking_scenario_plugin.py
+++ b/krkn/scenario_plugins/service_hijacking/service_hijacking_scenario_plugin.py
@@ -101,6 +101,7 @@ class ServiceHijackingScenarioPlugin(AbstractScenarioPlugin):
                 "service_namespace": service_namespace,
                 "original_selectors": original_service["spec"]["selector"],
                 "webservice_pod_name": webservice.pod_name,
+                "webservice_config_map_name": webservice.config_map_name,
             }
             json_str = json.dumps(rollback_data)
             encoded_data = base64.b64encode(json_str.encode("utf-8")).decode("utf-8")
@@ -161,6 +162,7 @@ class ServiceHijackingScenarioPlugin(AbstractScenarioPlugin):
             service_namespace = rollback_data["service_namespace"]
             original_selectors = rollback_data["original_selectors"]
             webservice_pod_name = rollback_data["webservice_pod_name"]
+            webservice_config_map_name = rollback_data.get("webservice_config_map_name")
             
             logging.info(
                 f"Rolling back service hijacking: restoring service {service_name} in namespace {service_namespace}"
@@ -193,7 +195,22 @@ class ServiceHijackingScenarioPlugin(AbstractScenarioPlugin):
                 logging.info(f"Successfully deleted hijacker pod: {webservice_pod_name}")
             except Exception as e:
                 logging.warning(f"Failed to delete hijacker pod {webservice_pod_name}: {e}")
-            
+
+            # Delete the hijacker ConfigMap (created alongside the pod by deploy_service_hijacking)
+            if webservice_config_map_name:
+                logging.info(f"Deleting hijacker ConfigMap: {webservice_config_map_name}")
+                try:
+                    lib_telemetry.get_lib_kubernetes().cli.delete_namespaced_config_map(
+                        webservice_config_map_name, service_namespace
+                    )
+                    logging.info(
+                        f"Successfully deleted hijacker ConfigMap: {webservice_config_map_name}"
+                    )
+                except Exception as e:
+                    logging.warning(
+                        f"Failed to delete hijacker ConfigMap {webservice_config_map_name}: {e}"
+                    )
+
             logging.info("Service hijacking rollback completed successfully.")
         except Exception as e:
             logging.error(f"Failed to rollback service hijacking: {e}")

--- a/tests/test_service_hijacking_scenario_plugin.py
+++ b/tests/test_service_hijacking_scenario_plugin.py
@@ -51,6 +51,7 @@ class TestRollbackServiceHijacking(unittest.TestCase):
             "service_namespace": "default",
             "original_selectors": {"app": "original-app"},
             "webservice_pod_name": "test-webservice",
+            "webservice_config_map_name": "test-webservice-cm",
         }
         json_str = json.dumps(rollback_data)
         encoded_data = base64.b64encode(json_str.encode("utf-8")).decode("utf-8")
@@ -71,6 +72,7 @@ class TestRollbackServiceHijacking(unittest.TestCase):
             "metadata": {"name": "test-service"}
         }
         mock_lib_kubernetes.delete_pod.return_value = None
+        mock_lib_kubernetes.cli.delete_namespaced_config_map.return_value = None
 
         # Call the rollback method
         ServiceHijackingScenarioPlugin.rollback_service_hijacking(
@@ -84,6 +86,44 @@ class TestRollbackServiceHijacking(unittest.TestCase):
         mock_lib_kubernetes.delete_pod.assert_called_once_with(
             "test-webservice", "default"
         )
+        mock_lib_kubernetes.cli.delete_namespaced_config_map.assert_called_once_with(
+            "test-webservice-cm", "default"
+        )
+
+    def test_rollback_service_hijacking_legacy_data_without_configmap(self):
+        """
+        Backwards compatibility: rollback data written before the ConfigMap-cleanup fix
+        is missing webservice_config_map_name. Rollback should still restore selectors
+        and delete the pod without raising.
+        """
+        rollback_data = {
+            "service_name": "test-service",
+            "service_namespace": "default",
+            "original_selectors": {"app": "original-app"},
+            "webservice_pod_name": "test-webservice",
+        }
+        encoded_data = base64.b64encode(
+            json.dumps(rollback_data).encode("utf-8")
+        ).decode("utf-8")
+        rollback_content = RollbackContent(
+            resource_identifier=encoded_data, namespace="default"
+        )
+
+        mock_lib_telemetry = MagicMock()
+        mock_lib_kubernetes = MagicMock()
+        mock_lib_telemetry.get_lib_kubernetes.return_value = mock_lib_kubernetes
+        mock_lib_kubernetes.replace_service_selector.return_value = {
+            "metadata": {"name": "test-service"}
+        }
+
+        ServiceHijackingScenarioPlugin.rollback_service_hijacking(
+            rollback_content, mock_lib_telemetry
+        )
+
+        mock_lib_kubernetes.delete_pod.assert_called_once_with(
+            "test-webservice", "default"
+        )
+        mock_lib_kubernetes.cli.delete_namespaced_config_map.assert_not_called()
 
     @patch("krkn.scenario_plugins.service_hijacking.service_hijacking_scenario_plugin.logging")
     def test_rollback_service_hijacking_invalid_data(self, mock_logging):
@@ -174,6 +214,7 @@ class TestServiceHijackingRun(unittest.TestCase):
         mock_webservice = MagicMock()
         mock_webservice.pod_name = "hijacker-pod"
         mock_webservice.selector = "app=hijacker"
+        mock_webservice.config_map_name = "hijacker-cm"
         mock_lib_kubernetes.deploy_service_hijacking.return_value = mock_webservice
         mock_lib_kubernetes.replace_service_selector.return_value = {
             "metadata": {"name": "nginx-service"},
@@ -235,6 +276,7 @@ class TestServiceHijackingRun(unittest.TestCase):
         mock_webservice = MagicMock()
         mock_webservice.pod_name = "hijacker-pod"
         mock_webservice.selector = "app=hijacker"
+        mock_webservice.config_map_name = "hijacker-cm"
         mock_lib_kubernetes.deploy_service_hijacking.return_value = mock_webservice
         # Patching returns None (failure)
         mock_lib_kubernetes.replace_service_selector.return_value = None
@@ -262,6 +304,7 @@ class TestServiceHijackingRun(unittest.TestCase):
         mock_webservice = MagicMock()
         mock_webservice.pod_name = "hijacker-pod"
         mock_webservice.selector = "app=hijacker"
+        mock_webservice.config_map_name = "hijacker-cm"
         mock_lib_kubernetes.deploy_service_hijacking.return_value = mock_webservice
         # First call (patch) succeeds, second call (restore) fails
         mock_lib_kubernetes.replace_service_selector.side_effect = [
@@ -294,6 +337,7 @@ class TestServiceHijackingRun(unittest.TestCase):
         mock_webservice = MagicMock()
         mock_webservice.pod_name = "hijacker-pod"
         mock_webservice.selector = "app=hijacker"
+        mock_webservice.config_map_name = "hijacker-cm"
         mock_lib_kubernetes.deploy_service_hijacking.return_value = mock_webservice
         mock_lib_kubernetes.replace_service_selector.return_value = {
             "metadata": {"name": "nginx-service"},
@@ -327,6 +371,7 @@ class TestServiceHijackingRun(unittest.TestCase):
         mock_webservice = MagicMock()
         mock_webservice.pod_name = "hijacker-pod"
         mock_webservice.selector = "app=hijacker"
+        mock_webservice.config_map_name = "hijacker-cm"
         mock_lib_kubernetes.deploy_service_hijacking.return_value = mock_webservice
         mock_lib_kubernetes.replace_service_selector.return_value = {
             "metadata": {"name": "nginx-service"},
@@ -381,6 +426,7 @@ class TestServiceHijackingRun(unittest.TestCase):
         mock_webservice = MagicMock()
         mock_webservice.pod_name = "hijacker-pod"
         mock_webservice.selector = "app=hijacker"
+        mock_webservice.config_map_name = "hijacker-cm"
         mock_lib_kubernetes.deploy_service_hijacking.return_value = mock_webservice
         mock_lib_kubernetes.replace_service_selector.return_value = {
             "metadata": {"name": "nginx-service"},


### PR DESCRIPTION
## Description

Fixes #1230.

The service hijacking scenario was leaving residue in the target namespace after a chaos run completed. While the existing rollback logic correctly restored the original service selectors and deleted the hijacker pod, the ConfigMap that `deploy_service_hijacking` creates alongside the pod (which holds the encoded response plan mounted into the hijacker container) was never cleaned up. Every run therefore orphaned a ConfigMap, which interfered with rerunning the same scenario back to back and left the namespace in a dirty state.

This change captures the ConfigMap name returned by `deploy_service_hijacking` at the point the hijacker is deployed and persists it inside the base64 encoded rollback payload alongside the existing pod name and original selectors. During rollback, the plugin reads that field and deletes the matching namespaced ConfigMap through the Kubernetes client, mirroring how the hijacker pod is already torn down. The deletion is wrapped in a `try`/`except` so a missing or already removed ConfigMap is logged as a warning rather than aborting the rest of the rollback. The new field is also read with `.get()` so any rollback data persisted by an older build of Krkn (where the key does not exist) still drives a complete rollback of the selector and the pod without raising.

## Verification

To confirm the fix end to end I deployed a standard `nginx` Deployment and Service into the `default` namespace of a kind cluster, then ran the service hijacking scenario using `scenarios/kube/service_hijacking.yaml` with the configuration shown in the issue. During the run I observed that the service selector switched to the hijacker selector and `curl` against the service returned the configured payloads for the duration of the chaos. After the scenario completed I inspected the namespace with `kubectl get svc nginx -o yaml`, `kubectl get pods` and `kubectl get configmaps`. The service selector was back to `app: nginx`, the hijacker pod was gone, and the previously orphaned hijacker ConfigMap was no longer present. Repeating the run immediately afterwards completed cleanly without colliding with leftover state from the previous run, which was the original failure mode described in the issue.

## Tests

The unit tests in `tests/test_service_hijacking_scenario_plugin.py` were updated so that the mocked webservice object exposes a `config_map_name` attribute everywhere `deploy_service_hijacking` is mocked. The existing rollback test now asserts that `delete_namespaced_config_map` is called with the expected name and namespace. A new test, `test_rollback_service_hijacking_legacy_data_without_configmap`, encodes a rollback payload that omits the new field and verifies that rollback still restores the selector and deletes the pod while leaving the ConfigMap deletion path untouched, which guards the backwards compatibility branch on the `.get()` read. All tests pass under `python -m unittest discover -s tests -v`.

In case of screenshots needed, please let me know 😅 .