### PR TITLE
multiprocess_nodes: move pool.close into finally block, fix log level

### DIFF
--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -230,10 +230,10 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         scenario_telemetry.affected_nodes.extend(affected_nodes_status.affected_nodes)
 
     def multiprocess_nodes(self, nodes, node_scenario_object, action, node_scenario):
+        pool = None
         try:
             # pool object with number of element
             pool = ThreadPool(processes=len(nodes))
-
             pool.starmap(
                 self.run_node,
                 zip(
@@ -243,10 +243,12 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                     repeat(node_scenario),
                 ),
             )
-
-            pool.close()
         except Exception as e:
-            logging.info("Error on pool multiprocessing: " + str(e))
+            logging.error("Error on pool multiprocessing: " + str(e))
+        finally:
+            if pool:
+                pool.close()
+                pool.join()
 
     def run_node(self, single_node, node_scenario_object, action, node_scenario):
         # Get the scenario specifics for running action nodes

--- a/tests/test_node_actions_scenario_plugin.py
+++ b/tests/test_node_actions_scenario_plugin.py
@@ -790,8 +790,9 @@ class TestNodeActionsScenarioPlugin(unittest.TestCase):
             mock_pool.assert_called_once_with(processes=3)
             mock_pool_instance.starmap.assert_called_once()
             mock_pool_instance.close.assert_called_once()
+            mock_pool_instance.join.assert_called_once()
 
-    @patch('logging.info')
+    @patch('logging.error')
     def test_multiprocess_nodes_with_exception(self, mock_logging):
         """
         Test multiprocess_nodes handles exceptions gracefully


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  

Fixed two bugs in `multiprocess_nodes` inside `node_actions_scenario_plugin.py`:

1. **Thread pool leak:** `pool.close()` was inside the `try` block. If `pool.starmap()` raised an exception, `close()` was never called and worker threads leaked until process exit. Moved `pool.close()` to a `finally` block with a null check.

2. **Wrong log level:** The exception handler used `logging.info()` instead of `logging.error()`, so pool failures were invisible at the default log level. Changed to `logging.error()`.

# Checklist before requesting a review

- [x] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

```bash

# for NodeActionsScenarioPlugin validate the multiprocess_nodes path.
# No new functionality was added,
python -m unittest tests.test_node_actions_scenario_plugin -v