### PR TITLE
Add rollback support for node outage scenarios (#916)

### DIFF
--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -45,10 +45,36 @@ from krkn.scenario_plugins.node_actions.ibmcloud_node_scenarios import (
 from krkn.scenario_plugins.node_actions.ibmcloud_power_node_scenarios import (
      ibmcloud_power_node_scenarios,
 )
+from krkn.rollback.handler import set_rollback_context_decorator
+from krkn.rollback.config import RollbackContent
+from krkn.scenario_plugins.node_actions.aws_node_scenarios import AWS
+from krkn.scenario_plugins.node_actions.gcp_node_scenarios import GCP
+from krkn.scenario_plugins.node_actions.az_node_scenarios import Azure
+from krkn.scenario_plugins.node_actions.openstack_node_scenarios import OPENSTACKCLOUD
+from krkn.scenario_plugins.node_actions.ibmcloud_node_scenarios import IbmCloud
+
 node_general = False
 
 
+def _get_node_cloud_object(cloud_type: str):
+    """Return cloud provider instance for rollback. Mirrors shut_down_scenario_plugin pattern."""
+    ct = cloud_type.lower()
+    if ct == "aws":
+        return AWS()
+    elif ct == "gcp":
+        return GCP()
+    elif ct == "openstack":
+        return OPENSTACKCLOUD()
+    elif ct in ("azure", "az"):
+        return Azure()
+    elif ct in ("ibm", "ibmcloud"):
+        return IbmCloud()
+    else:
+        raise ValueError(f"Cloud type '{cloud_type}' is not supported for node outage rollback")
+
+
 class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
+    @set_rollback_context_decorator
     def run(
         self,
         run_uuid: str,
@@ -220,6 +246,64 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                     )
                 nodes = [node for node in nodes if node not in exclude_nodes]
 
+        ROLLBACK_ACTIONS = {
+            "node_stop_scenario",
+            "node_termination_scenario",
+            "node_stop_start_scenario",
+        }
+        cloud_type = node_scenario.get("cloud_type", "generic")
+        if action in ROLLBACK_ACTIONS and cloud_type != "generic":
+            try:
+                cloud_object = _get_node_cloud_object(cloud_type)
+            except Exception as e:
+                cloud_object = None
+                logging.warning(f"Could not register node outage rollback: {e}")
+
+            if cloud_object is not None:
+                # Resolve each node independently so that a single unresolvable
+                # node (e.g. Azure/GCP returning None, or IbmCloud calling
+                # sys.exit) never aborts rollback registration for the rest.
+                # SystemExit is caught explicitly because it derives from
+                # BaseException and would otherwise terminate the process during
+                # this best-effort registration; BaseException is deliberately
+                # NOT caught so KeyboardInterrupt still propagates.
+                instance_ids = []
+                for node in nodes:
+                    try:
+                        instance_id = cloud_object.get_instance_id(node)
+                    except (Exception, SystemExit) as e:
+                        logging.warning(
+                            f"Skipping rollback registration for node '{node}': "
+                            f"could not resolve instance id ({e})"
+                        )
+                        continue
+                    if instance_id is None:
+                        logging.warning(
+                            f"Skipping rollback registration for node '{node}': "
+                            f"instance id could not be resolved"
+                        )
+                        continue
+                    instance_ids.append(instance_id)
+
+                if instance_ids:
+                    rollback_content = RollbackContent(
+                        cloud_type=cloud_type,
+                        instance_ids=tuple(instance_ids),
+                        skip_kubernetes=True,
+                    )
+                    self.rollback_handler.set_rollback_callable(
+                        NodeActionsScenarioPlugin.rollback_node_outage,
+                        rollback_content,
+                    )
+                    logging.info(
+                        f"Registered rollback for {len(instance_ids)} node(s) on {cloud_type}"
+                    )
+                else:
+                    logging.warning(
+                        f"No resolvable instance ids on {cloud_type}; "
+                        f"node outage rollback not registered"
+                    )
+
         # GCP api doesn't support multiprocessing calls, will only actually run 1
         if parallel_nodes:
             self.multiprocess_nodes(nodes, node_scenario_object, action, node_scenario)
@@ -341,3 +425,85 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
 
     def get_scenario_types(self) -> list[str]:
         return ["node_scenarios"]
+
+    @staticmethod
+    def rollback_node_outage(rollback_content: RollbackContent, lib_telemetry: KrknTelemetryOpenshift = None):
+        """
+        Restore stopped/terminated nodes. Operates independently of Kubernetes API.
+        Called by execute_rollback_version_files() on scenario failure.
+        """
+        import time
+        try:
+            cloud_type = rollback_content.cloud_type
+            node_ids = list(rollback_content.instance_ids or ())
+            if not cloud_type or not node_ids:
+                # Legacy fallback
+                content_parts = rollback_content.resource_identifier.split(":", 1)
+                if len(content_parts) != 2:
+                    logging.error(f"Invalid rollback content: {rollback_content.resource_identifier}")
+                    return
+                cloud_type = content_parts[0]
+                node_ids = [n.strip() for n in content_parts[1].split(",") if n.strip()]
+            if not node_ids:
+                logging.warning("No node IDs found in rollback content")
+                return
+            if cloud_type.lower() == "aws":
+                from krkn.scenario_plugins.node_actions.aws_node_scenarios import AWS
+                cloud_object = AWS()
+            elif cloud_type.lower() == "gcp":
+                from krkn.scenario_plugins.node_actions.gcp_node_scenarios import GCP
+                cloud_object = GCP()
+            elif cloud_type.lower() == "openstack":
+                from krkn.scenario_plugins.node_actions.openstack_node_scenarios import OPENSTACKCLOUD
+                cloud_object = OPENSTACKCLOUD()
+            elif cloud_type.lower() in ["azure", "az"]:
+                from krkn.scenario_plugins.node_actions.az_node_scenarios import Azure
+                cloud_object = Azure()
+            elif cloud_type.lower() in ["ibm", "ibmcloud"]:
+                from krkn.scenario_plugins.node_actions.ibmcloud_node_scenarios import IbmCloud
+                cloud_object = IbmCloud()
+            else:
+                logging.error(f"Unsupported cloud type for rollback: {cloud_type}")
+                return
+            timeout = 300
+            failed = []
+            for node_id in node_ids:
+                try:
+                    logging.info(f"Starting node for rollback: {node_id}")
+                    if isinstance(node_id, tuple):
+                        cloud_object.start_instances(node_id[1], node_id[0])
+                    else:
+                        cloud_object.start_instances(node_id)
+                except Exception as e:
+                    logging.error(f"Failed to start {node_id}: {e}")
+                    failed.append(node_id)
+            for node_id in node_ids:
+                if node_id in failed:
+                    continue
+                try:
+                    if isinstance(node_id, tuple):
+                        node_status = cloud_object.wait_until_running(node_id[1], node_id[0], timeout, None)
+                    else:
+                        node_status = cloud_object.wait_until_running(node_id, timeout, None)
+                    if not node_status:
+                        logging.warning(f"Timeout waiting for {node_id}")
+                        failed.append(node_id)
+                    else:
+                        logging.info(f"Node {node_id} restored")
+                except Exception as e:
+                    logging.error(f"Error waiting for {node_id}: {e}")
+                    failed.append(node_id)
+            total = len(node_ids)
+            restored = total - len(failed)
+            if not failed:
+                logging.info(f"Node outage rollback complete: {total}/{total} restored")
+            else:
+                logging.warning(f"Node outage rollback partial: {restored}/{total} restored. Failed: {failed}")
+            if restored > 0:
+                logging.info("Waiting 60s for cluster initialization...")
+                time.sleep(60)
+            logging.info("rollback_node_outage complete.")
+        except Exception as e:
+            logging.error(f"rollback_node_outage failed: {e}")
+            raise
+

--- a/tests/test_node_outage_rollback.py
+++ b/tests/test_node_outage_rollback.py
@@ -1,0 +1,422 @@
+"""Tests for NodeActionsScenarioPlugin node outage rollback functionality."""
+import unittest
+import pytest
+from unittest.mock import Mock, patch
+
+
+from krkn.scenario_plugins.node_actions.node_actions_scenario_plugin import NodeActionsScenarioPlugin
+from krkn.rollback.config import RollbackContent
+
+
+class TestNodeOutageRollback(unittest.TestCase):
+
+    @patch("time.sleep")
+    @patch('krkn.scenario_plugins.node_actions.aws_node_scenarios.AWS')
+    def test_rollback_node_outage_aws_success(self, mock_aws_class, mock_sleep):
+        mock_aws = Mock()
+        mock_aws_class.return_value = mock_aws
+        mock_aws.start_instances.return_value = None
+        mock_aws.wait_until_running.return_value = True
+
+        rollback_content = RollbackContent(
+            cloud_type="aws",
+            instance_ids=("i-12345",),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+
+        mock_aws.start_instances.assert_called_once_with("i-12345")
+        mock_aws.wait_until_running.assert_called_once_with("i-12345", 300, None)
+
+    @patch("time.sleep")
+    @patch('krkn.scenario_plugins.node_actions.aws_node_scenarios.AWS')
+    def test_rollback_node_outage_multiple_nodes(self, mock_aws_class, mock_sleep):
+        mock_aws = Mock()
+        mock_aws_class.return_value = mock_aws
+        mock_aws.start_instances.return_value = None
+        mock_aws.wait_until_running.return_value = True
+
+        rollback_content = RollbackContent(
+            cloud_type="aws",
+            instance_ids=("i-12345", "i-67890"),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+
+        self.assertEqual(mock_aws.start_instances.call_count, 2)
+        mock_aws.start_instances.assert_any_call("i-12345")
+        mock_aws.start_instances.assert_any_call("i-67890")
+        self.assertEqual(mock_aws.wait_until_running.call_count, 2)
+
+    @patch("time.sleep")
+    @patch('krkn.scenario_plugins.node_actions.aws_node_scenarios.AWS')
+    def test_rollback_node_outage_partial_failure(self, mock_aws_class, mock_sleep):
+        mock_aws = Mock()
+        mock_aws_class.return_value = mock_aws
+        
+        def start_side_effect(instance_id):
+            if instance_id == "i-fail":
+                raise Exception("Failed to start")
+            return None
+        
+        mock_aws.start_instances.side_effect = start_side_effect
+        mock_aws.wait_until_running.return_value = True
+
+        rollback_content = RollbackContent(
+            cloud_type="aws",
+            instance_ids=("i-12345", "i-fail"),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+
+        self.assertEqual(mock_aws.start_instances.call_count, 2)
+        mock_aws.wait_until_running.assert_called_once_with("i-12345", 300, None)
+
+    def test_rollback_node_outage_empty_node_list(self):
+        rollback_content = RollbackContent(
+            cloud_type="aws",
+            instance_ids=tuple(),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        with patch('krkn.scenario_plugins.node_actions.aws_node_scenarios.AWS') as mock_aws_class:
+            NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+            mock_aws_class.assert_not_called()
+
+    def test_rollback_node_outage_unsupported_cloud(self):
+        rollback_content = RollbackContent(
+            cloud_type="unsupported",
+            instance_ids=("i-12345",),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        # Should handle gracefully without raising
+        NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+
+    @patch('krkn.scenario_plugins.node_actions.aws_node_scenarios.AWS')
+    def test_rollback_node_outage_cloud_exception(self, mock_aws_class):
+        mock_aws = Mock()
+        mock_aws_class.return_value = mock_aws
+        mock_aws.start_instances.side_effect = Exception("Cloud API Error")
+
+        rollback_content = RollbackContent(
+            cloud_type="aws",
+            instance_ids=("i-12345",),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        # Should not raise exception
+        NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+
+        mock_aws.start_instances.assert_called_once_with("i-12345")
+        mock_aws.wait_until_running.assert_not_called()
+
+    @patch("time.sleep")
+    @patch('krkn.scenario_plugins.node_actions.gcp_node_scenarios.GCP')
+    def test_rollback_node_outage_gcp(self, mock_gcp_class, mock_sleep):
+        mock_gcp = Mock()
+        mock_gcp_class.return_value = mock_gcp
+        mock_gcp.start_instances.return_value = None
+        mock_gcp.wait_until_running.return_value = True
+
+        rollback_content = RollbackContent(
+            cloud_type="gcp",
+            instance_ids=("instance-1",),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+
+        mock_gcp.start_instances.assert_called_once_with("instance-1")
+
+    @patch("time.sleep")
+    @patch('krkn.scenario_plugins.node_actions.az_node_scenarios.Azure')
+    def test_rollback_node_outage_azure(self, mock_az_class, mock_sleep):
+        mock_az = Mock()
+        mock_az_class.return_value = mock_az
+        mock_az.start_instances.return_value = None
+        mock_az.wait_until_running.return_value = True
+
+        rollback_content = RollbackContent(
+            cloud_type="azure",
+            instance_ids=(("vm-1", "resource-group-1"),),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+
+        mock_az.start_instances.assert_called_once_with("resource-group-1", "vm-1")
+        mock_az.wait_until_running.assert_called_once_with("resource-group-1", "vm-1", 300, None)
+
+    @patch("time.sleep")
+    @patch('krkn.scenario_plugins.node_actions.openstack_node_scenarios.OPENSTACKCLOUD')
+    def test_rollback_node_outage_openstack(self, mock_os_class, mock_sleep):
+        mock_os = Mock()
+        mock_os_class.return_value = mock_os
+        mock_os.start_instances.return_value = None
+        mock_os.wait_until_running.return_value = True
+
+        rollback_content = RollbackContent(
+            cloud_type="openstack",
+            instance_ids=("os-node-1",),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+
+        mock_os.start_instances.assert_called_once_with("os-node-1")
+        mock_os.wait_until_running.assert_called_once_with("os-node-1", 300, None)
+
+    @patch("time.sleep")
+    @patch('krkn.scenario_plugins.node_actions.ibmcloud_node_scenarios.IbmCloud')
+    def test_rollback_node_outage_ibmcloud(self, mock_ibm_class, mock_sleep):
+        mock_ibm = Mock()
+        mock_ibm_class.return_value = mock_ibm
+        mock_ibm.start_instances.return_value = None
+        mock_ibm.wait_until_running.return_value = True
+
+        rollback_content = RollbackContent(
+            cloud_type="ibmcloud",
+            instance_ids=("ibm-node-1",),
+            skip_kubernetes=True,
+        )
+        mock_telemetry = Mock()
+
+        NodeActionsScenarioPlugin.rollback_node_outage(rollback_content, mock_telemetry)
+
+        mock_ibm.start_instances.assert_called_once_with("ibm-node-1")
+        mock_ibm.wait_until_running.assert_called_once_with("ibm-node-1", 300, None)
+
+    def test_rollback_content_structured_fields(self):
+        rollback_content = RollbackContent(
+            cloud_type="aws",
+            instance_ids=("i-12345",),
+            skip_kubernetes=True,
+        )
+        self.assertEqual(rollback_content.cloud_type, "aws")
+        self.assertEqual(rollback_content.instance_ids, ("i-12345",))
+        self.assertTrue(rollback_content.skip_kubernetes)
+
+    @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin._get_node_cloud_object')
+    @patch('krkn.scenario_plugins.node_actions.common_node_functions.get_node_by_name')
+    def test_rollback_registration_in_inject(self, mock_get_node, mock_get_cloud):
+        plugin = NodeActionsScenarioPlugin()
+        plugin.rollback_handler = Mock()
+        
+        mock_get_node.return_value = ["node1"]
+        mock_cloud_obj = Mock()
+        mock_cloud_obj.get_instance_id.return_value = "i-123"
+        mock_get_cloud.return_value = mock_cloud_obj
+        
+        mock_kubecli = Mock()
+        mock_telemetry = Mock()
+        mock_scenario_obj = Mock()
+        mock_scenario_obj.affected_nodes_status = Mock()
+        mock_scenario_obj.affected_nodes_status.affected_nodes = []
+
+        scenario_yaml = {
+            "node_name": "node1",
+            "cloud_type": "aws",
+        }
+
+        plugin.inject_node_scenario(
+            "node_stop_scenario", 
+            scenario_yaml, 
+            mock_scenario_obj, 
+            mock_kubecli, 
+            mock_telemetry
+        )
+
+        plugin.rollback_handler.set_rollback_callable.assert_called_once()
+        args, _ = plugin.rollback_handler.set_rollback_callable.call_args
+        self.assertEqual(args[0], NodeActionsScenarioPlugin.rollback_node_outage)
+        self.assertEqual(args[1].cloud_type, "aws")
+        self.assertEqual(args[1].instance_ids, ("i-123",))
+        self.assertTrue(args[1].skip_kubernetes)
+
+    @patch('krkn.scenario_plugins.node_actions.common_node_functions.get_node_by_name')
+    def test_rollback_not_registered_for_generic(self, mock_get_node):
+        plugin = NodeActionsScenarioPlugin()
+        plugin.rollback_handler = Mock()
+        
+        mock_get_node.return_value = ["node1"]
+        mock_kubecli = Mock()
+        mock_telemetry = Mock()
+        mock_scenario_obj = Mock()
+        mock_scenario_obj.affected_nodes_status = Mock()
+        mock_scenario_obj.affected_nodes_status.affected_nodes = []
+
+        scenario_yaml = {
+            "node_name": "node1",
+            "cloud_type": "generic",
+        }
+
+        plugin.inject_node_scenario(
+            "node_stop_scenario", 
+            scenario_yaml, 
+            mock_scenario_obj, 
+            mock_kubecli, 
+            mock_telemetry
+        )
+
+        plugin.rollback_handler.set_rollback_callable.assert_not_called()
+
+    @patch("krkn.rollback.handler.RollbackConfig.search_rollback_version_files")
+    @patch("krkn.rollback.handler._parse_rollback_module")
+    @patch("os.rename")
+    def test_execute_rollback_passes_none_telemetry(
+        self, mock_rename, mock_parse, mock_search
+    ):
+        from krkn.rollback.handler import execute_rollback_version_files
+        
+        mock_search.return_value = ["/tmp/test.py"]
+        
+        mock_callable = Mock()
+        mock_content = RollbackContent(
+            cloud_type="aws",
+            instance_ids=("i-123",),
+            skip_kubernetes=True
+        )
+        mock_parse.return_value = (mock_callable, mock_content)
+        
+        execute_rollback_version_files(
+            telemetry_ocp=Mock(),
+            run_uuid="uuid",
+            scenario_type="node_scenarios",
+            ignore_auto_rollback_config=True
+        )
+        
+        mock_callable.assert_called_once_with(mock_content, None)
+
+    @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin._get_node_cloud_object')
+    @patch('krkn.scenario_plugins.node_actions.common_node_functions.get_node_by_name')
+    def test_rollback_registered_for_stop_start(self, mock_get_node, mock_get_cloud):
+        """node_stop_start_scenario is destructive during its wait phase, so it must
+        register a rollback in case the run is interrupted before the node restarts."""
+        plugin = NodeActionsScenarioPlugin()
+        plugin.rollback_handler = Mock()
+
+        mock_get_node.return_value = ["node1"]
+        mock_cloud_obj = Mock()
+        mock_cloud_obj.get_instance_id.return_value = "i-123"
+        mock_get_cloud.return_value = mock_cloud_obj
+
+        mock_kubecli = Mock()
+        mock_telemetry = Mock()
+        mock_scenario_obj = Mock()
+        mock_scenario_obj.affected_nodes_status = Mock()
+        mock_scenario_obj.affected_nodes_status.affected_nodes = []
+
+        scenario_yaml = {
+            "node_name": "node1",
+            "cloud_type": "aws",
+        }
+
+        plugin.inject_node_scenario(
+            "node_stop_start_scenario",
+            scenario_yaml,
+            mock_scenario_obj,
+            mock_kubecli,
+            mock_telemetry
+        )
+
+        plugin.rollback_handler.set_rollback_callable.assert_called_once()
+        args, _ = plugin.rollback_handler.set_rollback_callable.call_args
+        self.assertEqual(args[0], NodeActionsScenarioPlugin.rollback_node_outage)
+        self.assertEqual(args[1].cloud_type, "aws")
+        self.assertEqual(args[1].instance_ids, ("i-123",))
+        self.assertTrue(args[1].skip_kubernetes)
+
+    @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin._get_node_cloud_object')
+    @patch('krkn.scenario_plugins.node_actions.common_node_functions.get_node_by_name')
+    def test_rollback_registration_skips_unresolvable_nodes(self, mock_get_node, mock_get_cloud):
+        """A node whose instance id cannot be resolved (None returned, or a provider
+        calling sys.exit -> SystemExit) is skipped without aborting registration for
+        the remaining, resolvable nodes."""
+        plugin = NodeActionsScenarioPlugin()
+        plugin.rollback_handler = Mock()
+
+        mock_get_node.return_value = ["node1", "node2", "node3"]
+
+        def resolve(node):
+            if node == "node1":
+                return "i-123"
+            if node == "node2":
+                return None
+            raise SystemExit(1)
+
+        mock_cloud_obj = Mock()
+        mock_cloud_obj.get_instance_id.side_effect = resolve
+        mock_get_cloud.return_value = mock_cloud_obj
+
+        mock_kubecli = Mock()
+        mock_telemetry = Mock()
+        mock_scenario_obj = Mock()
+        mock_scenario_obj.affected_nodes_status = Mock()
+        mock_scenario_obj.affected_nodes_status.affected_nodes = []
+
+        scenario_yaml = {
+            "node_name": "node1",
+            "cloud_type": "aws",
+        }
+
+        # Must not raise (SystemExit from the IBM-style provider is caught here).
+        plugin.inject_node_scenario(
+            "node_stop_scenario",
+            scenario_yaml,
+            mock_scenario_obj,
+            mock_kubecli,
+            mock_telemetry
+        )
+
+        plugin.rollback_handler.set_rollback_callable.assert_called_once()
+        args, _ = plugin.rollback_handler.set_rollback_callable.call_args
+        self.assertEqual(args[1].instance_ids, ("i-123",))
+
+    @patch('krkn.scenario_plugins.node_actions.node_actions_scenario_plugin._get_node_cloud_object')
+    @patch('krkn.scenario_plugins.node_actions.common_node_functions.get_node_by_name')
+    def test_rollback_not_registered_when_no_ids_resolve(self, mock_get_node, mock_get_cloud):
+        """If no node resolves to an instance id, no rollback is registered."""
+        plugin = NodeActionsScenarioPlugin()
+        plugin.rollback_handler = Mock()
+
+        mock_get_node.return_value = ["node1"]
+        mock_cloud_obj = Mock()
+        mock_cloud_obj.get_instance_id.return_value = None
+        mock_get_cloud.return_value = mock_cloud_obj
+
+        mock_kubecli = Mock()
+        mock_telemetry = Mock()
+        mock_scenario_obj = Mock()
+        mock_scenario_obj.affected_nodes_status = Mock()
+        mock_scenario_obj.affected_nodes_status.affected_nodes = []
+
+        scenario_yaml = {
+            "node_name": "node1",
+            "cloud_type": "aws",
+        }
+
+        plugin.inject_node_scenario(
+            "node_stop_scenario",
+            scenario_yaml,
+            mock_scenario_obj,
+            mock_kubecli,
+            mock_telemetry
+        )
+
+        plugin.rollback_handler.set_rollback_callable.assert_not_called()
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary

This PR implements rollback support for node outage scenarios as requested in #916.

The implementation integrates node outage actions with the existing rollback framework and follows the rollback architecture established by the shutdown scenario implementation.

### What changed

#### Rollback framework integration

- Added `@set_rollback_context_decorator` to `NodeActionsScenarioPlugin.run()`.
- Registered rollback operations in `inject_node_scenario()` before destructive actions are executed.
- Captured cloud provider instance identifiers prior to node stop/termination operations.
- Stored rollback metadata using the structured `RollbackContent` fields:
  - `cloud_type`
  - `instance_ids`
  - `skip_kubernetes=True`

#### Rollback implementation

Added `rollback_node_outage()` which:

- Restores stopped or terminated nodes using cloud provider APIs.
- Operates independently of Kubernetes APIs.
- Supports:
  - AWS
  - GCP
  - Azure
  - OpenStack
  - IBM Cloud
- Handles Azure-specific `(vm_name, resource_group)` rollback identifiers.
- Waits for instances to return to a running state before completing rollback.

#### Test coverage

Added `tests/test_node_outage_rollback.py` covering:

- AWS rollback success path
- Multiple node rollback
- Partial rollback failures
- Cloud API exceptions
- Empty rollback content
- Unsupported cloud types
- Azure rollback handling
- GCP rollback handling
- OpenStack rollback handling
- IBM Cloud rollback handling
- Rollback registration behavior
- Rollback execution path validation
- Structured `RollbackContent` validation

### Design notes

This implementation intentionally follows the rollback pattern used by the shutdown scenario rollback implementation and uses the structured rollback fields introduced by the rollback framework instead of serializing rollback state into `resource_identifier`.

Rollback registration occurs before destructive node actions execute, ensuring affected instance identifiers are available even if scenario execution fails.

### Related Issue

Fixes #916