### PR TITLE
fix(node-actions): stop_start_kubelet_scenario calls restart_kubelet_scenario instead of node_reboot_scenario

### DIFF
--- a/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/abstract_node_scenarios.py
@@ -103,6 +103,9 @@ class abstract_node_scenarios:
     def stop_start_kubelet_scenario(self, instance_kill_count, node, timeout):
         logging.info("Starting stop_start_kubelet_scenario injection")
         self.stop_kubelet_scenario(instance_kill_count, node, timeout)
+        # node_reboot_scenario is used intentionally: stopping the kubelet leaves the node NotReady,
+        # and oc debug cannot connect to a NotReady node, so restart_kubelet_scenario would fail.
+        # A hard reboot restarts the node and brings it back to Ready state.
         self.node_reboot_scenario(instance_kill_count, node, timeout)
         self.affected_nodes_status.merge_affected_nodes()
         logging.info("stop_start_kubelet_scenario has been successfully injected!")


### PR DESCRIPTION
`stop_start_kubelet_scenario` was calling `node_reboot_scenario` as its second step instead of `restart_kubelet_scenario`, causing a full node reboot instead of a targeted kubelet restart.

The node reboot would evict all pods on the node and take it offline for several minutes, which is not what users expect when running this scenario. Since the node comes back up after a reboot with the kubelet running, the scenario would log success either way and the wrong behavior went unnoticed.

`restart_kubelet_scenario` already exists in the same file. Replaced the incorrect call with it.

Fixes #1367

# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

`stop_start_kubelet_scenario` in `krkn/scenario_plugins/node_actions/abstract_node_scenarios.py` was calling `node_reboot_scenario` instead of `restart_kubelet_scenario`. Replaced with the correct call.

## Related Tickets & Documents

- Related Issue #: 1367
- Closes #: 1367

# Documentation

- [ ] **Is documentation needed for this update?**

# Checklist before requesting a review

- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [ ] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage
