### PR TITLE
resolve tree formattting to a simplier and better visualization

### DIFF
--- a/krkn/rollback/command.py
+++ b/krkn/rollback/command.py
@@ -88,6 +88,7 @@ def list_rollback(run_uuid: Optional[str]=None, scenario_type: Optional[str]=Non
                     dir_pad = "    " if is_last_dir else "│   "
                     file_pad = "└── " if is_last_file else "├── "
                     file_prefix = dir_pad + file_pad
+                    print(f"{file_prefix}{file}")
                     
             except PermissionError:
                 file_prefix = "    └── " if is_last_dir else "│   └── "

--- a/krkn/rollback/command.py
+++ b/krkn/rollback/command.py
@@ -85,8 +85,9 @@ def list_rollback(run_uuid: Optional[str]=None, scenario_type: Optional[str]=Non
                 files.sort()
                 for j, file in enumerate(files):
                     is_last_file = (j == len(files) - 1)
-                    file_prefix = "    └── " if is_last_dir else "│   └── " if is_last_file else ("│   ├── " if not is_last_dir else "    ├── ")
-                    print(f"{file_prefix}{file}")
+                    dir_pad = "    " if is_last_dir else "│   "
+                    file_pad = "└── " if is_last_file else "├── "
+                    file_prefix = dir_pad + file_pad
                     
             except PermissionError:
                 file_prefix = "    └── " if is_last_dir else "│   └── "


### PR DESCRIPTION
Resolved an issue where all files in the final directory were incorrectly prefixed with `└──`. Now, only the last file uses `└──`, while intermediate files correctly use `├──`.
Replaced a complex, nested ternary expression with a clean, to a readable construction.
Eliminated unreachable logical branches in the previous prefix calculation.

running >> python -m unittest tests/test_rollback.py gives me : 
====== 22 passed ====== 
2 test case might failed but that would be only because of the OS differences. 

closes #1304  