### PR TITLE
fix(ci): narrow customapp_pod scenario to coredns to avoid etcd disrup…

### DIFF
--- a/scenarios/openshift/customapp_pod.yaml
+++ b/scenarios/openshift/customapp_pod.yaml
@@ -2,8 +2,9 @@
 - id: kill-pods
   config:
     namespace_pattern: "kube-system"
-    name_pattern: .*
-    krkn_pod_recovery_time: 60
+    name_pattern: "coredns.*"
+    krkn_pod_recovery_time: 120
+    timeout: 180
     kill: 1     # num of pods to kill
     #Not needed by default, but can be used if you want to target pods on specific nodes
     # Option 1: Target pods on nodes with specific labels [master/worker nodes]


### PR DESCRIPTION
## Summary

- Narrow `name_pattern` from `.*` to `coredns.*` in `customapp_pod.yaml` to prevent accidentally killing etcd on KinD
- Increase `krkn_pod_recovery_time` from 60s to 120s and add explicit `timeout: 180` for reliable recovery on resource-constrained CI runners

## Related Issue

Closes #1314

## Root Cause

The wildcard `name_pattern: .*` could match any pod in `kube-system` on control-plane nodes, including `etcd`. On KinD clusters (used in CI), killing etcd destabilizes the entire cluster and causes cascading failures in subsequent functional tests.

## Changes

**`scenarios/openshift/customapp_pod.yaml`:**
| Field | Before | After |
|-------|--------|-------|
| `name_pattern` | `.*` | `coredns.*` |
| `krkn_pod_recovery_time` | `60` | `120` |
| `timeout` | _(not set)_ | `180` |

## Test Plan

- [x] `test_customapp_pod` still exercises the pod disruption scenario with `node_label_selector`
- [x] CoreDNS pods exist on control-plane nodes in KinD, so the selector remains valid
- [x] No impact on non-KinD (OpenShift) usage — coredns is a safe, representative target