### PR TITLE
fix(hogs): guard against ZeroDivisionError when samples list is empty

### DIFF
--- a/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
+++ b/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
@@ -134,9 +134,13 @@ class HogsScenarioPlugin(AbstractScenarioPlugin):
                 avg_node_resources.memory += resource.memory
                 avg_node_resources.disk_space += resource.disk_space
 
-            avg_node_resources.cpu = avg_node_resources.cpu/len(samples)
-            avg_node_resources.memory = avg_node_resources.memory / len(samples)
-            avg_node_resources.disk_space = avg_node_resources.disk_space / len(samples)
+            if len(samples) == 0:
+                logging.warning(f"[{node}] no samples collected, duration too short to measure resource usage")
+                return
+            else:
+                avg_node_resources.cpu = avg_node_resources.cpu / len(samples)
+                avg_node_resources.memory = avg_node_resources.memory / len(samples)
+                avg_node_resources.disk_space = avg_node_resources.disk_space / len(samples)
 
             if config.type == HogType.cpu:
                 logging.info(f"[{node}] detected cpu consumption: "

--- a/tests/test_hogs_scenario_plugin.py
+++ b/tests/test_hogs_scenario_plugin.py
@@ -6,14 +6,14 @@ Test suite for HogsScenarioPlugin class
 Usage:
     python -m coverage run -a -m unittest tests/test_hogs_scenario_plugin.py -v
 
-Assisted By: Claude Code
 """
 
+import queue
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from krkn_lib.k8s import KrknKubernetes
-from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+from krkn_lib.models.krkn import HogConfig, HogType
+from krkn_lib.models.k8s import NodeResources
 
 from krkn.scenario_plugins.hogs.hogs_scenario_plugin import HogsScenarioPlugin
 
@@ -21,19 +21,33 @@ from krkn.scenario_plugins.hogs.hogs_scenario_plugin import HogsScenarioPlugin
 class TestHogsScenarioPlugin(unittest.TestCase):
 
     def setUp(self):
-        """
-        Set up test fixtures for HogsScenarioPlugin
-        """
         self.plugin = HogsScenarioPlugin()
 
     def test_get_scenario_types(self):
-        """
-        Test get_scenario_types returns correct scenario type
-        """
         result = self.plugin.get_scenario_types()
-
         self.assertEqual(result, ["hog_scenarios"])
         self.assertEqual(len(result), 1)
+
+    def test_run_scenario_worker_no_samples_no_zero_division(self):
+        config = MagicMock(spec=HogConfig)
+        config.workers = 2
+        config.type = HogType.cpu
+        config.namespace = "default"
+        config.duration = 3
+
+        lib_k8s = MagicMock()
+        lib_k8s.get_node_resources_info.return_value = NodeResources()
+        lib_k8s.is_pod_running.return_value = False
+
+        exception_queue = queue.Queue()
+
+        with patch("krkn.scenario_plugins.hogs.hogs_scenario_plugin.time.sleep"), \
+             patch("krkn.scenario_plugins.hogs.hogs_scenario_plugin.time.time", side_effect=[0, 1000, 1000, 1000]):
+            self.plugin.run_scenario_worker(config, lib_k8s, "test-node", exception_queue)
+
+        if not exception_queue.empty():
+            raise exception_queue.get_nowait()
+        self.assertTrue(exception_queue.empty(), "ZeroDivisionError or other exception raised when samples list is empty")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

`run_scenario_worker()` in `krkn/scenario_plugins/hogs/hogs_scenario_plugin.py` crashes with `ZeroDivisionError` when `config.duration` is too short to collect any samples.

Line 109 has a hardcoded `time.sleep(3)` before the sampling loop. The loop condition on line 115 is:

```python
while time.time() - start < config.duration - 1:
```

If `duration` is 4 or less, 3 seconds have already elapsed by the time the loop starts and `samples` stays empty. Lines 137-139 then crash dividing by `len(samples)` which is 0.

Added a guard that logs a warning and skips the average calculation when no samples were collected. This affects all three hog types: cpu, memory, and io.

## Related Tickets & Documents

- Related Issue #1375
- Closes #1375

# Documentation

- [ ] Is documentation needed for this update?

# Checklist before requesting a review

- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [ ] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

## Test results

This fix adds a guard before the division on lines 137-139. The crash is triggered by setting `duration: 4` or less in any hogs scenario config. The fix logs a warning and skips the average calculation when no samples were collected instead of crashing.
