### PR TITLE
fix(cerberus): fix config key typo and shadowed global in get_status

### DIFF
--- a/krkn/cerberus/setup.py
+++ b/krkn/cerberus/setup.py
@@ -55,7 +55,6 @@ def get_status(start_time, end_time):
         # experience downtime during the chaos
         if check_application_routes:
             application_routes_status, unavailable_routes = application_status(
-                cerberus_url,
                 start_time,
                 end_time
             )

--- a/krkn/cerberus/setup.py
+++ b/krkn/cerberus/setup.py
@@ -32,14 +32,14 @@ def set_url(config):
         cerberus_url = get_yaml_item_value(config["cerberus"],"cerberus_url", "")
         global check_application_routes
         check_application_routes = \
-            get_yaml_item_value(config["cerberus"],"check_applicaton_routes","")
+            get_yaml_item_value(config["cerberus"],"check_application_routes","")
 
 def get_status(start_time, end_time):
     """
     Get cerberus status
     """
+    global check_application_routes
     cerberus_status = True
-    check_application_routes = False
     application_routes_status = True
     if cerberus_enabled:
         if not cerberus_url:

--- a/tests/test_cerberus_setup.py
+++ b/tests/test_cerberus_setup.py
@@ -33,7 +33,7 @@ class TestCerberusSetup(unittest.TestCase):
             "cerberus": {
                 "cerberus_enabled": True,
                 "cerberus_url": "http://cerberus.example.com",
-                "check_applicaton_routes": "route1,route2"
+                "check_application_routes": "route1,route2"
             }
         }
 
@@ -125,26 +125,22 @@ class TestCerberusSetup(unittest.TestCase):
         """Test get_status with application routes check when routes are healthy"""
         cerberus_setup.cerberus_enabled = True
         cerberus_setup.cerberus_url = "http://cerberus.example.com"
-        
-        # Mock both cerberus status check and history endpoint
+        cerberus_setup.check_application_routes = "route1,route2"
+
         def mock_get_side_effect(url, timeout):
             mock_response = MagicMock()
             if "/history?" in url:
-                # History endpoint - no failures
                 mock_response.content = json.dumps({"history": {"failures": []}}).encode()
             else:
-                # Status endpoint
                 mock_response.content = b"True"
             return mock_response
-        
+
         mock_get.side_effect = mock_get_side_effect
 
-        # Note: check_application_routes is set to False locally in get_status()
-        # so we can't test the full flow without modifying the function
-        # This test verifies cerberus status returns True
         result = cerberus_setup.get_status(0, 100)
 
         self.assertTrue(result)
+        self.assertEqual(mock_get.call_count, 2)
 
     @patch('krkn.cerberus.setup.requests.get')
     def test_get_status_with_application_routes_check_failure(self, mock_get):


### PR DESCRIPTION
Fixes #1302

The `check_application_routes` feature in cerberus has been silently broken by two bugs.

`set_url()` was reading the config key `check_applicaton_routes` (missing `i`), so any user using the correct spelling in their config YAML would silently get the empty string default and the feature would be skipped with no error or warning.

`get_status()` had a local variable assignment `check_application_routes = False` on line 42, which shadowed the module-level global set by `set_url()`. The `if check_application_routes:` check on line 56 always saw `False`, so the route checking block never ran regardless of config. The test file itself acknowledged this with a comment saying it couldn't test the full flow.

## Type of change
- [x] Bug fix

## Related Tickets & Documents
- Related Issue #: 1302
- Closes #: 1302

## Documentation
- [ ] Is documentation needed for this update?

A separate PR to the website repo will fix the same typo in `content/en/docs/krkn/config.md`.

## Checklist before requesting a review
- [x] Changes have been discussed in issue #1302
- [x] Self-review performed — both bugs verified by reading the code and the test file comment that acknowledged the shadowed global

## Tests performed

```bash
python -m coverage run -a -m unittest discover -s tests -v
