### PR TITLE
feat: add per-scenario recovery time summary metrics for node actions

### DIFF
--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -45,6 +45,11 @@ from krkn.scenario_plugins.node_actions.ibmcloud_node_scenarios import (
 from krkn.scenario_plugins.node_actions.ibmcloud_power_node_scenarios import (
      ibmcloud_power_node_scenarios,
 )
+
+from krkn.scenario_plugins.node_actions.recovery_time_summary import (
+    build_recovery_time_summary,
+    log_recovery_time_summary,
+)
 node_general = False
 
 
@@ -81,6 +86,15 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                         )
                         end_time = int(time.time())
                         cerberus.get_status(start_time, end_time)
+                        recovery_summary = build_recovery_time_summary(
+                            scenario_telemetry.affected_nodes
+                        )
+
+                        if recovery_summary is not None:
+                            log_recovery_time_summary(action, recovery_summary)
+                            scenario_telemetry.recovery_time_summary = (
+                                recovery_summary.to_dict()
+                            )
                 except (RuntimeError, Exception) as e:
                     logging.error("Node Actions exiting due to Exception %s" % e)
                     return 1

--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -77,6 +77,7 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                     )
                     for action in actions:
                         start_time = int(time.time())
+                        nodes_before = len(scenario_telemetry.affected_nodes)
                         self.inject_node_scenario(
                             action,
                             node_scenario,
@@ -86,9 +87,8 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                         )
                         end_time = int(time.time())
                         cerberus.get_status(start_time, end_time)
-                        recovery_summary = build_recovery_time_summary(
-                            scenario_telemetry.affected_nodes
-                        )
+                        new_nodes = scenario_telemetry.affected_nodes[nodes_before:]
+                        recovery_summary = build_recovery_time_summary(new_nodes)
 
                         if recovery_summary is not None:
                             log_recovery_time_summary(action, recovery_summary)

--- a/krkn/scenario_plugins/node_actions/recovery_time_summary.py
+++ b/krkn/scenario_plugins/node_actions/recovery_time_summary.py
@@ -1,0 +1,112 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from dataclasses import dataclass, field, asdict
+from typing import List, Optional
+
+
+@dataclass
+class RecoveryTimeStats:
+    metric: str
+    count: int = 0
+    min_seconds: float = 0.0
+    max_seconds: float = 0.0
+    avg_seconds: float = 0.0
+
+    def to_dict(self):
+        return asdict(self)
+
+
+@dataclass
+class RecoveryTimeSummary:
+    not_ready_time: RecoveryTimeStats = field(
+        default_factory=lambda: RecoveryTimeStats(metric="not_ready_time")
+    )
+    ready_time: RecoveryTimeStats = field(
+        default_factory=lambda: RecoveryTimeStats(metric="ready_time")
+    )
+    stopped_time: RecoveryTimeStats = field(
+        default_factory=lambda: RecoveryTimeStats(metric="stopped_time")
+    )
+    running_time: RecoveryTimeStats = field(
+        default_factory=lambda: RecoveryTimeStats(metric="running_time")
+    )
+
+    def to_dict(self):
+        return {
+            "not_ready_time": self.not_ready_time.to_dict(),
+            "ready_time": self.ready_time.to_dict(),
+            "stopped_time": self.stopped_time.to_dict(),
+            "running_time": self.running_time.to_dict(),
+        }
+
+
+def _stats_for(metric: str, values: List[float]) -> RecoveryTimeStats:
+    non_zero = [v for v in values if v > 0.0]
+    if not non_zero:
+        return RecoveryTimeStats(metric=metric)
+    return RecoveryTimeStats(
+        metric=metric,
+        count=len(non_zero),
+        min_seconds=round(min(non_zero), 3),
+        max_seconds=round(max(non_zero), 3),
+        avg_seconds=round(sum(non_zero) / len(non_zero), 3),
+    )
+
+
+def build_recovery_time_summary(affected_nodes: list) -> Optional[RecoveryTimeSummary]:
+    if not affected_nodes:
+        return None
+
+    not_ready, ready, stopped, running = [], [], [], []
+
+    for node in affected_nodes:
+        not_ready.append(float(getattr(node, "not_ready_time", 0.0) or 0.0))
+        ready.append(float(getattr(node, "ready_time", 0.0) or 0.0))
+        stopped.append(float(getattr(node, "stopped_time", 0.0) or 0.0))
+        running.append(float(getattr(node, "running_time", 0.0) or 0.0))
+
+    return RecoveryTimeSummary(
+        not_ready_time=_stats_for("not_ready_time", not_ready),
+        ready_time=_stats_for("ready_time", ready),
+        stopped_time=_stats_for("stopped_time", stopped),
+        running_time=_stats_for("running_time", running),
+    )
+
+
+def log_recovery_time_summary(action: str, summary: RecoveryTimeSummary) -> None:
+    logging.info(
+        "[recovery_time_summary] action=%s | "
+        "not_ready: count=%d min=%.3fs max=%.3fs avg=%.3fs | "
+        "ready: count=%d min=%.3fs max=%.3fs avg=%.3fs | "
+        "stopped: count=%d min=%.3fs max=%.3fs avg=%.3fs | "
+        "running: count=%d min=%.3fs max=%.3fs avg=%.3fs",
+        action,
+        summary.not_ready_time.count,
+        summary.not_ready_time.min_seconds,
+        summary.not_ready_time.max_seconds,
+        summary.not_ready_time.avg_seconds,
+        summary.ready_time.count,
+        summary.ready_time.min_seconds,
+        summary.ready_time.max_seconds,
+        summary.ready_time.avg_seconds,
+        summary.stopped_time.count,
+        summary.stopped_time.min_seconds,
+        summary.stopped_time.max_seconds,
+        summary.stopped_time.avg_seconds,
+        summary.running_time.count,
+        summary.running_time.min_seconds,
+        summary.running_time.max_seconds,
+        summary.running_time.avg_seconds,
+    )

