### PR TITLE
fix(deps): pin kubernetes client to <36.0.0 to resolve call_api crash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ jinja2==3.1.6
 jaraco-context>=6.1.0  # Fixes GHSA-58pv-8j8x-9vj2
 cbor2<5.7.0  # Pinned by arcaflow-plugin-sdk
 lxml==6.1.0
-kubernetes>=35.0.0
+kubernetes>=35.0.0,<36.0.0
 krkn-lib==6.1.0
 numpy==1.26.4
 pandas==2.2.0


### PR DESCRIPTION
## Type of change
- [x] Bug fix

## Problem
The functional tests fail with `scenario exception: ApiClient.call_api() got an unexpected keyword argument 'response_type'` because the newly released `kubernetes==36.0.1` python client removed the `response_type` argument.

## Solution
Pinned `kubernetes<36.0.0` in `requirements.txt` to restore compatibility with `krkn-lib`.

## Impact
Resolves the critical Python script failure occurring in upstream CI runs.