### PR TITLE
Abort on Rollback Serialization Failure

### DIFF
--- a/krkn/rollback/handler.py
+++ b/krkn/rollback/handler.py
@@ -278,3 +278,10 @@ class RollbackHandler:
             logger.info(f"Rollback callable serialized to {version_file}")
         except Exception as e:
             logger.error(f"Failed to serialize rollback callable: {e}")
+            logger.error(
+            "Aborting scenario '%s' because rollback registration failed for rollback context '%s'. "
+            "Rollback state could not be persisted and scenario execution cannot continue safely.",
+            self.scenario_type,
+            self.rollback_context,
+            )
+            raise

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -232,6 +232,35 @@ class TestRollbackCommand:
                 "scenario",
                 ignore_auto_rollback_config=True
             )
+        
+class TestRollbackHandler:
+
+    def test_set_rollback_callable_propagates_serialization_errors(self):
+        from unittest.mock import Mock
+        from krkn.rollback.handler import RollbackHandler
+
+        serializer = Mock()
+        serializer.serialize_callable.side_effect = PermissionError(
+            "permission denied"
+        )
+
+        rollback_handler = RollbackHandler(
+            scenario_type="test_scenario",
+            serializer=serializer,
+        )
+
+        rollback_handler.rollback_context = "test-context"
+
+        rollback_content = Mock()
+
+        def rollback_fn(content, telemetry):
+            pass
+
+        with pytest.raises(PermissionError):
+            rollback_handler.set_rollback_callable(
+                rollback_fn,
+                rollback_content,
+            )
 
 class TestRollbackAbstractScenarioPlugin:
 


### PR DESCRIPTION
# Type of change

* [ ] Refactor
* [ ] New feature
* [x] Bug fix
* [ ] Optimization

# Description

This change updates rollback registration error handling to propagate serialization failures instead of silently logging and continuing execution.

Previously, if rollback callable serialization failed (for example due to an unwritable rollback directory), the exception was logged and ignored. Scenario execution would continue even though rollback state had not been persisted.

With this change:

* Rollback serialization failures are re-raised to the caller.
* Scenario execution aborts when rollback registration fails.
* A clear error message is logged indicating that execution is being stopped because rollback state could not be persisted.
* A unit test has been added to verify that serialization errors are propagated.

## Related Tickets & Documents

* Related Issue #1404
* Closes #1404

# Checklist before requesting a review

* [ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See contributing guidelines.
* [x] I have performed a self-review of my code by running krkn and specific scenario.
* [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage.


# Tests and Output

```bash
pytest tests/test_rollback.py::TestRollbackHandler::test_set_rollback_callable_propagates_serialization_errors -v

PASSED
```
