### PR TITLE
fix: add upper bounds to loosely-pinned dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aliyun-python-sdk-core==2.13.36
 aliyun-python-sdk-ecs==4.24.25
 arcaflow-plugin-sdk==0.14.0
-boto3>=1.34.0  # Updated to support urllib3 2.x
+boto3>=1.34.0,<2.0  # Updated to support urllib3 2.x
 azure-identity==1.16.1
 azure-keyvault==4.2.0
 azure-mgmt-compute==30.5.0
@@ -12,11 +12,11 @@ docker>=6.0,<7.0  # docker 7.0+ has breaking changes; upgrade to 7.x to allow re
 gitpython==3.1.50
 google-auth==2.37.0
 google-cloud-compute==1.22.0
-ibm_cloud_sdk_core>=3.20.0  # Requires urllib3>=2.1.0 (compatible with updated boto3)
+ibm_cloud_sdk_core>=3.20.0,<4.0  # Requires urllib3>=2.1.0 (compatible with updated boto3)
 ibm_vpc==0.26.3  # Requires ibm_cloud_sdk_core
 jinja2==3.1.6
 lxml==6.1.0
-kubernetes>=35.0.0
+kubernetes>=35.0.0,<36.0
 krkn-lib==6.0.9
 numpy==1.26.4
 pandas==2.2.0
@@ -28,15 +28,15 @@ pytest==9.0.3
 python-ipmi==0.5.4
 python-openstackclient==6.5.0
 requests<2.32  # requests 2.32+ breaks docker Unix socket support; blocked until docker>=7.0
-requests-unixsocket>=0.4.0  # Required for Docker Unix socket support
-urllib3>=2.6.3  # CVE fixes; kubernetes>=35.0.0 allows urllib3>=2.x
+requests-unixsocket>=0.4.0,<1.0  # Required for Docker Unix socket support
+urllib3>=2.6.3,<3.0  # CVE fixes; kubernetes>=35.0.0 allows urllib3>=2.x
 service_identity==24.1.0
 PyYAML==6.0.1
 setuptools==78.1.1
-wheel>=0.44.0
+wheel>=0.44.0,<1.0
 zope.interface==6.1
 colorlog==6.10.1
 
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
-cryptography>=46.0.7 # pinned to avoid multiple CVEs (subgroup attack, buffer overflow, DNS constraints)
-protobuf>=4.25.8 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=46.0.7,<47.0 # pinned to avoid multiple CVEs (subgroup attack, buffer overflow, DNS constraints)
+protobuf>=4.25.8,<5.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary
Fixes #1315 — Pin all loosely-bounded dependencies in `requirements.txt` by adding upper version bounds to prevent breaking changes from major version bumps.

## Root Cause
Eight dependencies in `requirements.txt` used open-ended `>=` version ranges with no upper cap. These risk pulling in incompatible major versions on fresh installs or CI rebuilds, potentially breaking the build without any code changes.

## Fix
Added upper version bounds (`<major+1`) to all eight dependencies listed in the issue, following the precedent already set by `docker>=6.0,<7.0` and `requests<2.32` in the same file:

| Dependency | Before | After |
|---|---|---|
| boto3 | `>=1.34.0` | `>=1.34.0,<2.0` |
| ibm_cloud_sdk_core | `>=3.20.0` | `>=3.20.0,<4.0` |
| kubernetes | `>=35.0.0` | `>=35.0.0,<36.0` |
| requests-unixsocket | `>=0.4.0` | `>=0.4.0,<1.0` |
| urllib3 | `>=2.6.3` | `>=2.6.3,<3.0` |
| wheel | `>=0.44.0` | `>=0.44.0,<1.0` |
| cryptography | `>=46.0.7` | `>=46.0.7,<47.0` |
| protobuf | `>=4.25.8` | `>=4.25.8,<5.0` |

## Changes
- `requirements.txt` (+8 -8): Added upper version caps to 8 dependencies

## Testing
- [x] All version ranges are now bounded with compatible upper caps
- [x] No existing pinned dependencies were modified
- [x] The `docker>=6.0,<7.0` and `requests<2.32` constraints remain unchanged