### PR TITLE
fix: use date -s instead of date --date for pod time skew

### DIFF
--- a/krkn/scenario_plugins/time_actions/time_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/time_actions/time_actions_scenario_plugin.py
@@ -60,21 +60,28 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
     def pod_exec(
         self, pod_name, command, namespace, container_name, kubecli: KrknKubernetes
     ):
+        response = None
         for i in range(5):
-            response = kubecli.exec_cmd_in_pod(
-                command, pod_name, namespace, container_name
-            )
-            if not response:
+            try:
+                response = kubecli.exec_cmd_in_pod(
+                    command, pod_name, namespace, container_name
+                )
+                if not response:
+                    time.sleep(2)
+                    continue
+                elif (
+                    "unauthorized" in response.lower()
+                    or "authorization" in response.lower()
+                    or "impossible to determine the shell" in response.lower()
+                ):
+                    time.sleep(2)
+                    continue
+                else:
+                    break
+            except Exception as e:
+                logging.warning(f"Transient error in pod_exec for {pod_name}: {e}")
                 time.sleep(2)
                 continue
-            elif (
-                "unauthorized" in response.lower()
-                or "authorization" in response.lower()
-            ):
-                time.sleep(2)
-                continue
-            else:
-                break
         return response
 
     def exec_with_shell_fallback(self, command, pod_name, namespace, container_name, kubecli: KrknKubernetes, max_retries=3):
@@ -198,9 +205,9 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
             return "node", node_names
 
         elif "pod" in scenario["object_type"]:
-            skew_command = "date --date "
+            skew_command = "date -s "
             if scenario["action"] == "skew_date":
-                skewed_date = "00-01-01"
+                skewed_date = "2000-01-01"
                 skew_command += skewed_date
             elif scenario["action"] == "skew_time":
                 skewed_time = "01:01:01"
@@ -341,63 +348,93 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
             for node_name in names:
                 first_date_time = datetime.datetime.utcnow()
                 check_pod_name = f"time-skew-pod-{get_random_string(5)}"
-                node_datetime_string = kubecli.exec_command_on_node(
-                    node_name, [skew_command], check_pod_name
-                )
-                node_datetime = self.string_to_date(node_datetime_string)
                 counter = 0
-                while not (
-                    first_date_time < node_datetime < datetime.datetime.utcnow()
-                ):
+                success = False
+
+                while counter <= max_retries:
+                    node_datetime = datetime.datetime(datetime.MINYEAR, 1, 1)
+                    node_datetime_string = ""
+                    try:
+                        if counter == 0:
+                            node_datetime_string = kubecli.exec_command_on_node(
+                                node_name, [skew_command], check_pod_name
+                            )
+                        else:
+                            node_datetime_string = kubecli.exec_cmd_in_pod(
+                                [skew_command], check_pod_name, "default"
+                            )
+                        
+                        if node_datetime_string:
+                            if "impossible to determine the shell" in node_datetime_string.lower() or "unauthorized" in node_datetime_string.lower():
+                                logging.warning(f"Exec error on node {node_name}: {node_datetime_string}")
+                            else:
+                                node_datetime = self.string_to_date(node_datetime_string)
+                    except Exception as e:
+                        logging.warning(f"Transient error checking date on node {node_name}: {e}")
+
+                    if first_date_time < node_datetime < datetime.datetime.utcnow():
+                        success = True
+                        logging.info("Date in node " + str(node_name) + " reset properly")
+                        break
+
                     time.sleep(10)
                     logging.info(
                         "Date/time on node %s still not reset, "
                         "waiting 10 seconds and retrying" % node_name
                     )
-
-                    node_datetime_string = kubecli.exec_cmd_in_pod(
-                        [skew_command], check_pod_name, "default"
-                    )
-                    node_datetime = self.string_to_date(node_datetime_string)
                     counter += 1
-                    if counter > max_retries:
-                        logging.error(
-                            "Date and time in node %s didn't reset properly" % node_name
-                        )
-                        not_reset.append(node_name)
-                        break
-                if counter < max_retries:
-                    logging.info("Date in node " + str(node_name) + " reset properly")
-                kubecli.delete_pod(check_pod_name)
+
+                if not success:
+                    logging.error(
+                        "Date and time in node %s didn't reset properly after %d retries" 
+                        % (node_name, max_retries)
+                    )
+                    not_reset.append(node_name)
+
+                try:
+                    kubecli.delete_pod(check_pod_name)
+                except Exception:
+                    pass
 
         elif object_type == "pod":
             for pod_name in names:
                 first_date_time = datetime.datetime.utcnow()
                 counter = 0
