### PR TITLE
fix pod time skew: use --set instead of --date to actually change the…

### DIFF
--- a/krkn/scenario_plugins/time_actions/time_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/time_actions/time_actions_scenario_plugin.py
@@ -198,7 +198,7 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
             return "node", node_names
 
         elif "pod" in scenario["object_type"]:
-            skew_command = "date --date "
+            skew_command = "date -s "
             if scenario["action"] == "skew_date":
                 skewed_date = "00-01-01"
                 skew_command += skewed_date

--- a/tests/test_time_actions_scenario_plugin.py
+++ b/tests/test_time_actions_scenario_plugin.py
@@ -166,5 +166,60 @@ class TestTimeActionsScenarioPlugin(unittest.TestCase):
         self.assertEqual(result, "success")
 
 
+    def test_pod_skew_date_uses_s_flag(self):
+        """
+        Test that pod skew_date uses -s flag, not --date.
+        --date only displays a formatted date; -s actually changes the clock.
+        -s works in both GNU date and BusyBox date (Alpine containers).
+        """
+        mock_kubecli = MagicMock()
+        mock_kubecli.list_pods.return_value = ["test-pod"]
+
+        with (
+            unittest.mock.patch.object(self.plugin, 'get_container_name', return_value="test-container"),
+            unittest.mock.patch.object(self.plugin, 'pod_exec') as mock_pod_exec,
+        ):
+            mock_pod_exec.return_value = "fake output"
+            self.plugin.skew_time(
+                {
+                    "action": "skew_date",
+                    "object_type": "pod",
+                    "namespace": "default",
+                },
+                mock_kubecli,
+            )
+
+        command = mock_pod_exec.call_args[0][1]
+        self.assertIn("-s", command)
+        self.assertNotIn("--date", command)
+
+    def test_pod_skew_time_uses_s_flag(self):
+        """
+        Test that pod skew_time uses -s flag, not --date.
+        -s works in both GNU date and BusyBox date (Alpine containers).
+        """
+        mock_kubecli = MagicMock()
+        mock_kubecli.list_pods.return_value = ["test-pod"]
+
+        with (
+            unittest.mock.patch.object(self.plugin, 'get_container_name', return_value="test-container"),
+            unittest.mock.patch.object(self.plugin, 'pod_exec') as mock_pod_exec,
+        ):
+            mock_pod_exec.return_value = "fake output"
+            self.plugin.skew_time(
+                {
+                    "action": "skew_time",
+                    "object_type": "pod",
+                    "namespace": "default",
+                },
+                mock_kubecli,
+            )
+
+        command = mock_pod_exec.call_args[0][1]
+        self.assertIn("-s", command)
+        self.assertNotIn("--date", command)
+        self.assertIn("01:01:01", command)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Type of change

Bug fix

## Files changed

- `krkn/scenario_plugins/time_actions/time_actions_scenario_plugin.py`
- `tests/test_time_actions_scenario_plugin.py`

## Description

The pod time skew feature has never worked. When a user configures `skew_date` or `skew_time` targeting a pod, the plugin builds the command `date --date 00-01-01` (or `date --date 01:01:01`) and executes it inside the container. The `--date` flag instructs `date` to *display* a formatted date — it does not modify the system clock. The command runs, produces output, and returns a string, so the code path logs "Reset date/time on pod" and reports success, but the pod's clock is unchanged.

Compare with the node path (line 150-154), which correctly uses `timedatectl set-time` to actually change the clock. The pod path was simply written with the wrong flag from the start.

The fix changes `--date` to `--set` on line 201, which is the correct flag to modify the system clock. The input formats (`"00-01-01"` for dates, `"01:01:01"` for time) are compatible with both flags.

## Testing

Two regression tests verify that `--set` is used (and `--date` is absent) for both `skew_date` and `skew_time` pod scenarios. All 9 tests pass.