### PR TITLE
Fix exact run UUID matching in list rollback

### DIFF
--- a/krkn/rollback/command.py
+++ b/krkn/rollback/command.py
@@ -52,8 +52,12 @@ def list_rollback(run_uuid: Optional[str]=None, scenario_type: Optional[str]=Non
             item_path = os.path.join(versions_directory, item)
             if os.path.isdir(item_path):
                 # Apply run_uuid filter if specified
-                if run_uuid is None or run_uuid in item:
+                if run_uuid is None:
                     run_dirs.append(item)
+                else:
+                    _, dir_uuid = item.split("-", 1)
+                    if dir_uuid == run_uuid:
+                        run_dirs.append(item)
         
         if not run_dirs:
             if run_uuid:

--- a/krkn/rollback/command.py
+++ b/krkn/rollback/command.py
@@ -52,12 +52,8 @@ def list_rollback(run_uuid: Optional[str]=None, scenario_type: Optional[str]=Non
             item_path = os.path.join(versions_directory, item)
             if os.path.isdir(item_path):
                 # Apply run_uuid filter if specified
-                if run_uuid is None:
+                if RollbackConfig.is_rollback_context_directory_format(item, run_uuid):
                     run_dirs.append(item)
-                else:
-                    _, dir_uuid = item.split("-", 1)
-                    if dir_uuid == run_uuid:
-                        run_dirs.append(item)
         
         if not run_dirs:
             if run_uuid:

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -265,6 +265,33 @@ class TestRollbackCommand:
                 "scenario",
                 ignore_auto_rollback_config=True
             )
+            
+    def test_list_rollback_filters_by_exact_run_uuid(self, tmp_path, capsys):
+        """Verify that run_uuid filtering requires an exact UUID match and does
+        not match timestamp or UUID substrings."""
+        from krkn.rollback.command import list_rollback
+        from krkn.rollback.config import RollbackConfig
+        from unittest.mock import patch
+
+        rollback_dir = tmp_path / "rollback"
+        rollback_dir.mkdir()
+        (
+            rollback_dir /"123456789-abcd1234-1111-2222-333344445555"
+        ).mkdir()
+
+        (
+            rollback_dir /"113456780-efgh5678-aaaa-bbbb-ccccddddeeee"
+        ).mkdir()
+
+        with patch.object(RollbackConfig,"versions_directory",str(rollback_dir)):
+            list_rollback(run_uuid="11")
+
+        captured = capsys.readouterr()
+
+        # "11" appears as a substring in the rollback directory names but is not
+        # an exact run UUID, therefore no directories should be matched.
+        assert "abcd1234-1111-2222-333344445555" not in captured.out
+        assert "efgh5678-aaaa-bbbb-ccccddddeeee" not in captured.out 
 
 class TestRollbackAbstractScenarioPlugin:
 

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -266,9 +266,9 @@ class TestRollbackCommand:
                 ignore_auto_rollback_config=True
             )
             
-    def test_list_rollback_filters_by_exact_run_uuid(self, tmp_path, capsys):
-        """Verify that run_uuid filtering requires an exact UUID match and does
-        not match timestamp or UUID substrings."""
+    def test_list_rollback_requires_exact_run_uuid_match(self, tmp_path, capsys):
+        """Verify that rollback context filtering requires an exact run UUID
+        match and does not return directories for partial UUID values.""" 
         from krkn.rollback.command import list_rollback
         from krkn.rollback.config import RollbackConfig
         from unittest.mock import patch
@@ -284,12 +284,11 @@ class TestRollbackCommand:
         ).mkdir()
 
         with patch.object(RollbackConfig,"versions_directory",str(rollback_dir)):
-            list_rollback(run_uuid="11")
+            list_rollback(run_uuid="abcd1234")
 
         captured = capsys.readouterr()
 
-        # "11" appears as a substring in the rollback directory names but is not
-        # an exact run UUID, therefore no directories should be matched.
+        # Partial UUID values should not match rollback context directories.
         assert "abcd1234-1111-2222-333344445555" not in captured.out
         assert "efgh5678-aaaa-bbbb-ccccddddeeee" not in captured.out 
 


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization

# Description  

Fixes `list-rollback` run UUID filtering to require an exact UUID match.

Previously, the command used substring matching against the entire rollback directory name (`<timestamp>-<run_uuid>`), which could incorrectly match rollback directories when a partial value appeared in either the timestamp or UUID.

This change updates the filtering logic to compare only the UUID portion of the rollback directory and require an exact match.

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #1392 
- Closes #1392 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

### Validation

Verified the regression test passes:

```bash
pytest tests/test_rollback.py -k exact_run_uuid -v
```

Output:

```text
tests/test_rollback.py::TestRollbackCommand::test_list_rollback_filters_by_exact_run_uuid PASSED   [100%]

1 passed, 23 deselected
```