### PR TITLE
fix(node_actions): replace unstructured print_exc with logging in bar…

### DIFF
--- a/krkn/scenario_plugins/node_actions/bm_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/bm_node_scenarios.py
@@ -253,9 +253,9 @@ class bm_node_scenarios(abstract_node_scenarios):
                     " %s. Test Failed. Most errors are caused by "
                     "an incorrect ipmi address or login" % (e)
                 )
-                traceback.print_exc()
+                logging.error(traceback.format_exc())
                 logging.error("node_reboot_scenario injection failed!")
-                raise e
+                raise
             self.affected_nodes_status.affected_nodes.append(affected_node)
 
     def node_disk_detach_attach_scenario(self, instance_kill_count, node, timeout, duration):


### PR DESCRIPTION
#1334
hi @paigerube14  @chaitanyaenr @ddjain 
# Type of change
* [ ] Refactor
* [ ] New feature
* [x] Bug fix
* [ ] Optimization

# Description

## Problem

In `bm_node_scenarios.py`, the `node_reboot_scenario` exception block used `traceback.print_exc()`, which prints directly to `sys.stderr` and bypasses Kraken’s configured logging handlers. This caused stack traces to be missing from log files and telemetry dashboards during Baremetal reboot failures.

## Solution

Replaced `traceback.print_exc()` with `logging.error(traceback.format_exc())` so exception tracebacks are captured through Kraken’s structured logging pipeline.

## Impact

* Improves debugging by preserving complete stack traces in logs
* Ensures consistency with Kraken logging standards
* Makes Baremetal reboot failure analysis easier in CI/CD and production environments

## Related Tickets & Documents

* Related Issue #: N/A
* Closes #: N/A

# Documentation

* [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)

N/A

# Checklist before requesting a review

* [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
* [x] I have performed a self-review of my code by running krkn and specific scenario
* [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python -m unittest tests.test_node_actions_scenario_plugin

Ran 43 tests in 1.986s

OK
```

## Additional Checklist

* [x] My code follows the code style of this project.
* [x] I have run the unit test suite locally and all tests passed.
* [x] I have signed-off my commits in accordance with Developer Certificate of Origin (DCO).
