### PR TITLE
Add issue management

### DIFF
--- a/.github/workflows/linked-issue-to-pr-management.yml
+++ b/.github/workflows/linked-issue-to-pr-management.yml
@@ -1,0 +1,24 @@
+name: Linked Issue to PR Management
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issues:
+    types: [opened, labeled]
+
+jobs: 
+    handle-issue: 
+      if: github.event_name == 'issues'
+      permissions: 
+        issues: write
+        contents: read
+        pull-requests: write
+      uses: krkn-chaos/actions/.github/workflows/linked-issue-to-pr-management.yml@main
+    handle-pr: 
+      if: github.event_name == 'pull_request_target'
+      permissions: 
+        issues: write
+        contents: read
+        pull-requests: write
+      uses: krkn-chaos/actions/.github/workflows/linked-issue-to-pr-management.yml@main
+        


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
Completed Phase 1 of the GitHub Actions workflows that enforce an issue-first contribution process with automated gating, reviewer assignment, and stale management.

New Issue Opened
  → auto-label: needs-triage
  → bot comment: "awaiting maintainer review"
  → maintainers notified
       ↓
Maintainer Reviews
  → adds triage/accepted (or kind/bug skips this)
  → bot auto-assigns issue reporter (priority assignment)
  → bot: "you've been assigned, submit PR within 14 days"

## Related Tickets & Documents
- fixes #1418 

## Related Documentation PR (if applicable)  
[contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/) may need to be updated 

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)

*REQUIRED*:
Description of combination of tests performed and output of run
- tested the workflow on my own private repository and ensured the proper actions were triggered
