### PR TITLE
fix(container): check_failed_containers exits early after first recovery due to list.remove() misuse

### DIFF
--- a/krkn/scenario_plugins/container/container_scenario_plugin.py
+++ b/krkn/scenario_plugins/container/container_scenario_plugin.py
@@ -223,9 +223,9 @@ class ContainerScenarioPlugin(AbstractScenarioPlugin):
         self, killed_container_list, wait_time, kubecli: KrknKubernetes
     ):
 
-        container_ready = []
         timer = 0
         while timer <= wait_time:
+            container_ready = []
             for killed_container in killed_container_list:
                 # pod namespace contain name
                 pod_output = kubecli.get_pod_info(
@@ -238,7 +238,7 @@ class ContainerScenarioPlugin(AbstractScenarioPlugin):
                             container_ready.append(killed_container)
             if len(container_ready) != 0:
                 for item in container_ready:
-                    killed_container_list = killed_container_list.remove(item)
+                    killed_container_list.remove(item)
             if killed_container_list is None or len(killed_container_list) == 0:
                 return []
             timer += 5


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

`check_failed_containers()` in `krkn/scenario_plugins/container/container_scenario_plugin.py` was assigning the return value of `list.remove()` back to `killed_container_list`. `list.remove()` modifies the list in-place and returns `None`, so after the first recovered container, `killed_container_list` becomes `None`. The next line immediately returns `[]`, leaving all remaining containers unchecked.

Removed the assignment so `list.remove()` operates in-place as intended.

## Related Tickets & Documents

- Related Issue #1372
- Closes #1372

# Documentation

- [ ] Is documentation needed for this update?

# Checklist before requesting a review

- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [ ] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

## Test results

This is a one-line fix removing an incorrect assignment. The bug is triggered by any container scenario that kills more than one container. The scenario reports success after the first container recovers regardless of the rest. The fix makes `list.remove()` operate in-place as intended by Python's list API.
