### PR TITLE
fix(health-check): derive final record status from status_code instead of hardcoding True

### DIFF
--- a/krkn/health_checks/http_health_check_plugin.py
+++ b/krkn/health_checks/http_health_check_plugin.py
@@ -249,7 +249,7 @@ class HttpHealthCheckPlugin(AbstractHealthCheckPlugin):
             ).total_seconds()
             final_record = {
                 "url": url,
-                "status": True,
+                "status": health_check_tracker[url]["status_code"] == 200,
                 "status_code": health_check_tracker[url]["status_code"],
                 "start_timestamp": health_check_tracker[url][
                     "start_timestamp"


### PR DESCRIPTION
Fixes #1369

# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

In `run_health_check`, when the chaos run ends, every URL still in `health_check_tracker` gets a final telemetry record written for it. The `status` field in that record was hardcoded to `True`, so any endpoint that was down for the entire run would be recorded as healthy.

The change records written mid-run already derive status correctly:

    "status": previous_status_code == "200",

The final record now uses the same pattern:

    "status": health_check_tracker[url]["status_code"] == 200,

## Related Tickets & Documents

- Related Issue #: 1369
- Closes #: 1369

# Documentation

- [ ] **Is documentation needed for this update?**

# Checklist before requesting a review

- [ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [ ] I have performed a self-review of my code by running krkn and specific scenario