### PR TITLE
fix: resolve shared mutable state and list.remove() bugs

### DIFF
--- a/krkn/scenario_plugins/container/container_scenario_plugin.py
+++ b/krkn/scenario_plugins/container/container_scenario_plugin.py
@@ -222,10 +222,17 @@ class ContainerScenarioPlugin(AbstractScenarioPlugin):
     def check_failed_containers(
         self, killed_container_list, wait_time, kubecli: KrknKubernetes
     ):
+        """
+        Check if killed containers have become ready within the specified wait time.
 
-        container_ready = []
+        :param killed_container_list: List of killed containers to check
+        :param wait_time: Maximum time to wait for containers to become ready
+        :param kubecli: Kubernetes client instance
+        :return: List of containers that did not become ready within wait_time
+        """
         timer = 0
         while timer <= wait_time:
+            container_ready = []
             for killed_container in killed_container_list:
                 # pod namespace contain name
                 pod_output = kubecli.get_pod_info(
@@ -238,8 +245,8 @@ class ContainerScenarioPlugin(AbstractScenarioPlugin):
                             container_ready.append(killed_container)
             if len(container_ready) != 0:
                 for item in container_ready:
-                    killed_container_list = killed_container_list.remove(item)
-            if killed_container_list is None or len(killed_container_list) == 0:
+                    killed_container_list.remove(item)
+            if len(killed_container_list) == 0:
                 return []
             timer += 5
             logging.info("Waiting 5 seconds for containers to become ready")

--- a/krkn/scenario_plugins/scenario_plugin_factory.py
+++ b/krkn/scenario_plugins/scenario_plugin_factory.py
@@ -24,11 +24,9 @@ class ScenarioPluginNotFound(Exception):
 
 class ScenarioPluginFactory:
 
-    loaded_plugins: dict[str, Any] = {}
-    failed_plugins: list[Tuple[str, str, str]] = []
-    package_name = None
-
     def __init__(self, package_name: str = "krkn.scenario_plugins"):
+        self.loaded_plugins: dict[str, Any] = {}
+        self.failed_plugins: list[Tuple[str, str, str]] = []
         self.package_name = package_name
         self.__load_plugins(AbstractScenarioPlugin)
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Optimization

## Description

This PR fixes two critical bugs that cause runtime failures in krkn:

### 1. ScenarioPluginFactory Shared Mutable State Issue

**Problem:** Class-level variables (`loaded_plugins`, `failed_plugins`, `package_name`) were shared across all instances of `ScenarioPluginFactory`, causing state pollution between different plugin factory instances.

**Fix:** Moved these variables to instance initialization in the `__init__` method, ensuring each factory instance has its own isolated state.

**Impact:** Prevents plugin loading conflicts and ensures correct plugin registration.

**File:** `krkn/scenario_plugins/scenario_plugin_factory.py`

### 2. Container Plugin list.remove() Return Value Misuse

**Problem:** The code incorrectly assigned the return value of `list.remove()` (which is `None`) back to `killed_container_list`, causing the list to become `None` and subsequent operations to fail.

**Fix:** Removed the incorrect assignment and fixed the conditional check to only test list length.

**Impact:** Ensures container scenario execution completes successfully without runtime errors.

**File:** `krkn/scenario_plugins/container/container_scenario_plugin.py`

## Related Issues

- Related to #1204 

## Files Changed

- `krkn/scenario_plugins/scenario_plugin_factory.py` - Fixed shared mutable state
- `krkn/scenario_plugins/container/container_scenario_plugin.py` - Fixed list.remove() misuse

## Testing

- [x] Self-review performed
- [x] Changes follow project coding standards
- [x] DCO sign-off included in commit
- [x] Verified fixes resolve the identified bugs

## Checklist before requesting a review

- [x] PR has single focused purpose (bug fixes only)
- [x] Commit messages are clear and descriptive
- [x] All commits are signed off (DCO compliant)
- [x] Changes are minimal and targeted
- [x] No unrelated changes included
- [x] Rebased on latest upstream/main

