### PR TITLE
fix: exempt artifacthub_badge from CLOMonitor (fixes #1294)

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,6 @@
+# CLOMonitor metadata file
+# https://github.com/cncf/clomonitor
+
+exemptions:
+  - check: artifacthub_badge
+    reason: "Krkn is a Python chaos engineering framework, not a Kubernetes artifact type that gets indexed by Artifact Hub."


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix (CI / Audit Check Fix)
- [ ] Optimization

# Description  
Added a `.clomonitor.yml` metadata file at the root of the repository to exempt the project from the CLOMonitor `artifacthub_badge` audit check. 

Krkn is a Python-based chaos engineering framework, not a Kubernetes package or artifact type (like a Helm chart or Operator) that gets indexed by Artifact Hub. Consequently, the Artifact Hub badge check fails inappropriately on CLOMonitor. Adding this exemption resolves the failure and corrects the CLOMonitor audit status.

## Related Tickets & Documents
- Related Issue #: 1294
- Closes #: 1294

# Documentation  
- [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)  
N/A

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [x] I have performed a self-review of my changes.

*REQUIRED*:
Description of combination of tests performed and output of run:

> [!NOTE]
> This is a purely non-code metadata configuration change (`.clomonitor.yml`) used by the CLOMonitor integration. No Python source code, scenarios, or runtime behaviors were modified.

Verified that the YAML syntax is valid:
```yaml
# CLOMonitor metadata file
# https://github.com/cncf/clomonitor

exemptions:
  - check: artifacthub_badge
    reason: "Krkn is a Python chaos engineering framework, not a Kubernetes artifact type that gets indexed by Artifact Hub."
