### PR TITLE
feat: add wait_until condition support for chaos scenarios

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,29 @@ Implement: stop, start, reboot, terminate instances.
     scenario_type: <type>  # Must match plugin's get_scenario_types()
 ```
 
+### Wait Until Condition
+
+Scenarios support an optional `wait_until` block that polls a user-provided condition after chaos injection and before log collection. This allows waiting for the system to recover (e.g., pods ready, endpoints healthy) instead of using a fixed sleep.
+
+```yaml
+- id: kill-pods
+  config:
+    namespace_pattern: ^openshift-etcd$
+  wait_until:
+    type: python                          # "python" or "script"
+    target: my_module.check_pods_ready    # module.function or /path/to/script.sh
+    max_wait_time: 300                    # max seconds to wait (required)
+    poll_interval: 5                      # seconds between checks (default: 10)
+```
+
+**Condition types:**
+- **`python`**: `target` is a `module.function` path. Signature: `(kubeconfig: str, scenario: str) -> bool`. Return `True` when condition is met.
+- **`script`**: `target` is a path to a shell script. Receives kubeconfig and scenario path as arguments. Exit code `0` = condition met.
+
+**Timeout behavior**: If the condition is not met within `max_wait_time`, krkn logs a warning and continues — it does not fail the scenario.
+
+**Implementation**: `krkn/utils/wait_until.py` (polling utility), integrated in `abstract_scenario_plugin.py` after rollback and before `end_timestamp`/log collection.
+
 ## Code Style
 
 - **Import order**: Standard library, third-party, local imports

--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -150,14 +150,20 @@ class AbstractScenarioPlugin(ABC):
                     telemetry, run_uuid, scenario_telemetry.scenario_type
                 )
             wait_config = _parse_wait_until(scenario_config)
-            if wait_config:
-                kubeconfig = krkn_config.get("kraken", {}).get(
-                    "kubeconfig_path", ""
-                )
-                condition_met = wait_until_condition(
-                    wait_config, kubeconfig, scenario_config
-                )
-                scenario_telemetry.wait_until_met = condition_met
+            if wait_config is not None:
+                try:
+                    kubeconfig = krkn_config.get("kraken", {}).get(
+                        "kubeconfig_path", ""
+                    )
+                    condition_met = wait_until_condition(
+                        wait_config, kubeconfig, scenario_config
+                    )
+                    scenario_telemetry.wait_until_met = condition_met
+                except Exception as e:
+                    logging.warning(
+                        f"wait_until: unexpected error, continuing: {e}"
+                    )
+                    scenario_telemetry.wait_until_met = False
 
             scenario_telemetry.exit_status = return_value
             scenario_telemetry.end_timestamp = time.time()

--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -15,10 +15,13 @@ import logging
 import os
 import time
 from abc import ABC, abstractmethod
+
+import yaml
 from krkn_lib.models.telemetry import ScenarioTelemetry
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 
 from krkn import utils, cerberus
+from krkn.utils.wait_until import wait_until_condition
 from krkn.rollback.handler import (
     RollbackHandler,
     execute_rollback_version_files,
@@ -146,6 +149,16 @@ class AbstractScenarioPlugin(ABC):
                 execute_rollback_version_files(
                     telemetry, run_uuid, scenario_telemetry.scenario_type
                 )
+            wait_config = _parse_wait_until(scenario_config)
+            if wait_config:
+                kubeconfig = krkn_config.get("kraken", {}).get(
+                    "kubeconfig_path", ""
+                )
+                condition_met = wait_until_condition(
+                    wait_config, kubeconfig, scenario_config
+                )
+                scenario_telemetry.wait_until_met = condition_met
+
             scenario_telemetry.exit_status = return_value
             scenario_telemetry.end_timestamp = time.time()
             start_time = int(scenario_telemetry.start_timestamp)
@@ -176,4 +189,22 @@ class AbstractScenarioPlugin(ABC):
             
         return failed_scenarios, scenario_telemetries
 
-    
+
+def _parse_wait_until(scenario_config_path: str) -> dict | None:
+    """
+    Parse a scenario YAML file and extract the wait_until block if present.
+    Returns the wait_until dict or None.
+    """
+    try:
+        with open(scenario_config_path, "r") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict) and "wait_until" in item:
+                    return item["wait_until"]
+        elif isinstance(data, dict) and "wait_until" in data:
+            return data["wait_until"]
+    except Exception as e:
+        logging.warning(f"wait_until: failed to parse '{scenario_config_path}': {e}")
+    return None
+

--- a/krkn/utils/wait_until.py
+++ b/krkn/utils/wait_until.py
@@ -2,9 +2,11 @@ import importlib
 import logging
 import subprocess
 import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
 
 DEFAULT_POLL_INTERVAL = 10
+MAX_SCRIPT_OUTPUT_LEN = 4096
 
 
 def wait_until_condition(
@@ -21,6 +23,12 @@ def wait_until_condition(
     :param scenario: path to the scenario config file
     :return: True if condition was met, False if timed out
     """
+    if not isinstance(wait_config, dict):
+        logging.error(
+            f"wait_until: expected a dict, got {type(wait_config).__name__}"
+        )
+        return False
+
     condition_type = wait_config.get("type")
     target = wait_config.get("target")
     max_wait_time = wait_config.get("max_wait_time")
@@ -29,6 +37,21 @@ def wait_until_condition(
     if not condition_type or not target or max_wait_time is None:
         logging.error(
             "wait_until: missing required fields (type, target, max_wait_time)"
+        )
+        return False
+
+    try:
+        max_wait_time = float(max_wait_time)
+        poll_interval = float(poll_interval)
+    except (TypeError, ValueError):
+        logging.error(
+            "wait_until: max_wait_time and poll_interval must be numeric"
+        )
+        return False
+
+    if max_wait_time <= 0 or poll_interval <= 0:
+        logging.error(
+            "wait_until: max_wait_time and poll_interval must be > 0"
         )
         return False
 
@@ -49,9 +72,16 @@ def wait_until_condition(
 
     deadline = time.time() + max_wait_time
     while time.time() < deadline:
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            break
+        poll_timeout = min(poll_interval, remaining)
+
         try:
             if condition_type == "python":
-                result = check_fn(kubeconfig, scenario)
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    future = executor.submit(check_fn, kubeconfig, scenario)
+                    result = future.result(timeout=poll_timeout)
                 if result:
                     logging.info(f"wait_until: condition '{target}' met")
                     return True
@@ -60,11 +90,24 @@ def wait_until_condition(
                     [target, kubeconfig, scenario],
                     capture_output=True,
                     text=True,
-                    timeout=poll_interval,
+                    timeout=poll_timeout,
                 )
                 if completed.returncode == 0:
                     logging.info(f"wait_until: script '{target}' returned 0, condition met")
                     return True
+                else:
+                    if completed.stderr:
+                        logging.debug(
+                            f"wait_until: script stderr: "
+                            f"{completed.stderr[:MAX_SCRIPT_OUTPUT_LEN]}"
+                        )
+                    if completed.stdout:
+                        logging.debug(
+                            f"wait_until: script stdout: "
+                            f"{completed.stdout[:MAX_SCRIPT_OUTPUT_LEN]}"
+                        )
+        except FuturesTimeoutError:
+            logging.warning(f"wait_until: python condition '{target}' timed out during poll, retrying")
         except subprocess.TimeoutExpired:
             logging.warning(f"wait_until: script '{target}' timed out during poll, retrying")
         except Exception as e:

--- a/krkn/utils/wait_until.py
+++ b/krkn/utils/wait_until.py
@@ -1,0 +1,107 @@
+import importlib
+import logging
+import subprocess
+import time
+
+
+DEFAULT_POLL_INTERVAL = 10
+
+
+def wait_until_condition(
+    wait_config: dict,
+    kubeconfig: str,
+    scenario: str,
+) -> bool:
+    """
+    Polls a user-provided condition (Python function or shell script)
+    until it succeeds or max_wait_time is reached.
+
+    :param wait_config: dict with keys: type, target, max_wait_time, poll_interval
+    :param kubeconfig: path to the kubeconfig file
+    :param scenario: path to the scenario config file
+    :return: True if condition was met, False if timed out
+    """
+    condition_type = wait_config.get("type")
+    target = wait_config.get("target")
+    max_wait_time = wait_config.get("max_wait_time")
+    poll_interval = wait_config.get("poll_interval", DEFAULT_POLL_INTERVAL)
+
+    if not condition_type or not target or max_wait_time is None:
+        logging.error(
+            "wait_until: missing required fields (type, target, max_wait_time)"
+        )
+        return False
+
+    if condition_type == "python":
+        check_fn = _load_python_condition(target)
+        if check_fn is None:
+            return False
+    elif condition_type == "script":
+        check_fn = None
+    else:
+        logging.error(f"wait_until: unknown type '{condition_type}', expected 'python' or 'script'")
+        return False
+
+    logging.info(
+        f"wait_until: polling {condition_type} condition '{target}' "
+        f"every {poll_interval}s (max {max_wait_time}s)"
+    )
+
+    deadline = time.time() + max_wait_time
+    while time.time() < deadline:
+        try:
+            if condition_type == "python":
+                result = check_fn(kubeconfig, scenario)
+                if result:
+                    logging.info(f"wait_until: condition '{target}' met")
+                    return True
+            else:
+                completed = subprocess.run(
+                    [target, kubeconfig, scenario],
+                    capture_output=True,
+                    text=True,
+                    timeout=poll_interval,
+                )
+                if completed.returncode == 0:
+                    logging.info(f"wait_until: script '{target}' returned 0, condition met")
+                    return True
+        except subprocess.TimeoutExpired:
+            logging.warning(f"wait_until: script '{target}' timed out during poll, retrying")
+        except Exception as e:
+            logging.warning(f"wait_until: condition check raised {type(e).__name__}: {e}")
+
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            break
+        time.sleep(min(poll_interval, remaining))
+
+    logging.warning(
+        f"wait_until: condition '{target}' not met within {max_wait_time}s, continuing"
+    )
+    return False
+
+
+def _load_python_condition(target: str):
+    """
+    Import a Python function from a 'module.submodule.function' path.
+    Returns the callable or None on failure.
+    """
+    parts = target.rsplit(".", 1)
+    if len(parts) != 2:
+        logging.error(
+            f"wait_until: invalid python target '{target}', "
+            f"expected 'module.function' format"
+        )
+        return None
+
+    module_path, func_name = parts
+    try:
+        module = importlib.import_module(module_path)
+        func = getattr(module, func_name)
+        if not callable(func):
+            logging.error(f"wait_until: '{target}' is not callable")
+            return None
+        return func
+    except (ImportError, AttributeError) as e:
+        logging.error(f"wait_until: failed to load '{target}': {e}")
+        return None

--- a/tests/test_wait_until.py
+++ b/tests/test_wait_until.py
@@ -87,6 +87,61 @@ class TestWaitUntilConditionPython(unittest.TestCase):
         )
         self.assertFalse(result)
 
+    def test_non_dict_config_returns_false(self):
+        result = wait_until_condition(
+            "not_a_dict",
+            "/fake/kubeconfig",
+            "/fake/scenario.yaml",
+        )
+        self.assertFalse(result)
+
+    def test_string_max_wait_time_coerced(self):
+        mock_fn = MagicMock(return_value=True)
+        with patch(
+            "krkn.utils.wait_until._load_python_condition", return_value=mock_fn
+        ):
+            result = wait_until_condition(
+                {"type": "python", "target": "mod.fn", "max_wait_time": "10", "poll_interval": "1"},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+        self.assertTrue(result)
+
+    def test_non_numeric_max_wait_time_returns_false(self):
+        result = wait_until_condition(
+            {"type": "python", "target": "mod.fn", "max_wait_time": "abc"},
+            "/fake/kubeconfig",
+            "/fake/scenario.yaml",
+        )
+        self.assertFalse(result)
+
+    def test_negative_max_wait_time_returns_false(self):
+        result = wait_until_condition(
+            {"type": "python", "target": "mod.fn", "max_wait_time": -5},
+            "/fake/kubeconfig",
+            "/fake/scenario.yaml",
+        )
+        self.assertFalse(result)
+
+    def test_python_condition_timeout_per_poll(self):
+        import threading
+        event = threading.Event()
+
+        def blocking_fn(kubeconfig, scenario):
+            event.wait(timeout=30)
+            return True
+
+        with patch(
+            "krkn.utils.wait_until._load_python_condition", return_value=blocking_fn
+        ):
+            result = wait_until_condition(
+                {"type": "python", "target": "mod.fn", "max_wait_time": 2, "poll_interval": 0.5},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+        self.assertFalse(result)
+        event.set()
+
 
 class TestWaitUntilConditionScript(unittest.TestCase):
 
@@ -117,6 +172,25 @@ class TestWaitUntilConditionScript(unittest.TestCase):
                 "/fake/scenario.yaml",
             )
         self.assertTrue(result)
+
+    def test_script_failure_logs_output(self):
+        mock_result = MagicMock(returncode=1, stdout="some output", stderr="some error")
+        mock_success = MagicMock(returncode=0, stdout="", stderr="")
+        with patch(
+            "krkn.utils.wait_until.subprocess.run",
+            side_effect=[mock_result, mock_success],
+        ), patch("krkn.utils.wait_until.time.sleep"), patch(
+            "logging.debug"
+        ) as mock_debug:
+            result = wait_until_condition(
+                {"type": "script", "target": "/fake/script.sh", "max_wait_time": 30, "poll_interval": 1},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+        self.assertTrue(result)
+        debug_messages = [str(call) for call in mock_debug.call_args_list]
+        self.assertTrue(any("stderr" in m for m in debug_messages))
+        self.assertTrue(any("stdout" in m for m in debug_messages))
 
     def test_script_timeout(self):
         mock_result = MagicMock(returncode=1)

--- a/tests/test_wait_until.py
+++ b/tests/test_wait_until.py
@@ -1,0 +1,158 @@
+import os
+import stat
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+
+from krkn.utils.wait_until import wait_until_condition, _load_python_condition
+
+
+class TestWaitUntilConditionPython(unittest.TestCase):
+
+    def test_condition_met_immediately(self):
+        mock_fn = MagicMock(return_value=True)
+        with patch(
+            "krkn.utils.wait_until._load_python_condition", return_value=mock_fn
+        ):
+            result = wait_until_condition(
+                {"type": "python", "target": "mod.fn", "max_wait_time": 10, "poll_interval": 1},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+        self.assertTrue(result)
+        mock_fn.assert_called_once_with("/fake/kubeconfig", "/fake/scenario.yaml")
+
+    def test_condition_met_after_retries(self):
+        mock_fn = MagicMock(side_effect=[False, False, True])
+        with patch(
+            "krkn.utils.wait_until._load_python_condition", return_value=mock_fn
+        ), patch("krkn.utils.wait_until.time.sleep"):
+            result = wait_until_condition(
+                {"type": "python", "target": "mod.fn", "max_wait_time": 30, "poll_interval": 1},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+        self.assertTrue(result)
+        self.assertEqual(mock_fn.call_count, 3)
+
+    def test_timeout_returns_false(self):
+        mock_fn = MagicMock(return_value=False)
+        with patch(
+            "krkn.utils.wait_until._load_python_condition", return_value=mock_fn
+        ), patch("krkn.utils.wait_until.time.sleep"), patch(
+            "krkn.utils.wait_until.time.time",
+            side_effect=[0, 0, 5, 5, 11, 11],
+        ):
+            result = wait_until_condition(
+                {"type": "python", "target": "mod.fn", "max_wait_time": 10, "poll_interval": 5},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+        self.assertFalse(result)
+
+    def test_exception_in_condition_does_not_crash(self):
+        mock_fn = MagicMock(side_effect=[RuntimeError("boom"), True])
+        with patch(
+            "krkn.utils.wait_until._load_python_condition", return_value=mock_fn
+        ), patch("krkn.utils.wait_until.time.sleep"):
+            result = wait_until_condition(
+                {"type": "python", "target": "mod.fn", "max_wait_time": 30, "poll_interval": 1},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+        self.assertTrue(result)
+        self.assertEqual(mock_fn.call_count, 2)
+
+    def test_invalid_target_returns_false(self):
+        result = wait_until_condition(
+            {"type": "python", "target": "nonexistent_module.fn", "max_wait_time": 5, "poll_interval": 1},
+            "/fake/kubeconfig",
+            "/fake/scenario.yaml",
+        )
+        self.assertFalse(result)
+
+    def test_missing_required_fields(self):
+        result = wait_until_condition(
+            {"type": "python"},
+            "/fake/kubeconfig",
+            "/fake/scenario.yaml",
+        )
+        self.assertFalse(result)
+
+    def test_unknown_type_returns_false(self):
+        result = wait_until_condition(
+            {"type": "unknown", "target": "something", "max_wait_time": 5},
+            "/fake/kubeconfig",
+            "/fake/scenario.yaml",
+        )
+        self.assertFalse(result)
+
+
+class TestWaitUntilConditionScript(unittest.TestCase):
+
+    def test_script_success(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+            f.write("#!/bin/bash\nexit 0\n")
+            script_path = f.name
+        os.chmod(script_path, os.stat(script_path).st_mode | stat.S_IEXEC)
+
+        try:
+            result = wait_until_condition(
+                {"type": "script", "target": script_path, "max_wait_time": 10, "poll_interval": 1},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+            self.assertTrue(result)
+        finally:
+            os.unlink(script_path)
+
+    def test_script_fails_then_succeeds(self):
+        mock_results = [MagicMock(returncode=1), MagicMock(returncode=0)]
+        with patch(
+            "krkn.utils.wait_until.subprocess.run", side_effect=mock_results
+        ), patch("krkn.utils.wait_until.time.sleep"):
+            result = wait_until_condition(
+                {"type": "script", "target": "/fake/script.sh", "max_wait_time": 30, "poll_interval": 1},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+        self.assertTrue(result)
+
+    def test_script_timeout(self):
+        mock_result = MagicMock(returncode=1)
+        with patch(
+            "krkn.utils.wait_until.subprocess.run", return_value=mock_result
+        ), patch("krkn.utils.wait_until.time.sleep"), patch(
+            "krkn.utils.wait_until.time.time",
+            side_effect=[0, 0, 5, 5, 11, 11],
+        ):
+            result = wait_until_condition(
+                {"type": "script", "target": "/fake/script.sh", "max_wait_time": 10, "poll_interval": 5},
+                "/fake/kubeconfig",
+                "/fake/scenario.yaml",
+            )
+        self.assertFalse(result)
+
+
+class TestLoadPythonCondition(unittest.TestCase):
+
+    def test_invalid_format_no_dot(self):
+        result = _load_python_condition("nofunctionpath")
+        self.assertIsNone(result)
+
+    def test_nonexistent_module(self):
+        result = _load_python_condition("nonexistent_xyz.check")
+        self.assertIsNone(result)
+
+    def test_valid_builtin(self):
+        fn = _load_python_condition("os.path.exists")
+        self.assertIsNotNone(fn)
+        self.assertTrue(callable(fn))
+
+    def test_non_callable_attribute(self):
+        result = _load_python_condition("os.sep")
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds an optional `wait_until` block to scenario configs that polls a user-provided condition (Python function or shell script) after chaos injection and before result collection
- Allows waiting for system recovery (e.g., pods ready, endpoints healthy) instead of relying on a fixed sleep duration
- Integrates into `AbstractScenarioPlugin` between rollback and end-timestamp collection

## Details
- **New utility**: `krkn/utils/wait_until.py` — generic polling loop supporting both `python` (importable `module.function`) and `script` (shell script with exit code) condition types
- **Integration point**: `krkn/scenario_plugins/abstract_scenario_plugin.py` — parses `wait_until` from scenario YAML and invokes the poller after rollback
- **Timeout behavior**: logs a warning and continues if condition is not met within `max_wait_time` — does not fail the scenario

### Example scenario config
```yaml
- id: kill-pods
  config:
    namespace_pattern: ^openshift-etcd$
  wait_until:
    type: python
    target: my_module.check_pods_ready
    max_wait_time: 300
    poll_interval: 5
```

## Test plan
- [x] Unit tests added in `tests/test_wait_until.py`
- [x] Tests cover: immediate success, retry logic, timeout, error handling, invalid configs, script execution
- [ ] Manual validation on a cluster with a real scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)