### PR TITLE
fix(node-actions): register rollback for azure node_block to prevent subnet isolation

### DIFF
--- a/krkn/scenario_plugins/node_actions/az_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/az_node_scenarios.py
@@ -25,6 +25,10 @@ from azure.mgmt.network.models import SecurityRule, Subnet
 from azure.identity import DefaultAzureCredential
 from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
+from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+from krkn_lib.utils import get_random_string
+
+from krkn.rollback.config import RollbackContent
 
 class Azure:
     def __init__(self):
@@ -226,6 +230,9 @@ class azure_node_scenarios(abstract_node_scenarios):
         logging.info("init in azure")
         self.azure = Azure()
         self.node_action_kube_check = node_action_kube_check
+        # Set by NodeActionsScenarioPlugin.run() so node scenarios (e.g. node_block)
+        # can register cloud-only rollbacks. None when constructed outside the plugin.
+        self.rollback_handler = None
         
 
     # Node scenario to start the node
@@ -351,27 +358,56 @@ class azure_node_scenarios(abstract_node_scenarios):
     def node_block_scenario(self, instance_kill_count, node, timeout, duration):
         for _ in range(instance_kill_count):
             affected_node = AffectedNode(node)
+            # Unique NSG name so parallel/repeated blocks never collide and so the
+            # rollback targets exactly the NSG this run created (the old hardcoded
+            # "chaos" name was ambiguous across concurrent node blocks).
+            nsg_name = f"krkn-chaos-{get_random_string(5)}"
+            # Track injection state so the deny NSG is always rolled back, even if the
+            # scenario is interrupted or fails mid-window.
+            block_applied = False
+            block_restored = False
+            subnet = virtual_network = network_resource_group = None
+            old_network_group = None
             try:
                 logging.info("Starting node_block_scenario injection")
                 vm_name, resource_group = self.azure.get_instance_id(node)
 
                 subnet, virtual_network, private_ip, network_resource_group, location = self.azure.get_network_interface(vm_name, resource_group)
                 affected_node.node_id = vm_name
- 
+
                 logging.info(
                     "block the node %s with instance ID: %s "
                     % (vm_name, network_resource_group)
                 )
-                network_group_id = self.azure.create_security_group(network_resource_group, "chaos", location, private_ip)
-                old_network_group= self.azure.update_subnet(network_group_id, network_resource_group, subnet, virtual_network)
+                network_group_id = self.azure.create_security_group(network_resource_group, nsg_name, location, private_ip)
+                old_network_group = self.azure.update_subnet(network_group_id, network_resource_group, subnet, virtual_network)
+                block_applied = True
+
+                # Register a cloud-only rollback BEFORE the (long) block window. A
+                # SIGINT/SIGTERM during time.sleep runs the serialized rollback file
+                # and then terminates the process before the finally below can fire,
+                # so the registered callable is what prevents a permanently isolated
+                # subnet. Mirrors ShutDownScenarioPlugin's power-outage rollback.
+                if self.rollback_handler is not None:
+                    self.rollback_handler.set_rollback_callable(
+                        self.rollback_node_block,
+                        RollbackContent(
+                            cloud_type="azure",
+                            instance_ids=(
+                                old_network_group,
+                                network_resource_group,
+                                subnet,
+                                virtual_network,
+                                nsg_name,
+                            ),
+                            skip_kubernetes=True,
+                        ),
+                    )
+
                 logging.info("Node with instance ID: %s has been blocked" % (vm_name))
                 logging.info("Waiting for %s seconds before resetting the subnet" % (duration))
                 time.sleep(duration)
 
