### PR TITLE
Remove duplicate RollbackCallable definition in Rollback Config

### DIFF
--- a/krkn/rollback/config.py
+++ b/krkn/rollback/config.py
@@ -32,14 +32,6 @@ RollbackCallable: TypeAlias = Callable[
 ]
 
 
-if TYPE_CHECKING:
-    from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
-
-RollbackCallable: TypeAlias = Callable[
-    ["RollbackContent", "KrknTelemetryOpenshift"], None
-]
-
-
 class SingletonMeta(type):
     _instances = {}
 


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  
Removes a duplicated `RollbackCallable` type alias declaration and associated `TYPE_CHECKING` import block from `krkn/rollback/config.py`.

The duplicate block defined the same type alias with the same implementation and did not affect runtime behavior. This removes redundant code.

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: 
- Closes #:   

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage
