### PR TITLE
ci: pin workflow action references to commit SHAs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Install Grype
       run: |
@@ -67,10 +67,10 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Test Build the Docker images
       if: github.event_name == 'pull_request'
@@ -130,7 +130,7 @@ jobs:
 
     - name: Login to krkn-chaos quay
       if: startsWith(github.ref, 'refs/tags')
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -152,7 +152,7 @@ jobs:
 
     - name: Login to redhat-chaos quay
       if: startsWith(github.ref, 'refs/tags')
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER_1 }}
@@ -173,7 +173,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     steps:
     - name: Login to krkn-chaos quay
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -193,7 +193,7 @@ jobs:
         docker manifest push quay.io/krkn-chaos/krkn:latest
 
     - name: Login to redhat-chaos quay
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USER_1 }}
@@ -213,7 +213,7 @@ jobs:
         docker manifest push quay.io/redhat-chaos/krkn:latest
 
     - name: Rebuild krkn-hub
-      uses: redhat-chaos/actions/krkn-hub@main
+      uses: redhat-chaos/actions/krkn-hub@aa421229ca6d4ad13785039d0736611c6439fc3e # main
       with:
         QUAY_USER: ${{ secrets.QUAY_USERNAME }}
         QUAY_TOKEN: ${{ secrets.QUAY_PASSWORD }}
@@ -229,17 +229,17 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Check out doc repo
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
         with:
           repository: krkn-chaos/krkn-lib-docs
           path: krkn-lib-docs
           ssh-key: ${{ secrets.KRKN_LIB_DOCS_PRIV_KEY }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build image for security scan
         run: |

--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
   rebase:
-    uses: krkn-chaos/actions/.github/workflows/needs-rebase.yml@main
+    uses: krkn-chaos/actions/.github/workflows/needs-rebase.yml@d17d7433f988dc95a7ae2b15b3505b1f256dc1f6 # main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: calculate previous tag
         run: |
           git fetch --tags origin

--- a/.github/workflows/require-docs.yml
+++ b/.github/workflows/require-docs.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Enforce Documentation Update (if required)
         if: steps.check_docs.outputs.docs_required == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   stale:
-    uses: krkn-chaos/actions/.github/workflows/stale.yml@main
+    uses: krkn-chaos/actions/.github/workflows/stale.yml@d17d7433f988dc95a7ae2b15b3505b1f256dc1f6 # main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Create multi-node KinD cluster
-        uses: redhat-chaos/actions/kind@main
+        uses: redhat-chaos/actions/kind@aa421229ca6d4ad13785039d0736611c6439fc3e # main
       - name: Deploy prometheus & Port Forwarding
-        uses: redhat-chaos/actions/prometheus@main
+        uses: redhat-chaos/actions/prometheus@aa421229ca6d4ad13785039d0736611c6439fc3e # main
       - name: Deploy Elasticsearch
         with:
           ELASTIC_PORT: ${{ env.ELASTIC_PORT }}
           RUN_ID: ${{ github.run_id }}
-        uses: redhat-chaos/actions/elastic@main
+        uses: redhat-chaos/actions/elastic@aa421229ca6d4ad13785039d0736611c6439fc3e # main
       - name: Download elastic password
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: elastic_password_${{ github.run_id }}
       - name: Set elastic password on env
@@ -30,7 +30,7 @@ jobs:
           ELASTIC_PASSWORD=$(cat elastic_password.txt)
           echo "ELASTIC_PASSWORD=$ELASTIC_PASSWORD" >> "$GITHUB_ENV"
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.11'
           architecture: 'x64'
@@ -112,7 +112,7 @@ jobs:
       # for the badge
       - name: Configure AWS Credentials
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -133,7 +133,7 @@ jobs:
           echo >> $GITHUB_STEP_SUMMARY
       - name: Upload CI logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ci-logs
           path: CI/out
@@ -150,14 +150,14 @@ jobs:
           html2text --ignore-images --ignore-links -b 0 htmlcov/index.html >> $GITHUB_STEP_SUMMARY
       - name: Upload coverage data
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage
           path: htmlcov
           if-no-files-found: error
       - name: Upload json coverage
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage.json
           path: coverage.json
@@ -176,17 +176,17 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
         - name: Check out doc repo
-          uses: actions/checkout@master
+          uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
           with:
             repository: krkn-chaos/krkn-lib-docs
             path: krkn-lib-docs
             ssh-key: ${{ secrets.KRKN_LIB_DOCS_PRIV_KEY }}
         - name: Download json coverage
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
           with:
             name: coverage.json
         - name: Set up Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
           with:
             python-version: '3.11'
         - name: Copy badge on GitHub Page Repo

--- a/.github/workflows/tests_v2.yml
+++ b/.github/workflows/tests_v2.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Create KinD cluster
-        uses: redhat-chaos/actions/kind@main
+        uses: redhat-chaos/actions/kind@aa421229ca6d4ad13785039d0736611c6439fc3e # main
 
       - name: Pre-load test images into KinD
         run: |
@@ -23,7 +23,7 @@ jobs:
           kind load docker-image quay.io/krkn-chaos/krkn:tools
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.11'
           architecture: 'x64'
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload tests_v2 artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: tests-v2-results
           path: |


### PR DESCRIPTION
# Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

# Description

Pins mutable GitHub Actions workflow references to immutable commit SHAs across repository workflows.

This change improves supply-chain security and aligns with OpenSSF Scorecard recommendations by replacing floating tags and branches (`@v3`, `@v4`, `@main`, `@master`) with their corresponding commit SHAs.

Changes included:

- Pinned GitHub-owned Actions to commit SHAs
- Pinned Docker Actions to commit SHAs
- Pinned reusable workflows from `krkn-chaos/actions`
- Pinned composite actions from `redhat-chaos/actions`
- Preserved original versions as comments (for example: `# v3`, `# v4`, `# main`, `# master`) for readability and future updates
- No workflow logic was modified
- No action versions were upgraded
- Existing workflow behavior remains unchanged because each SHA corresponds to the commit currently resolved by the original reference

## Related Tickets & Documents

- Related Issue #: #1319
- Closes #: #1319

# Documentation

- [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)

N/A

# Checklist before requesting a review

- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See https://krkn-chaos.dev/docs/contribution-guidelines/
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:

Description of combination of tests performed and output of run

This PR only modifies GitHub Actions workflow references and does not alter workflow logic, application code, deployment behavior, test execution, or runtime functionality.

Validation performed:

- Verified all mutable workflow references were replaced with immutable commit SHAs
- Verified no action versions were upgraded
- Verified all original version identifiers were preserved as comments
- Verified only the intended 7 workflow files were modified
- Verified `.github/workflows/scorecard-analysis.yml` was not modified because it is already SHA-pinned
- Verified `.github/workflows/pr-size-labeler.yml` was not modified because it is already SHA-pinned
- Reviewed resulting workflow diffs for syntax correctness
- Confirmed all replacements are direct SHA equivalents of the previously referenced tags or branches

```bash
git diff --stat upstream/main...HEAD

.github/workflows/docker-image.yml
.github/workflows/needs-rebase.yml
.github/workflows/release.yml
.github/workflows/require-docs.yml
.github/workflows/stale.yml
.github/workflows/tests.yml
.github/workflows/tests_v2.yml

7 files changed, 32 insertions(+), 32 deletions(-)
```