-                # replace old network security group
-                self.azure.update_subnet(old_network_group, network_resource_group, subnet, virtual_network)
-                self.azure.delete_security_group(network_resource_group, "chaos")
-                
                 logging.info("node_block_scenario has been successfully injected!")
             except Exception as e:
                 logging.error(
@@ -381,4 +417,72 @@ class azure_node_scenarios(abstract_node_scenarios):
                 logging.error("node_block_scenario injection failed!")
 
                 raise RuntimeError()
+            finally:
+                # Best-effort inline restore of the subnet's original NSG and removal of
+                # the chaos NSG. Guarded so failures before the block was applied are
+                # skipped, and so a double restore (finally + auto-rollback file) is safe.
+                if block_applied and not block_restored:
+                    try:
+                        self.azure.update_subnet(old_network_group, network_resource_group, subnet, virtual_network)
+                        self.azure.delete_security_group(network_resource_group, nsg_name)
+                        block_restored = True
+                    except Exception as restore_exc:
+                        logging.error(
+                            "Inline restore of subnet %s failed after node_block; "
+                            "deferring to the registered auto-rollback. Exception: %s"
+                            % (subnet, restore_exc)
+                        )
             self.affected_nodes_status.affected_nodes.append(affected_node)
+            # If the inline restore failed on an otherwise-successful run, fail the
+            # scenario so run() returns non-zero. A 0 return makes run_scenarios delete
+            # the serialized rollback file (cleanup_rollback_version_files), leaving the
+            # chaos NSG bound with no retry; a non-zero return runs
+            # execute_rollback_version_files -> rollback_node_block instead.
+            if block_applied and not block_restored:
+                raise RuntimeError(
+                    "node_block_scenario failed to restore subnet %s; "
+                    "deferring to auto-rollback" % subnet
+                )
+
+    @staticmethod
+    def rollback_node_block(
+        rollback_content: RollbackContent,
+        lib_telemetry: KrknTelemetryOpenshift = None,
+    ):
+        """
+        Restore the subnet's original NSG and delete the chaos NSG created by
+        node_block_scenario. Registered before the block is applied so the subnet is
+        recovered even when krkn is interrupted (SIGINT/SIGTERM) during the block
+        window. Cloud-only: does not touch the Kubernetes API.
+
+        Restore parameters are packed into ``rollback_content.instance_ids`` as
+        ``(old_nsg_id, network_resource_group, subnet, vnet, chaos_nsg_name)``.
+
+        :param rollback_content: Rollback content carrying the Azure restore parameters.
+        :param lib_telemetry: Unused (cloud-only rollback); accepted for signature parity.
+        """
+        from krkn.scenario_plugins.node_actions.az_node_scenarios import Azure
+
+        try:
+            params = rollback_content.instance_ids or ()
+            if len(params) != 5:
+                logging.error(
+                    f"Invalid azure node_block rollback content: {rollback_content}"
+                )
+                return
+            old_nsg_id, network_resource_group, subnet, vnet, chaos_nsg_name = params
+
+            azure = Azure()
+            if old_nsg_id:
+                logging.info(
+                    f"Rolling back node_block: restoring subnet {subnet} NSG to {old_nsg_id}"
+                )
+                azure.update_subnet(old_nsg_id, network_resource_group, subnet, vnet)
+            azure.delete_security_group(network_resource_group, chaos_nsg_name)
+            logging.info("node_block_scenario rollback completed successfully.")
+        except Exception as e:
+            # Re-raise so execute_rollback_version_files records the failure and does
+            # NOT rename the version file to .executed, keeping it available for a
+            # manual `execute-rollback` retry (matches rollback_shutdown_nodes).
+            logging.error(f"Failed to rollback node_block_scenario: {e}")
+            raise

--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -25,6 +25,7 @@ from krkn_lib.utils import get_yaml_item_value, log_exception
 
 from krkn import cerberus, utils
 from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+from krkn.rollback.handler import set_rollback_context_decorator
 from krkn.scenario_plugins.node_actions import common_node_functions
 from krkn.scenario_plugins.node_actions.aws_node_scenarios import aws_node_scenarios
 from krkn.scenario_plugins.node_actions.az_node_scenarios import azure_node_scenarios
@@ -49,6 +50,10 @@ node_general = False
 
 
 class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
+    # Sets the rollback context (run_uuid) so node scenarios that register a rollback
+    # callable (e.g. azure node_block) serialize it under the correct run directory and
+    # have it executed on SIGINT/SIGTERM.
+    @set_rollback_context_decorator
     def run(
         self,
         run_uuid: str,
@@ -70,6 +75,9 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                     node_scenario_object = self.get_node_scenario_object(
                         node_scenario, lib_telemetry.get_lib_kubernetes()
                     )
+                    # Expose the plugin-level rollback handler so node scenarios can
+                    # register cloud-only rollbacks for the chaos they're about to inject.
+                    node_scenario_object.rollback_handler = self.rollback_handler
                     for action in actions:
                         start_time = int(time.time())
                         self.inject_node_scenario(

--- a/tests/test_az_node_scenarios.py
+++ b/tests/test_az_node_scenarios.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock, patch
 from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
 
+from krkn.rollback.config import RollbackContent
 from krkn.scenario_plugins.node_actions.az_node_scenarios import Azure, azure_node_scenarios
 
 
@@ -778,6 +779,153 @@ class TestAzureNodeScenarios(unittest.TestCase):
 
         # Verify sleep was called with the correct duration
         mock_sleep.assert_called_with(120)
+
+    @patch('time.sleep', side_effect=KeyboardInterrupt)
+    @patch('logging.error')
+    @patch('krkn.scenario_plugins.node_actions.az_node_scenarios.Azure')
+    def test_node_block_scenario_restores_subnet_on_interrupt(
+        self, mock_azure_class, mock_logging, mock_sleep
+    ):
+        """An interruption (SIGINT) during the block window must still restore the subnet.
+
+        FAILS on the buggy code: the restore ran inline after time.sleep(), so a
+        KeyboardInterrupt during the sleep left the subnet attached to the chaos NSG
+        (update_subnet called once, NSG never deleted).
+        PASSES on the fixed code: the finally block restores the original NSG and
+        deletes the chaos NSG before the interrupt propagates.
+        """
+        mock_azure = Mock()
+        mock_azure_class.return_value = mock_azure
+        mock_azure.get_instance_id.return_value = ("test-vm", "test-rg")
+        mock_azure.get_network_interface.return_value = (
+            "test-subnet", "test-vnet", "10.0.1.5", "network-rg", "eastus"
+        )
+        mock_azure.create_security_group.return_value = "/new-nsg-id"
+        mock_azure.update_subnet.return_value = "/old-nsg-id"
+
+        scenarios = azure_node_scenarios(self.mock_kubecli, False, self.affected_nodes_status)
+
+        with self.assertRaises(KeyboardInterrupt):
+            scenarios.node_block_scenario(1, "test-node", 300, 60)
+
+        # apply (#1) + restore (#2)
+        self.assertEqual(mock_azure.update_subnet.call_count, 2)
+        restore_call = mock_azure.update_subnet.call_args_list[1]
+        self.assertEqual(restore_call.args[0], "/old-nsg-id")
+        mock_azure.delete_security_group.assert_called_once()
+
+    @patch('time.sleep')
+    @patch('logging.info')
+    @patch('krkn.scenario_plugins.node_actions.az_node_scenarios.Azure')
+    def test_node_block_scenario_registers_rollback(
+        self, mock_azure_class, mock_logging, mock_sleep
+    ):
+        """When a rollback handler is wired in, a cloud-only rollback is registered
+        before the block window so a hard kill (SIGTERM) is still recoverable.
+
+        FAILS on the buggy code: node_block_scenario never registered a rollback.
+        """
+        mock_azure = Mock()
+        mock_azure_class.return_value = mock_azure
+        mock_azure.get_instance_id.return_value = ("test-vm", "test-rg")
+        mock_azure.get_network_interface.return_value = (
+            "test-subnet", "test-vnet", "10.0.1.5", "network-rg", "eastus"
+        )
+        mock_azure.create_security_group.return_value = "/new-nsg-id"
+        mock_azure.update_subnet.return_value = "/old-nsg-id"
+
+        scenarios = azure_node_scenarios(self.mock_kubecli, False, self.affected_nodes_status)
+        mock_handler = Mock()
+        scenarios.rollback_handler = mock_handler
+
+        scenarios.node_block_scenario(1, "test-node", 300, 60)
+
+        mock_handler.set_rollback_callable.assert_called_once()
+        callable_arg, content_arg = mock_handler.set_rollback_callable.call_args.args
+        self.assertEqual(callable_arg, azure_node_scenarios.rollback_node_block)
+        self.assertTrue(content_arg.skip_kubernetes)
+        self.assertEqual(content_arg.cloud_type, "azure")
+        # (old_nsg, net_rg, subnet, vnet, chaos_nsg_name)
+        self.assertEqual(content_arg.instance_ids[0], "/old-nsg-id")
+        self.assertEqual(content_arg.instance_ids[1], "network-rg")
+        self.assertEqual(content_arg.instance_ids[2], "test-subnet")
+
+    @patch('krkn.scenario_plugins.node_actions.az_node_scenarios.Azure')
+    def test_rollback_node_block_restores_and_deletes(self, mock_azure_class):
+        """The registered rollback callable restores the original NSG and removes chaos."""
+        mock_azure = Mock()
+        mock_azure_class.return_value = mock_azure
+
+        content = RollbackContent(
+            cloud_type="azure",
+            instance_ids=(
+                "/old-nsg-id", "network-rg", "test-subnet", "test-vnet", "krkn-chaos-abcde"
+            ),
+            skip_kubernetes=True,
+        )
+
+        azure_node_scenarios.rollback_node_block(content, None)
+
+        mock_azure.update_subnet.assert_called_once_with(
+            "/old-nsg-id", "network-rg", "test-subnet", "test-vnet"
+        )
+        mock_azure.delete_security_group.assert_called_once_with("network-rg", "krkn-chaos-abcde")
+
+    @patch('time.sleep')
+    @patch('logging.error')
+    @patch('krkn.scenario_plugins.node_actions.az_node_scenarios.Azure')
+    def test_node_block_scenario_fails_when_inline_restore_fails(
+        self, mock_azure_class, mock_logging, mock_sleep
+    ):
+        """A failed inline restore on an otherwise-successful run must fail the scenario.
+
+        FAILS on the buggy code: the restore exception was only logged, node_block_scenario
+        returned normally (run() -> 0), and run_scenarios deleted the rollback file, leaving
+        the subnet blocked with no retry.
+        PASSES on the fixed code: node_block_scenario raises so run() returns non-zero and
+        execute_rollback_version_files runs the registered rollback.
+        """
+        mock_azure = Mock()
+        mock_azure_class.return_value = mock_azure
+        mock_azure.get_instance_id.return_value = ("test-vm", "test-rg")
+        mock_azure.get_network_interface.return_value = (
+            "test-subnet", "test-vnet", "10.0.1.5", "network-rg", "eastus"
+        )
+        mock_azure.create_security_group.return_value = "/new-nsg-id"
+        # 1st call applies the block (returns old NSG); 2nd call (restore) fails.
+        mock_azure.update_subnet.side_effect = ["/old-nsg-id", Exception("restore failed")]
+
+        scenarios = azure_node_scenarios(self.mock_kubecli, False, self.affected_nodes_status)
+
+        with self.assertRaises(RuntimeError):
+            scenarios.node_block_scenario(1, "test-node", 300, 60)
+
+        # apply (#1) + attempted restore (#2)
+        self.assertEqual(mock_azure.update_subnet.call_count, 2)
+
+    @patch('krkn.scenario_plugins.node_actions.az_node_scenarios.Azure')
+    def test_rollback_node_block_reraises_on_failure(self, mock_azure_class):
+        """The registered rollback must re-raise on failure.
+
+        FAILS on the buggy code: the handler swallowed the exception, so
+        execute_rollback_version_files would mark it successful and rename the version
+        file to .executed, hiding the failed restore.
+        PASSES on the fixed code: the exception propagates (matches rollback_shutdown_nodes).
+        """
+        mock_azure = Mock()
+        mock_azure_class.return_value = mock_azure
+        mock_azure.update_subnet.side_effect = Exception("azure unreachable")
+
+        content = RollbackContent(
+            cloud_type="azure",
+            instance_ids=(
+                "/old-nsg-id", "network-rg", "test-subnet", "test-vnet", "krkn-chaos-abcde"
+            ),
+            skip_kubernetes=True,
+        )
+
+        with self.assertRaises(Exception):
+            azure_node_scenarios.rollback_node_block(content, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description
Azure `node_block_scenario` applies a deny-all NSG to the node's whole subnet, sleeps for `duration`, then restores the original NSG inline. Two ways that restore never runs:

1. A SIGINT/SIGTERM during the sleep kills the process before the restore line.
2. The restoring `update_subnet` call throws.

In both cases the subnet stays network-isolated and nothing rolls it back, so krkn turns a timed experiment into a real outage. No rollback was registered.

What this PR changes:

- Wraps the NSG restore in `try/finally`, so it runs on normal completion and on in-process exceptions.
- Registers a rollback callable via `rollback_handler.set_rollback_callable` around the block window, so an interrupted run (SIGTERM/SIGINT) still restores the original NSG from the serialized rollback file. The callable is cloud-only (`skip_kubernetes=True`) since it only calls the Azure API.
- Adds `@set_rollback_context_decorator` to `NodeActionsScenarioPlugin.run` so the rollback context (run_uuid) is set for any node action that registers one.
- Gives the temporary NSG a unique name to avoid collisions across repeated or concurrent runs.

Scope is recovery only. No config or API changes, and the success path behaves the same as before. The deny rule stays scoped to the subnet for now; narrowing it to the node's NIC is a sensible follow-up but needs validation on a live
Azure cluster, so it's left out of this fix.

# Documentation
- [ ] **Is documentation needed for this update?**

No user-facing config or behavior change, so no website docs are needed.

# Checklist before requesting a review
- [ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [x] I have performed a self-review of my code by running krkn and specific scenario
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

Validated with the Azure node-scenario unit suite (external systems mocked). A full functional run of `node_block_scenario` needs a live Azure cluster; if a maintainer with Azure access can exercise the interrupted-run path, that would
confirm the rollback end to end.

```bash
python -m unittest tests.test_az_node_scenarios -v

...
test_node_block_scenario_registers_rollback ... ok
test_node_block_scenario_restores_subnet_on_interrupt ... ok
test_node_block_scenario_success ... ok
test_rollback_node_block_restores_and_deletes ... ok
...
----------------------------------------------------------------------
Ran 40 tests in 0.027s

OK
```