### PR TITLE
node_based_zone: move pool.close into finally block, fix log level

### DIFF
--- a/krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py
+++ b/krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py
@@ -107,11 +107,14 @@ class ZoneOutageScenarioPlugin(AbstractScenarioPlugin):
 
             # stop nodes in parallel
             pool = ThreadPool(processes=len(nodes))
-            pool.starmap(
-                self.cloud_object.node_stop_scenario,
-                zip(repeat(1), nodes, repeat(timeout), repeat(None)),
-            )
-            pool.close()
+            try:
+                pool.starmap(
+                    self.cloud_object.node_stop_scenario,
+                    zip(repeat(1), nodes, repeat(timeout), repeat(None)),
+                )
+            finally:
+                pool.close()
+                pool.join()
 
             logging.info(
                 "Waiting for the specified duration " "in the config: %s" % duration
@@ -120,13 +123,16 @@ class ZoneOutageScenarioPlugin(AbstractScenarioPlugin):
 
             # start nodes in parallel
             pool = ThreadPool(processes=len(nodes))
-            pool.starmap(
-                self.cloud_object.node_start_scenario,
-                zip(repeat(1), nodes, repeat(timeout), repeat(None)),
-            )
-            pool.close()
+            try:
+                pool.starmap(
+                    self.cloud_object.node_start_scenario,
+                    zip(repeat(1), nodes, repeat(timeout), repeat(None)),
+                )
+            finally:
+                pool.close()
+                pool.join()
         except Exception as e:
-            logging.info(
+            logging.error(
                 f"Node based zone outage scenario failed with exception: {e}"
             )
             return 1

--- a/tests/test_zone_outage_scenario_plugin.py
+++ b/tests/test_zone_outage_scenario_plugin.py
@@ -436,5 +436,77 @@ class TestZoneOutageRun(unittest.TestCase):
         self.assertEqual(result, 1)
 
 
+    @patch("time.sleep")
+    @patch(
+        "krkn.scenario_plugins.zone_outage."
+        "zone_outage_scenario_plugin.gcp_node_scenarios"
+    )
+    def test_node_based_zone_logs_error_on_exception(
+        self, mock_gcp_class, mock_sleep
+    ):
+        """Test node_based_zone uses logging.error for exceptions"""
+        scenario_file = self._create_scenario_file()
+        mock_lib_telemetry, mock_lib_kubernetes, mock_scenario_telemetry = (
+            self._create_mocks()
+        )
+
+        mock_lib_kubernetes.list_killable_nodes.return_value = ["node-1"]
+        mock_cloud = MagicMock()
+        mock_cloud.node_stop_scenario.side_effect = Exception("stop failed")
+        mock_gcp_class.return_value = mock_cloud
+
+        plugin = ZoneOutageScenarioPlugin()
+        with self.assertLogs(level="ERROR") as logs:
+            result = plugin.run(
+                run_uuid=str(uuid.uuid4()),
+                scenario=scenario_file,
+                lib_telemetry=mock_lib_telemetry,
+                scenario_telemetry=mock_scenario_telemetry,
+            )
+
+        self.assertEqual(result, 1)
+        self.assertTrue(
+            any(
+                "Node based zone outage scenario failed" in log
+                for log in logs.output
+            )
+        )
+
+    @patch("time.sleep")
+    @patch(
+        "krkn.scenario_plugins.zone_outage."
+        "zone_outage_scenario_plugin.ThreadPool"
+    )
+    def test_node_based_zone_pool_close_on_exception(
+        self, mock_thread_pool, mock_sleep
+    ):
+        """Test pool.close() is called via finally when starmap raises"""
+        mock_pool_instance = MagicMock()
+        mock_pool_instance.starmap.side_effect = Exception("stop failed")
+        mock_thread_pool.return_value = mock_pool_instance
+
+        scenario_file = self._create_scenario_file()
+        mock_lib_telemetry, mock_lib_kubernetes, mock_scenario_telemetry = (
+            self._create_mocks()
+        )
+        mock_lib_kubernetes.list_killable_nodes.return_value = ["node-1"]
+
+        with patch(
+            "krkn.scenario_plugins.zone_outage."
+            "zone_outage_scenario_plugin.gcp_node_scenarios"
+        ) as mock_gcp:
+            mock_gcp.return_value = MagicMock()
+            plugin = ZoneOutageScenarioPlugin()
+            result = plugin.run(
+                run_uuid=str(uuid.uuid4()),
+                scenario=scenario_file,
+                lib_telemetry=mock_lib_telemetry,
+                scenario_telemetry=mock_scenario_telemetry,
+            )
+
+        self.assertEqual(result, 1)
+        mock_pool_instance.close.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Type of change:** Bug fix

Found two issues in `node_based_zone` inside `zone_outage_scenario_plugin.py`.

### What's wrong

**1. Pool leak**

Two `ThreadPool` instances - one for stopping nodes, one for starting them. Both follow the same pattern:

```python
pool = ThreadPool(...)
pool.starmap(...)
pool.close()
```
pool.close() sits right after starmap with nothing in between. If starmap throws (network blip, API timeout, whatever), execution jumps straight to except and close() never runs. Worker threads hang around until the process exits.

**2. Wrong log level**
The except block uses logging.info() instead of logging.error(). At the default log level (WARNING), the error message is invisible. Pool failures silently disappear.

**What changed**
- Wrapped both pools in try/finally so close() and join() always run
- Changed logging.info to logging.error in the exception handler

**Testing**


**before fix:**

<img width="1263" height="598" alt="image" src="https://github.com/user-attachments/assets/789ffca3-9e44-456b-b7bc-7370cbbaf5b5" />



**after fix:**

<img width="1566" height="444" alt="image" src="https://github.com/user-attachments/assets/00e8c5fb-ee7b-4e67-b494-1bc696900cde" />



**Full suite - 13/13 pass:**

<img width="1246" height="721" alt="image" src="https://github.com/user-attachments/assets/37aae186-eb5c-4c53-b3da-316d2e169c39" />


- Self-review
- Unit tests added
- Existing tests pass