### PR TITLE
fix: add top-level read-all permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - 'v*'
+
+permissions: read-all
+
 jobs:
   release:
     permissions:


### PR DESCRIPTION
## Summary

- Addresses Scorecard code scanning alert [#4](https://github.com/krkn-chaos/krkn/security/code-scanning/4): **Token-Permissions** (High severity)
- `release.yml` had no top-level `permissions` block, so `GITHUB_TOKEN` defaulted to GitHub's broad write-access defaults across all jobs
- Adding `permissions: read-all` at the top level enforces least privilege by default
- The `release` job already had `permissions: contents: write` at job level — that remains untouched and covers everything the job needs (creating releases, uploading assets)

## Change

```yaml
permissions: read-all   # ← added; restricts default token to read-only

jobs:
  release:
    permissions:
      contents: write   # ← unchanged; job-level write for release creation
```

## Test plan

- [ ] Tag a release and confirm the workflow completes successfully
- [ ] Confirm Scorecard alert #4 is resolved after the next scheduled scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)