### PR TITLE
fix(hogs): correct IO disk space measurement formula

### DIFF
--- a/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
+++ b/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
@@ -146,7 +146,7 @@ class HogsScenarioPlugin(AbstractScenarioPlugin):
                              f"{avg_node_resources.memory / node_resources_start.memory * 100} %")
             if config.type == HogType.io:
                 logging.info(f"[{node}] detected disk space allocated: "
-                             f"{(avg_node_resources.disk_space - node_resources_end.disk_space) / 1024 / 1024} MB")
+                             f"{(node_resources_start.disk_space - avg_node_resources.disk_space) / 1024 / 1024} MB")
         except Exception as e:
             exception_queue.put(e)
 


### PR DESCRIPTION
The IO hog scenario reported negative disk space values because:
1. disk_space from get_node_resources_info() returns availableBytes (free space), not used space
2. The formula subtracted from node_resources_end (misleadingly named, actually measured 3s after pod deploy) instead of node_resources_start

When the IO hog writes data, available space decreases. The original formula (avg - end) produced negative values. The correct formula is (start - avg) which measures how much available space was consumed.

Tested on AKS (2-node cluster) with io-write-bytes=512m:
- Before: -512.24 MB, -495.16 MB, -23.72 MB (5/5 negative)
- After:  +512.38 MB, +512.23 MB, +500.48 MB (3/3 correct)

# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  

The IO hog scenario in `hogs_scenario_plugin.py` (line 149) computes disk space allocation using:

```python
(avg_node_resources.disk_space - node_resources_end.disk_space) / 1024 / 1024
```

This has two bugs:

1. **Wrong subtraction direction**: `get_node_resources_info()` returns `availableBytes` from the Kubelet stats API (`/api/v1/nodes/<node>/proxy/stats/summary` → `node.fs.availableBytes`). When the IO hog writes data, available space **decreases**. The formula computes `avg_available - early_available`, which is negative since the average during the test is lower than the early snapshot. The correct direction is `start - avg` (pre-deployment baseline minus average during test).

2. **Wrong baseline variable**: `node_resources_end` is measured just 3 seconds after pod deployment (line 110), not at the end of the test. The correct baseline is `node_resources_start` (measured before pod deployment, line 98), which is consistent with how the memory measurement works on line 145.

**Fix**: Changed line 149 to:
```python
(node_resources_start.disk_space - avg_node_resources.disk_space) / 1024 / 1024
```

This bug was introduced in commit `c7e068a` ("Hog scenario porting from arcaflow to native", PR #748, Jan 31 2025) and has been present since the IO hog measurement was first written. The CPU and memory measurements in the same function are correct — only the IO formula was wrong.

## Related Tickets & Documents

- Related Issue #1401 
- Closes #1401 

# Documentation  
- [ ] **Is documentation needed for this update?**

No documentation update needed — this is a bugfix to an internal measurement formula.

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

### Live cluster testing (AKS, 2-node, K8s 1.34)

**Before fix** — 5 consecutive runs, all negative:
```bash
python run_kraken.py --config config/aks-config.yaml

# Run 1: [INFO] [aks-nodepool1-31945403-vmss000000] detected disk space allocated: -0.0744485294126207 MB
# Run 2: [INFO] [aks-nodepool1-31945403-vmss000000] detected disk space allocated: -0.0166015625 MB
# Run 3: [INFO] [aks-nodepool1-31945403-vmss000001] detected disk space allocated: -495.15869140625 MB
# Run 4: [INFO] [aks-nodepool1-31945403-vmss000001] detected disk space allocated: -23.72216796875 MB
# Run 5: [INFO] [aks-nodepool1-31945403-vmss000001] detected disk space allocated: -512.237847222219 MB
```

**After fix** — 3 consecutive runs, all positive and matching configured `io-write-bytes: 512m`:
```bash
python run_kraken.py --config config/aks-config.yaml

# Run 1: [INFO] [aks-nodepool1-31945403-vmss000000] detected disk space allocated: 512.3843749999942 MB
# Run 2: [INFO] [aks-nodepool1-31945403-vmss000001] detected disk space allocated: 512.22900390625 MB
# Run 3: [INFO] [aks-nodepool1-31945403-vmss000001] detected disk space allocated: 500.4787326388905 MB
```

### Unit tests — 1225 passed, 0 failed:
```bash
python -m pytest tests/ -v --ignore=tests/test_power_outage_rollback.py -x

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/shiva/github/krkn
collected 1225 items

tests/test_hogs_scenario_plugin.py::TestHogsScenarioPlugin::test_get_scenario_types PASSED [100%]
...
====================== 1225 passed, 62 warnings in 19.22s ======================
```

**Note**: `test_power_outage_rollback.py` was excluded because `test_rollback_shutdown_nodes_different_cloud_providers` hangs indefinitely — this is a pre-existing issue unrelated to this change.

### Scenario config used
```yaml
duration: 30
workers: ''
hog-type: io
image: quay.io/krkn-chaos/krkn-hog
namespace: default
io-block-size: 1m
io-write-bytes: 512m
io-target-pod-folder: /hog-data
io-target-pod-volume:
  name: node-volume
  hostPath:
    path: /tmp/krkn-io-test
node-selector: "agentpool=nodepool1"
number-of-nodes: 1
taints: []
```