--- a/tests/test_recovery_time_summary.py
+++ b/tests/test_recovery_time_summary.py
@@ -1,0 +1,189 @@
+import logging
+import unittest
+from types import SimpleNamespace
+
+from krkn.scenario_plugins.node_actions.recovery_time_summary import (
+    RecoveryTimeStats,
+    _stats_for,
+    build_recovery_time_summary,
+    log_recovery_time_summary,
+)
+
+
+def make_node(not_ready=0.0, ready=0.0, stopped=0.0, running=0.0):
+    return SimpleNamespace(
+        not_ready_time=not_ready,
+        ready_time=ready,
+        stopped_time=stopped,
+        running_time=running,
+    )
+
+
+class TestStatsFor(unittest.TestCase):
+
+    def test_empty_returns_zero_stats(self):
+        result = _stats_for("ready_time", [])
+        self.assertEqual(result.count, 0)
+        self.assertEqual(result.min_seconds, 0.0)
+        self.assertEqual(result.max_seconds, 0.0)
+        self.assertEqual(result.avg_seconds, 0.0)
+
+    def test_all_zeros_treated_as_no_data(self):
+        result = _stats_for("stopped_time", [0.0, 0.0])
+        self.assertEqual(result.count, 0)
+
+    def test_single_value(self):
+        result = _stats_for("ready_time", [42.5])
+        self.assertEqual(result.count, 1)
+        self.assertAlmostEqual(result.min_seconds, 42.5)
+        self.assertAlmostEqual(result.max_seconds, 42.5)
+        self.assertAlmostEqual(result.avg_seconds, 42.5)
+
+    def test_multiple_values(self):
+        result = _stats_for("ready_time", [10.0, 20.0, 30.0])
+        self.assertEqual(result.count, 3)
+        self.assertAlmostEqual(result.min_seconds, 10.0)
+        self.assertAlmostEqual(result.max_seconds, 30.0)
+        self.assertAlmostEqual(result.avg_seconds, 20.0)
+
+    def test_zeros_excluded_from_aggregation(self):
+        result = _stats_for("running_time", [0.0, 15.0, 0.0, 25.0])
+        self.assertEqual(result.count, 2)
+        self.assertAlmostEqual(result.min_seconds, 15.0)
+        self.assertAlmostEqual(result.max_seconds, 25.0)
+        self.assertAlmostEqual(result.avg_seconds, 20.0)
+
+    def test_values_rounded_to_three_decimal_places(self):
+        result = _stats_for("ready_time", [1.0 / 3.0])
+        self.assertEqual(result.avg_seconds, round(1.0 / 3.0, 3))
+
+    def test_metric_name_preserved(self):
+        result = _stats_for("stopped_time", [5.0])
+        self.assertEqual(result.metric, "stopped_time")
+
+
+class TestBuildRecoveryTimeSummary(unittest.TestCase):
+
+    def test_empty_list_returns_none(self):
+        self.assertIsNone(build_recovery_time_summary([]))
+
+    def test_none_returns_none(self):
+        self.assertIsNone(build_recovery_time_summary(None))
+
+    def test_stop_scenario_only_stopped_and_not_ready_populated(self):
+        nodes = [make_node(not_ready=0.18, stopped=140.74)]
+        result = build_recovery_time_summary(nodes)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.stopped_time.count, 1)
+        self.assertAlmostEqual(result.stopped_time.avg_seconds, 140.74)
+        self.assertEqual(result.ready_time.count, 0)
+        self.assertEqual(result.running_time.count, 0)
+
+    def test_start_scenario_only_ready_and_running_populated(self):
+        nodes = [make_node(ready=43.52, running=12.31)]
+        result = build_recovery_time_summary(nodes)
+        self.assertEqual(result.ready_time.count, 1)
+        self.assertAlmostEqual(result.ready_time.avg_seconds, 43.52)
+        self.assertAlmostEqual(result.running_time.avg_seconds, 12.31)
+        self.assertEqual(result.stopped_time.count, 0)
+
+    def test_multiple_nodes_aggregated(self):
+        # mirrors the example from the official krkn docs
+        nodes = [
+            make_node(not_ready=0.182, stopped=140.741),
+            make_node(not_ready=0.161, stopped=146.721),
+            make_node(ready=43.521, running=12.306),
+            make_node(ready=48.333, running=12.052),
+        ]
+        result = build_recovery_time_summary(nodes)
+        self.assertEqual(result.stopped_time.count, 2)
+        self.assertAlmostEqual(result.stopped_time.min_seconds, 140.741, places=2)
+        self.assertAlmostEqual(result.stopped_time.max_seconds, 146.721, places=2)
+        self.assertEqual(result.ready_time.count, 2)
+        expected_avg = round((43.521 + 48.333) / 2, 3)
+        self.assertAlmostEqual(result.ready_time.avg_seconds, expected_avg, places=2)
+
+    def test_missing_attribute_defaults_to_zero(self):
+        bare = SimpleNamespace(ready_time=30.0)
+        result = build_recovery_time_summary([bare])
+        self.assertEqual(result.ready_time.count, 1)
+        self.assertEqual(result.stopped_time.count, 0)
+
+    def test_none_attribute_treated_as_zero(self):
+        node = make_node(ready=None, stopped=50.0)
+        result = build_recovery_time_summary([node])
+        self.assertEqual(result.ready_time.count, 0)
+        self.assertEqual(result.stopped_time.count, 1)
+
+    def test_to_dict_is_json_serializable(self):
+        import json
+        nodes = [make_node(ready=10.0, running=5.0)]
+        result = build_recovery_time_summary(nodes)
+        try:
+            json.dumps(result.to_dict())
+        except TypeError as e:
+            self.fail(f"to_dict() produced non-serializable output: {e}")
+
+    def test_to_dict_has_all_four_keys(self):
+        nodes = [make_node(ready=1.0)]
+        result = build_recovery_time_summary(nodes)
+        self.assertEqual(
+            set(result.to_dict().keys()),
+            {"not_ready_time", "ready_time", "stopped_time", "running_time"},
+        )
+
+
+class TestLogRecoveryTimeSummary(unittest.TestCase):
+
+    def _sample_summary(self):
+        nodes = [
+            make_node(stopped=120.0, not_ready=0.2),
+            make_node(ready=45.0, running=10.0),
+        ]
+        return build_recovery_time_summary(nodes)
+
+    def test_logs_at_info_level(self):
+        summary = self._sample_summary()
+        with self.assertLogs(level=logging.INFO):
+            log_recovery_time_summary("node_stop_start_scenario", summary)
+
+    def test_log_has_prefix(self):
+        summary = self._sample_summary()
+        with self.assertLogs(level=logging.INFO) as ctx:
+            log_recovery_time_summary("node_stop_start_scenario", summary)
+        self.assertTrue(any("[recovery_time_summary]" in line for line in ctx.output))
+
+    def test_log_contains_action_name(self):
+        summary = self._sample_summary()
+        with self.assertLogs(level=logging.INFO) as ctx:
+            log_recovery_time_summary("node_reboot_scenario", summary)
+        self.assertTrue(any("node_reboot_scenario" in line for line in ctx.output))
+
+    def test_log_contains_numeric_values(self):
+        summary = self._sample_summary()
+        with self.assertLogs(level=logging.INFO) as ctx:
+            log_recovery_time_summary("node_stop_scenario", summary)
+        combined = "\n".join(ctx.output)
+        self.assertIn("120.000", combined)
+
+
+class TestRecoveryTimeStatsToDict(unittest.TestCase):
+
+    def test_all_fields_present(self):
+        stats = RecoveryTimeStats(
+            metric="ready_time",
+            count=2,
+            min_seconds=10.0,
+            max_seconds=20.0,
+            avg_seconds=15.0,
+        )
+        d = stats.to_dict()
+        self.assertEqual(d["metric"], "ready_time")
+        self.assertEqual(d["count"], 2)
+        self.assertAlmostEqual(d["min_seconds"], 10.0)
+        self.assertAlmostEqual(d["max_seconds"], 20.0)
+        self.assertAlmostEqual(d["avg_seconds"], 15.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recovery_time_summary.py
+++ b/tests/test_recovery_time_summary.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import logging
 import unittest
 from types import SimpleNamespace


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
Adds a `RecoveryTimeSummary` that computes `min/max/avg` of the four timing fields already tracked per-node by krkn-lib (`not_ready_time`,`ready_time`, `stopped_time`, `running_time`) and surfaces them as an aggregate per-scenario metric after each node action completes.

Addresses the open roadmap item:
"Add recovery time metrics to each scenario for better regression analysis"

The summary is logged with a greppable `[recovery_time_summary]` prefix and attached to `scenario_telemetry` so it flows into the final chaos run output and Elasticsearch.

## Related Tickets & Documents
-Related Issue #: N/A (directly implements open roadmap item)

- Related Issue #: 
- Closes #: N/A

# Documentation  
- [ ] **Is documentation needed for this update?**

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run
<img width="920" height="363" alt="image" src="https://github.com/user-attachments/assets/fb6dee3c-9f52-498b-b114-e781e5ab6087" />


