### PR TITLE
fix(license): add missing copyright and license headers to health che…

### DIFF
--- a/krkn/health_checks/__init__.py
+++ b/krkn/health_checks/__init__.py
@@ -1,3 +1,16 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Health check plugins for krkn chaos engineering framework.
 

--- a/krkn/health_checks/abstract_health_check_plugin.py
+++ b/krkn/health_checks/abstract_health_check_plugin.py
@@ -1,3 +1,16 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import logging
 import queue
 import threading

--- a/krkn/health_checks/health_check_factory.py
+++ b/krkn/health_checks/health_check_factory.py
@@ -1,3 +1,16 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import importlib
 import inspect
 import logging

--- a/krkn/health_checks/http_health_check_plugin.py
+++ b/krkn/health_checks/http_health_check_plugin.py
@@ -1,3 +1,16 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 HTTP Health Check Plugin
 

--- a/krkn/health_checks/simple_health_check_plugin.py
+++ b/krkn/health_checks/simple_health_check_plugin.py
@@ -1,3 +1,16 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Simple Health Check Plugin (for testing the factory)
 

--- a/krkn/scenario_plugins/storage_throttle/__init__.py
+++ b/krkn/scenario_plugins/storage_throttle/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
#1361
hi @paigerube14 
Type of Change:
[ ]Refactor / Documentation

### Problem

Some of the recently added/refactored health check plugin files were missing the standard Apache-2.0 license header. Because of this, the repository’s automated license compliance checks were failing.

The affected files were:

* `krkn/health_checks/__init__.py`
* `krkn/health_checks/abstract_health_check_plugin.py`
* `krkn/health_checks/health_check_factory.py`
* `krkn/health_checks/http_health_check_plugin.py`
* `krkn/health_checks/simple_health_check_plugin.py`
* `krkn/scenario_plugins/storage_throttle/__init__.py`

### Solution

Added the standard Apache-2.0 copyright header to all of the affected files to align them with the repository’s licensing requirements.

### Impact

This restores full license compliance for the affected parts of the codebase and ensures the automated license checks pass successfully.
