### PR TITLE
feat(tests): migrate pod error scenario tests to v2 framework

### DIFF
--- a/CI/tests_v2/lib/utils.py
+++ b/CI/tests_v2/lib/utils.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 # no-op (e.g. a selector matched nothing) and the happy-path test should fail.
 SCENARIO_EXECUTION_MARKERS = {
     "pod_disruption": r"Deleting pod |waiting up to .* seconds for pod recovery",
+    "pod_error_scenarios": r"Deleting pod |waiting up to .* seconds for pod recovery",
     "application_outage": r"Creating the network policy|Deleting the network policy",
     "storage_throttle": r"Setting io\.max|Verified blkio settings|Privileged pod deployed",
     "namespace_deletion": r"Delete objects in selected namespace|Deleted all objects in namespace",

--- a/CI/tests_v2/pytest.ini
+++ b/CI/tests_v2/pytest.ini
@@ -8,6 +8,7 @@ addopts = -v
 markers =
     functional: marks a test as a functional test (deselect with '-m "not functional"')
     pod_disruption: marks a test as a pod disruption scenario test
+    pod_error_scenarios: marks a test as a pod error/failure-mode scenario test
     application_outage: marks a test as an application outage scenario test
     storage_throttle: marks a test as a storage throttle scenario test
     cpu_hog: marks a test as a CPU hog scenario test

--- a/CI/tests_v2/scenarios/pod_error_scenarios/resource.yaml
+++ b/CI/tests_v2/scenarios/pod_error_scenarios/resource.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: krkn-pod-error-target
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: krkn-pod-error-target
+  template:
+    metadata:
+      labels:
+        app: krkn-pod-error-target
+    spec:
+      containers:
+      - name: app
+        image: nginx:alpine
+        ports:
+        - containerPort: 80

--- a/CI/tests_v2/scenarios/pod_error_scenarios/scenario_base.yaml
+++ b/CI/tests_v2/scenarios/pod_error_scenarios/scenario_base.yaml
@@ -1,0 +1,6 @@
+- id: kill-pods
+  config:
+    namespace_pattern: "^default$"
+    label_selector: app=krkn-pod-error-target
+    krkn_pod_recovery_time: 120
+    kill: 1

--- a/CI/tests_v2/scenarios/pod_error_scenarios/test_pod_error_scenarios.py
+++ b/CI/tests_v2/scenarios/pod_error_scenarios/test_pod_error_scenarios.py
@@ -29,7 +29,7 @@ class TestPodErrorScenarios(BaseScenarioTest):
 
     # -- Helper assertions -------------------------------------------
 
-    def assert_no_hang_and_correct_logs(self, result, ns, expected_reasons, expected_keywords=None):
+    def assert_failure_logs_contain(self, result, ns, expected_reasons, expected_keywords=None):
         # Timeouts / hangs are caught at the execution level by run_kraken (raises
         # TimeoutExpired) or pytest timeout budgets. Reaching here guarantees the run completed.
         
@@ -80,7 +80,7 @@ class TestPodErrorScenarios(BaseScenarioTest):
         ns = self.ns
         result = self.run_scenario(self.tmp_path, ns, overrides={"kill": 100})
         assert_kraken_failure(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
-        self.assert_no_hang_and_correct_logs(
+        self.assert_failure_logs_contain(
             result, ns, expected_reasons=["not enough pods match", "expected 100", "found only 2 pods"]
         )
 
@@ -95,7 +95,7 @@ class TestPodErrorScenarios(BaseScenarioTest):
         assert_kraken_failure(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
         
         # Verify no hang and logs contain namespace and expected timeout/recovery errors
-        self.assert_no_hang_and_correct_logs(
+        self.assert_failure_logs_contain(
             result, ns, expected_reasons=["timeout", "recover"]
         )
         
@@ -113,7 +113,7 @@ class TestPodErrorScenarios(BaseScenarioTest):
         )
         result = self.run_kraken(config_path)
         assert_kraken_failure(result, context="invalid namespace pattern", tmp_path=self.tmp_path)
-        self.assert_no_hang_and_correct_logs(
+        self.assert_failure_logs_contain(
             result, "nonexistent-ns-xyz", expected_reasons=["not enough pods match", "expected 1", "found only 0 pods"]
         )
 
@@ -121,6 +121,6 @@ class TestPodErrorScenarios(BaseScenarioTest):
         ns = self.ns
         result = self.run_scenario(self.tmp_path, ns, overrides={"label_selector": "app=nonexistent"})
         assert_kraken_failure(result, context=f"namespace={ns}, label mismatch", tmp_path=self.tmp_path)
-        self.assert_no_hang_and_correct_logs(
+        self.assert_failure_logs_contain(
             result, ns, expected_reasons=["not enough pods match", "expected 1", "found only 0 pods"]
         )

--- a/CI/tests_v2/scenarios/pod_error_scenarios/test_pod_error_scenarios.py
+++ b/CI/tests_v2/scenarios/pod_error_scenarios/test_pod_error_scenarios.py
@@ -80,6 +80,9 @@ class TestPodErrorScenarios(BaseScenarioTest):
         ns = self.ns
         result = self.run_scenario(self.tmp_path, ns, overrides={"kill": 100})
         assert_kraken_failure(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
+        # Expected error text must match the message raised at
+        # pod_disruption_scenario_plugin.py:234. Update both together
+        # if that message wording changes.
         self.assert_failure_logs_contain(
             result, ns, expected_reasons=["not enough pods match", "expected 100", "found only 2 pods"]
         )

--- a/CI/tests_v2/scenarios/pod_error_scenarios/test_pod_error_scenarios.py
+++ b/CI/tests_v2/scenarios/pod_error_scenarios/test_pod_error_scenarios.py
@@ -1,0 +1,126 @@
+"""
+Functional test for pod error / failure-mode coverage.
+Migrated from CI/tests/test_pod_error.sh with expected-failure semantics added.
+"""
+
+import pytest
+
+from lib.base import BaseScenarioTest
+from lib.utils import (
+    assert_kraken_failure,
+    assert_kraken_success,
+    assert_scenario_executed,
+    get_pods_list,
+    pod_uids,
+)
+
+
+@pytest.mark.functional
+@pytest.mark.pod_error_scenarios
+class TestPodErrorScenarios(BaseScenarioTest):
+    WORKLOAD_MANIFEST = "CI/tests_v2/scenarios/pod_error_scenarios/resource.yaml"
+    WORKLOAD_IS_PATH = True
+    LABEL_SELECTOR = "app=krkn-pod-error-target"
+    SCENARIO_NAME = "pod_error_scenarios"
+    SCENARIO_TYPE = "pod_disruption_scenarios"
+    NAMESPACE_KEY_PATH = [0, "config", "namespace_pattern"]
+    NAMESPACE_IS_REGEX = True
+    OVERRIDES_KEY_PATH = [0, "config"]
+
+    # -- Helper assertions -------------------------------------------
+
+    def assert_no_hang_and_correct_logs(self, result, ns, expected_reasons, expected_keywords=None):
+        # Timeouts / hangs are caught at the execution level by run_kraken (raises
+        # TimeoutExpired) or pytest timeout budgets. Reaching here guarantees the run completed.
+        
+        combined = (result.stdout or "") + "\n" + (result.stderr or "")
+        combined_lower = combined.lower()
+        
+        # Assert namespace is in the logs
+        assert ns.lower() in combined_lower, f"Expected namespace '{ns}' not found in logs"
+        
+        # Assert failure reasons are in the logs
+        for reason in expected_reasons:
+            assert reason.lower() in combined_lower, f"Expected failure reason '{reason}' not found in logs"
+            
+        if expected_keywords:
+            for kw in expected_keywords:
+                assert kw.lower() in combined_lower, f"Expected log keyword '{kw}' not found in logs"
+
+    # -- Happy path --------------------------------------------------
+
+    @pytest.mark.order(1)
+    def test_kill_one_pod_recovers(self, wait_for_pods_running):
+        ns = self.ns
+        result = self.run_scenario(self.tmp_path, ns)
+        assert_kraken_success(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
+        assert_scenario_executed(result, self.SCENARIO_NAME, context=f"namespace={ns}", tmp_path=self.tmp_path)
+        wait_for_pods_running(ns, self.LABEL_SELECTOR, timeout=90)
+
+    @pytest.mark.order(2)
+    def test_kill_multiple_pods(self, wait_for_pods_running):
+        ns = self.ns
+        before = get_pods_list(self.k8s_core, ns, self.LABEL_SELECTOR)
+        before_uids = set(pod_uids(before))
+
+        result = self.run_scenario(self.tmp_path, ns, overrides={"kill": 2})
+        assert_kraken_success(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
+        assert_scenario_executed(result, self.SCENARIO_NAME, context=f"namespace={ns}", tmp_path=self.tmp_path)
+
+        wait_for_pods_running(ns, self.LABEL_SELECTOR, timeout=90)
+        after = get_pods_list(self.k8s_core, ns, self.LABEL_SELECTOR)
+        after_uids = set(pod_uids(after))
+        assert before_uids.isdisjoint(after_uids), (
+            f"Expected both pods replaced (namespace={ns}). before={before_uids} after={after_uids}"
+        )
+
+    # -- Negative / failure-mode --------------------------------------
+
+    def test_excessive_kill_count_fails(self):
+        ns = self.ns
+        result = self.run_scenario(self.tmp_path, ns, overrides={"kill": 100})
+        assert_kraken_failure(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
+        self.assert_no_hang_and_correct_logs(
+            result, ns, expected_reasons=["not enough pods match", "expected 100", "found only 2 pods"]
+        )
+
+    def test_recovery_timeout_fails(self):
+        ns = self.ns
+        before = get_pods_list(self.k8s_core, ns, self.LABEL_SELECTOR)
+        before_names = [p.metadata.name for p in before.items]
+
+        result = self.run_scenario(
+            self.tmp_path, ns, overrides={"krkn_pod_recovery_time": 1}
+        )
+        assert_kraken_failure(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
+        
+        # Verify no hang and logs contain namespace and expected timeout/recovery errors
+        self.assert_no_hang_and_correct_logs(
+            result, ns, expected_reasons=["timeout", "recover"]
+        )
+        
+        # Verify at least one target pod name is in the logs
+        combined_lower = ((result.stdout or "") + "\n" + (result.stderr or "")).lower()
+        found_pod = any(name.lower() in combined_lower for name in before_names)
+        assert found_pod, f"None of the target pods {before_names} were found in failure logs"
+
+    @pytest.mark.no_workload
+    def test_invalid_namespace_pattern_fails(self):
+        scenario = self.load_and_patch_scenario(self.repo_root, "nonexistent-ns-xyz")
+        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_bad_ns")
+        config_path = self.build_config(
+            self.SCENARIO_TYPE, str(scenario_path), filename="pod_error_bad_ns_config.yaml"
+        )
+        result = self.run_kraken(config_path)
+        assert_kraken_failure(result, context="invalid namespace pattern", tmp_path=self.tmp_path)
+        self.assert_no_hang_and_correct_logs(
+            result, "nonexistent-ns-xyz", expected_reasons=["not enough pods match", "expected 1", "found only 0 pods"]
+        )
+
+    def test_zero_pods_matching_label_fails(self):
+        ns = self.ns
+        result = self.run_scenario(self.tmp_path, ns, overrides={"label_selector": "app=nonexistent"})
+        assert_kraken_failure(result, context=f"namespace={ns}, label mismatch", tmp_path=self.tmp_path)
+        self.assert_no_hang_and_correct_logs(
+            result, ns, expected_reasons=["not enough pods match", "expected 1", "found only 0 pods"]
+        )

--- a/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
@@ -12,6 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
+
+# --- Python 3.12+ aliyunsdkcore vendored six compatibility patch ---
+import importlib
+import importlib.util
+
+class VendoredSixRedirect:
+    def find_spec(self, fullname, path, target=None):
+        if '.six' in fullname:
+            parts = fullname.split('.')
+            if 'six' in parts:
+                idx = parts.index('six')
+                std_fullname = '.'.join(['six'] + parts[idx+1:])
+                try:
+                    mod = importlib.import_module(std_fullname)
+                    sys.modules[fullname] = mod
+                    return importlib.util.find_spec(std_fullname)
+                except Exception:
+                    pass
+        return None
+
+sys.meta_path.insert(0, VendoredSixRedirect())
+# -------------------------------------------------------------------
+
 import time
 import logging
 import krkn.scenario_plugins.node_actions.common_node_functions as nodeaction

--- a/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/alibaba_node_scenarios.py
@@ -12,29 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import sys
-
-# --- Python 3.12+ aliyunsdkcore vendored six compatibility patch ---
-import importlib
-import importlib.util
-
-class VendoredSixRedirect:
-    def find_spec(self, fullname, path, target=None):
-        if '.six' in fullname:
-            parts = fullname.split('.')
-            if 'six' in parts:
-                idx = parts.index('six')
-                std_fullname = '.'.join(['six'] + parts[idx+1:])
-                try:
-                    mod = importlib.import_module(std_fullname)
-                    sys.modules[fullname] = mod
-                    return importlib.util.find_spec(std_fullname)
-                except Exception:
-                    pass
-        return None
-
-sys.meta_path.insert(0, VendoredSixRedirect())
-# -------------------------------------------------------------------
-
 import time
 import logging
 import krkn.scenario_plugins.node_actions.common_node_functions as nodeaction


### PR DESCRIPTION
# Type of change
- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description
Migrates `CI/tests/test_pod_error.sh` to the v2 pytest framework under
`CI/tests_v2/scenarios/pod_error_scenarios/`. Covers happy-path pod kill/recovery
(single and multiple pods) and negative/failure-mode cases (excessive kill count,
recovery timeout, invalid namespace pattern, zero-match label selector), with
assertions on failure logs containing pod/namespace context.

New/modified files:
- `CI/tests_v2/scenarios/pod_error_scenarios/resource.yaml` — 2-replica nginx deployment
- `CI/tests_v2/scenarios/pod_error_scenarios/scenario_base.yaml` — base `pod_disruption_scenarios` config
- `CI/tests_v2/scenarios/pod_error_scenarios/test_pod_error_scenarios.py` — `TestPodErrorScenarios`
- `CI/tests_v2/pytest.ini` — registers `pod_error_scenarios` marker
- `CI/tests_v2/lib/utils.py` — registers `pod_error_scenarios` in `SCENARIO_EXECUTION_MARKERS`

## Related Tickets & Documents
- Related Issue #: #1438
- Closes #: #1438

# Documentation
- [ ] **Is documentation needed for this update?**
No — this is test-infrastructure-only and doesn't change user-facing behavior or scenario config surface.

## Related Documentation PR (if applicable)
N/A

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [x] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage *(N/A — this PR itself is the test coverage)*

**Description of combination of tests performed and output of run:**
```bash
pytest CI/tests_v2/ -v -m pod_error_scenarios --log-cli-level=DEBUG
============================= test session starts =============================
platform win32 -- Python 3.12.10, pytest-9.0.3, pluggy-1.6.0 -- C:\Users\Harsh\krkn\venv\Scripts\python.exe
cachedir: .pytest_cache
metadata: {'Python': '3.12.10', 'Platform': 'Windows-11-10.0.26200-SP0', 'Packages': {'pytest': '9.0.3', 'pluggy': '1.6.0'}, 'Plugins': {'html': '4.2.0', 'metadata': '3.1.1', 'order': '1.5.0', 'rerunfailures': '16.3', 'timeout': '2.4.0', 'xdist': '3.8.0'}}
rootdir: C:\Users\Harsh\krkn\CI\tests_v2
configfile: pytest.ini
plugins: html-4.2.0, metadata-3.1.1, order-1.5.0, rerunfailures-16.3, timeout-2.4.0, xdist-3.8.0
collecting ... collected 38 items / 32 deselected / 6 selected

CI\tests_v2\scenarios\pod_error_scenarios\test_pod_error_scenarios.py::TestPodErrorScenarios::test_kill_one_pod_recovers 
------------------------------- live log setup --------------------------------
INFO     lib.k8s:k8s.py:20 Kube config loaded successfully
INFO     lib.k8s:k8s.py:62 Running tests against cluster: context=kind-ci-krkn cluster=kind-ci-krkn
INFO     lib.preflight:preflight.py:48 Preflight: Kubernetes control plane is running at https://127.0.0.1:64240
INFO     lib.namespace:namespace.py:109 Created test namespace: krkn-test-30f3f25c
INFO     lib.base:base.py:113 Deploying workload from C:\Users\Harsh\krkn\CI\tests_v2\scenarios\pod_error_scenarios\resource.yaml in ns=krkn-test-30f3f25c, label_selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:239 Workload applied in namespace=krkn-test-30f3f25c, waiting for pods with selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:241 Pods ready in namespace=krkn-test-30f3f25c
PASSED                                                                   [ 16%]
------------------------------ live log teardown ------------------------------
DEBUG    kubernetes.client.rest:rest.py:235 response body: {"kind":"Namespace","status":{"phase":"Terminating"}}

CI\tests_v2\scenarios\pod_error_scenarios\test_pod_error_scenarios.py::TestPodErrorScenarios::test_kill_multiple_pods 
------------------------------- live log setup --------------------------------
INFO     lib.namespace:namespace.py:109 Created test namespace: krkn-test-b27cff17
INFO     lib.base:base.py:113 Deploying workload from C:\Users\Harsh\krkn\CI\tests_v2\scenarios\pod_error_scenarios\resource.yaml in ns=krkn-test-b27cff17, label_selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:239 Workload applied in namespace=krkn-test-b27cff17, waiting for pods with selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:241 Pods ready in namespace=krkn-test-b27cff17
PASSED                                                                   [ 33%]
------------------------------ live log teardown ------------------------------
DEBUG    kubernetes.client.rest:rest.py:235 response body: {"kind":"Namespace","status":{"phase":"Terminating"}}

CI\tests_v2\scenarios\pod_error_scenarios\test_pod_error_scenarios.py::TestPodErrorScenarios::test_excessive_kill_count_fails 
------------------------------- live log setup --------------------------------
INFO     lib.namespace:namespace.py:109 Created test namespace: krkn-test-e8646e3b
INFO     lib.base:base.py:113 Deploying workload from C:\Users\Harsh\krkn\CI\tests_v2\scenarios\pod_error_scenarios\resource.yaml in ns=krkn-test-e8646e3b, label_selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:239 Workload applied in namespace=krkn-test-e8646e3b, waiting for pods with selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:241 Pods ready in namespace=krkn-test-e8646e3b
PASSED                                                                   [ 50%]
------------------------------ live log teardown ------------------------------
DEBUG    kubernetes.client.rest:rest.py:235 response body: {"kind":"Namespace","status":{"phase":"Terminating"}}

CI\tests_v2\scenarios\pod_error_scenarios\test_pod_error_scenarios.py::TestPodErrorScenarios::test_recovery_timeout_fails 
------------------------------- live log setup --------------------------------
INFO     lib.namespace:namespace.py:109 Created test namespace: krkn-test-f5b24c18
INFO     lib.base:base.py:113 Deploying workload from C:\Users\Harsh\krkn\CI\tests_v2\scenarios\pod_error_scenarios\resource.yaml in ns=krkn-test-f5b24c18, label_selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:239 Workload applied in namespace=krkn-test-f5b24c18, waiting for pods with selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:241 Pods ready in namespace=krkn-test-f5b24c18
PASSED                                                                   [ 66%]
------------------------------ live log teardown ------------------------------
DEBUG    kubernetes.client.rest:rest.py:235 response body: {"kind":"Namespace","status":{"phase":"Terminating"}}

CI\tests_v2\scenarios\pod_error_scenarios\test_pod_error_scenarios.py::TestPodErrorScenarios::test_invalid_namespace_pattern_fails 
------------------------------- live log setup --------------------------------
INFO     lib.namespace:namespace.py:109 Created test namespace: krkn-test-93a8d11c
PASSED                                                                   [ 83%]
------------------------------ live log teardown ------------------------------
DEBUG    kubernetes.client.rest:rest.py:235 response body: {"kind":"Namespace","status":{"phase":"Terminating"}}

CI\tests_v2\scenarios\pod_error_scenarios\test_pod_error_scenarios.py::TestPodErrorScenarios::test_zero_pods_matching_label_fails 
------------------------------- live log setup --------------------------------
INFO     lib.namespace:namespace.py:109 Created test namespace: krkn-test-c1311ce6
INFO     lib.base:base.py:113 Deploying workload from C:\Users\Harsh\krkn\CI\tests_v2\scenarios\pod_error_scenarios\resource.yaml in ns=krkn-test-c1311ce6, label_selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:239 Workload applied in namespace=krkn-test-c1311ce6, waiting for pods with selector=app=krkn-pod-error-target
INFO     lib.deploy:deploy.py:241 Pods ready in namespace=krkn-test-c1311ce6
PASSED                                                                   [100%]
------------------------------ live log teardown ------------------------------
DEBUG    kubernetes.client.rest:rest.py:235 response body: {"kind":"Namespace","status":{"phase":"Terminating"}}


========================= Execution Evidence Summary ==========================
PASSED  —               scenarios/pod_error_scenarios/test_pod_error_scenarios.py::TestPodErrorScenarios::test_excessive_kill_count_fails
PASSED  —               scenarios/pod_error_scenarios/test_pod_error_scenarios.py::TestPodErrorScenarios::test_invalid_namespace_pattern_fails
PASSED  ✓ Verified      scenarios/pod_error_scenarios/test_pod_error_scenarios.py::TestPodErrorScenarios::test_kill_multiple_pods
PASSED  ✓ Verified      scenarios/pod_error_scenarios/test_pod_error_scenarios.py::TestPodErrorScenarios::test_kill_one_pod_recovers
PASSED  —               scenarios/pod_error_scenarios/test_pod_error_scenarios.py::TestPodErrorScenarios::test_recovery_timeout_fails
PASSED  —               scenarios/pod_error_scenarios/test_pod_error_scenarios.py::TestPodErrorScenarios::test_zero_pods_matching_label_fails
================ 6 passed, 32 deselected in 466.21s (0:07:46) =================
```