### PR TITLE
added PR size labeler

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,34 @@
+name: PR Size Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label PR by size
+        uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: "size/xs"
+          xs_max_size: "10"
+          s_label: "size/s"
+          s_max_size: "100"
+          m_label: "size/m"
+          m_max_size: "500"
+          l_label: "size/l"
+          l_max_size: "1000"
+          xl_label: "size/xl"
+          fail_if_xl: "false"
+          message_if_xl: >
+            This PR exceeds the recommended size of 1000 lines.
+            Please consider splitting it into smaller, focused PRs to make
+            it easier to review and reduce the risk of regressions.
+          files_to_ignore: "requirements.txt *.lock"


### PR DESCRIPTION
I have added a PR size labeler with this change. Appropriate label will be added based upon the size, if the diff is within 10, it would be labeled xs, if within 100, it would be labeled s, if within 500, it would be labeled m, if within 1000, it would be labeled l, and if more than it, an automated comment will be commented telling user to split across various PRs.

If we want to alter the size based upon the diff, let me know. Also, if you want to fail workflow upon XL size, we can set `fail_if_xl` to true to do that. The labels will automatically be created once PR starts creating.

Note: Instead of creating workflow from scratch, I have added action from marketplace which is also used in other popular repos.


Fixes #1318 