-                pod_datetime_string = self.pod_exec(
-                    pod_name[0], skew_command, pod_name[1], pod_name[2], kubecli
-                )
-                pod_datetime = self.string_to_date(pod_datetime_string)
-                while not (first_date_time < pod_datetime < datetime.datetime.utcnow()):
+                success = False
+
+                while counter <= max_retries:
+                    pod_datetime = datetime.datetime(datetime.MINYEAR, 1, 1)
+                    try:
+                        pod_datetime_string = self.pod_exec(
+                            pod_name[0], skew_command, pod_name[1], pod_name[2], kubecli
+                        )
+                        if pod_datetime_string:
+                            if "impossible to determine the shell" in pod_datetime_string.lower() or "unauthorized" in pod_datetime_string.lower():
+                                logging.warning(f"Exec error on pod {pod_name[0]}: {pod_datetime_string}")
+                            else:
+                                pod_datetime = self.string_to_date(pod_datetime_string)
+                    except Exception as e:
+                        logging.warning(f"Transient error checking date on pod {pod_name[0]}: {e}")
+
+                    if first_date_time < pod_datetime < datetime.datetime.utcnow():
+                        success = True
+                        logging.info("Date in pod " + str(pod_name[0]) + " reset properly")
+                        break
+
                     time.sleep(10)
                     logging.info(
                         "Date/time on pod %s still not reset, "
                         "waiting 10 seconds and retrying" % pod_name[0]
                     )
-                    pod_datetime = self.pod_exec(
-                        pod_name[0], skew_command, pod_name[1], pod_name[2], kubecli
-                    )
-                    pod_datetime = self.string_to_date(pod_datetime)
                     counter += 1
-                    if counter > max_retries:
-                        logging.error(
-                            "Date and time in pod %s didn't reset properly"
-                            % pod_name[0]
-                        )
-                        not_reset.append(pod_name[0])
-                        break
-                if counter < max_retries:
-                    logging.info("Date in pod " + str(pod_name[0]) + " reset properly")
+
+                if not success:
+                    logging.error(
+                        "Date and time in pod %s didn't reset properly after %d retries"
+                        % (pod_name[0], max_retries)
+                    )
+                    not_reset.append(pod_name[0])
+
         return not_reset
 
     def get_scenario_types(self) -> list[str]:

--- a/tests/test_time_actions_scenario_plugin.py
+++ b/tests/test_time_actions_scenario_plugin.py
@@ -165,6 +165,89 @@ class TestTimeActionsScenarioPlugin(unittest.TestCase):
         
         self.assertEqual(result, "success")
 
+    @patch('krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.time.sleep')
+    def test_pod_exec_handles_exceptions(self, mock_sleep):
+        """Test that pod_exec catches transient exceptions and retries"""
+        mock_kubecli = MagicMock()
+        mock_kubecli.exec_cmd_in_pod.side_effect = [Exception("Network error"), "impossible to determine the shell", "success"]
+        
+        result = self.plugin.pod_exec("pod", "cmd", "ns", "container", mock_kubecli)
+        
+        self.assertEqual(result, "success")
+        self.assertEqual(mock_kubecli.exec_cmd_in_pod.call_count, 3)
+
+    @patch('krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.datetime')
+    @patch('krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.time.sleep')
+    def test_check_date_time_pod_retry_on_exception(self, mock_sleep, mock_dt):
+        """Test that check_date_time for pods retries on transient failures then succeeds"""
+        import datetime as real_dt
+
+        mock_dt.MINYEAR = real_dt.MINYEAR
+        mock_dt.datetime.side_effect = lambda *a, **k: real_dt.datetime(*a, **k)
+
+        t_first = real_dt.datetime(2026, 1, 1, 0, 0, 0)
+        t_parsed = real_dt.datetime(2026, 1, 1, 0, 5, 0)
+        t_after = real_dt.datetime(2026, 1, 1, 0, 10, 0)
+
+        # Trace of utcnow() calls:
+        #   1. line 401: first_date_time = utcnow()  →  t_first
+        #   2. iter 0: pod_exec→False, pod_datetime stays MINYEAR, line 419 utcnow()  →  anything (comparison fails)
+        #   3. iter 1: pod_exec→False, same, line 419 utcnow()
+        #   4. iter 2: pod_exec→"str", string_to_date→t_parsed, line 419 utcnow()  →  t_after  (t_first < t_parsed < t_after → success!)
+        utcnow_returns = iter([t_first, t_after, t_after, t_after])
+        mock_dt.datetime.utcnow = MagicMock(side_effect=lambda: next(utcnow_returns, t_after))
+
+        mock_kubecli = MagicMock()
+
+        with patch.object(self.plugin, 'pod_exec') as mock_pod_exec, \
+             patch.object(self.plugin, 'string_to_date') as mock_s2d:
+
+            mock_pod_exec.side_effect = [False, False, "Thu Jan  1 00:05:00 UTC 2026"]
+            mock_s2d.return_value = t_parsed
+
+            names = [["test-pod", "default", "test-container"]]
+            not_reset = self.plugin.check_date_time("pod", names, mock_kubecli)
+
+            self.assertEqual(not_reset, [])
+            self.assertEqual(mock_pod_exec.call_count, 3)
+            self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch('krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.datetime')
+    @patch('krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.time.sleep')
+    def test_check_date_time_node_retry_on_exception(self, mock_sleep, mock_dt):
+        """Test that check_date_time for nodes retries on transient exec errors then succeeds"""
+        import datetime as real_dt
+
+        mock_dt.MINYEAR = real_dt.MINYEAR
+        mock_dt.datetime.side_effect = lambda *a, **k: real_dt.datetime(*a, **k)
+
+        t_first = real_dt.datetime(2026, 1, 1, 0, 0, 0)
+        t_parsed = real_dt.datetime(2026, 1, 1, 0, 5, 0)
+        t_after = real_dt.datetime(2026, 1, 1, 0, 10, 0)
+
+        # Trace of utcnow() calls:
+        #   1. line 349: first_date_time = utcnow()  →  t_first
+        #   2. iter 0 (counter==0): exec_command_on_node raises, line 375 utcnow()  →  anything
+        #   3. iter 1 (counter==1): exec_cmd_in_pod succeeds, string_to_date→t_parsed, line 375 utcnow() → t_after
+        utcnow_returns = iter([t_first, t_after, t_after])
+        mock_dt.datetime.utcnow = MagicMock(side_effect=lambda: next(utcnow_returns, t_after))
+
+        mock_kubecli = MagicMock()
+        mock_kubecli.exec_command_on_node.side_effect = Exception("TLS handshake error")
+        mock_kubecli.exec_cmd_in_pod.return_value = "Thu Jan  1 00:05:00 UTC 2026"
+
+        with patch.object(self.plugin, 'string_to_date') as mock_s2d:
+            mock_s2d.return_value = t_parsed
+
+            names = ["test-node"]
+            not_reset = self.plugin.check_date_time("node", names, mock_kubecli)
+
+            self.assertEqual(not_reset, [])
+            self.assertEqual(mock_kubecli.exec_command_on_node.call_count, 1)
+            self.assertEqual(mock_kubecli.exec_cmd_in_pod.call_count, 1)
+            self.assertEqual(mock_sleep.call_count, 1)
+
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  
Corrected the pod-level time skew command from `date --date ` (which is a read-only operation in Linux that only parses and prints the date) to `date -s ` (which actually sets the system/container clock).

