### PR TITLE
chore: add @ddjain to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @paigerube14 @tsebastiani @chaitanyaenr
+*   @paigerube14 @tsebastiani @chaitanyaenr @ddjain


### PR DESCRIPTION
## Summary
- Add `@ddjain` as a code owner in `.github/CODEOWNERS`

## Related
- Closes #1420

## Checklist
- No code changes — ownership metadata only