### PR TITLE
fix: start_klusterlet_scenario action calls start instead of stop

### DIFF
--- a/krkn/scenario_plugins/managed_cluster/managed_cluster_scenario_plugin.py
+++ b/krkn/scenario_plugins/managed_cluster/managed_cluster_scenario_plugin.py
@@ -115,7 +115,7 @@ class ManagedClusterScenarioPlugin(AbstractScenarioPlugin):
                         run_kill_count, single_managedcluster, timeout
                     )
                 elif action == "start_klusterlet_scenario":
-                    managedcluster_scenario_object.stop_klusterlet_scenario(
+                    managedcluster_scenario_object.start_klusterlet_scenario(
                         run_kill_count, single_managedcluster, timeout
                     )
                 elif action == "stop_klusterlet_scenario":


### PR DESCRIPTION
Fixes #1323

`inject_managedcluster_scenario` in `managed_cluster_scenario_plugin.py` had a copy-paste bug, the `start_klusterlet_scenario` action branch was calling `stop_klusterlet_scenario` on the scenarios object instead of `start_klusterlet_scenario`. Anyone configuring `action: start_klusterlet_scenario` would actually stop the klusterlet (scale to 0 replicas) instead of starting it (scale to 3).

One-line fix: call the correct method.