Previously, the time skew scenario would run the read-only command and complete without actually skewing any pod clocks, yet misleadingly report success (`exit_status: 0`) after the verification loop timed out or matched the normal host clock.

Note that for this write operation to succeed inside container namespaces, target pods must have the `SYS_TIME` capability added to their security context:
```yaml
securityContext:
  capabilities:
    add:
      - SYS_TIME
```

## Related Tickets & Documents
- Related Issue #1422 
- Closes #1422 

# Documentation  
- [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)  
N/A

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

### Automated Tests
Ran the full unit test suite:
```bash
python -m unittest discover -s tests -v
...
Ran 1202 tests in 17.065s

OK
```

### Manual Verification / Scenario Run
Ran the time skew scenario on AKS targeting a patched nginx deployment with `SYS_TIME` capability:

```bash
python run_kraken.py --config config/aks-config.yaml
```

**Logs Output Snippet:**
```
2026-06-25 16:42:35,519 [INFO] Running TimeActionsScenarioPlugin: ['time_scenarios'] -> scenarios/kube/aks-time-skew.yml
2026-06-25 16:42:35,520 [INFO] Querying for the pods matching the app=nginx label_selector in namespace krkn-test
2026-06-25 16:42:40,050 [INFO] Reset date/time on pod nginx-7fc7468556-2qj8d
2026-06-25 16:42:43,722 [INFO] Reset date/time on pod nginx-7fc7468556-d47nl
2026-06-25 16:42:47,618 [INFO] Reset date/time on pod nginx-7fc7468556-nrtdd
2026-06-25 16:42:49,888 [INFO] Obj_date time Thu Jun 25 01:01:03 UTC 2026
2026-06-25 16:42:49,888 [INFO] Obj_date sub time Thu Jun 25 01:01:03 UTC 2026
2026-06-25 16:42:49,888 [INFO] Search response: Thu Jun 25 01:01:03 UTC 2026
2026-06-25 16:42:59,889 [INFO] Date/time on pod nginx-7fc7468556-2qj8d still not reset, waiting 10 seconds and retrying
...
2026-06-25 16:43:53,483 [INFO] Obj_date time Thu Jun 25 16:43:53 UTC 2026
2026-06-25 16:43:53,483 [INFO] Date in pod nginx-7fc7468556-2qj8d reset properly
...
2026-06-25 16:44:02,293 [INFO] Successfully finished running Kraken. UUID for the run: 0c973e21-62be-49ec-85c3-fccd40526234. Report generated at kraken.report. Exiting
```