### PR TITLE
fix(license): resolve check_license.py symlink traversal crash on Windows

### DIFF
--- a/scripts/check_license.py
+++ b/scripts/check_license.py
@@ -32,6 +32,7 @@ Usage:
 import argparse
 import re
 import sys
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -66,10 +67,12 @@ def is_test_file(path: Path) -> bool:
 def collect_source_files() -> list[Path]:
     source_files = []
     excluded_dirs = {".git", ".github", "venv", "venv3111", "build", "dist", "__pycache__", "tests", "CI"}
-    for path in REPO_ROOT.rglob("*.py"):
-        if not any(part in excluded_dirs or part.startswith(".") for part in path.parts):
-            if not is_test_file(path):
-                source_files.append(path)
+    for root, dirs, files in os.walk(REPO_ROOT, followlinks=False):
+        # In-place modify dirs to avoid traversing excluded directories
+        dirs[:] = [d for d in dirs if d not in excluded_dirs and not d.startswith(".")]
+        for file in files:
+            if file.endswith(".py") and not file.startswith("test_"):
+                source_files.append(Path(root) / file)
     return source_files
 
 


### PR DESCRIPTION
#1359
hi @paigerube14 
Type of Change:
Bug fix

Problem: In Windows environments, scripts/check_license.py used Path.rglob("*.py") to search for python source files. On Windows systems, this method attempts to traverse directories in a way that triggers path-not-found or permission issues (such as with symlinks), causing the license checker script to crash with os error 2 during local runs.

Solution: Replaced Path.rglob with os.walk(..., followlinks=False) to safely traverse the repository tree and ignore excluded directories in-place.

Impact: Prevents the license checker from crashing on Windows, ensuring a consistent local development and CI experience across all operating systems.