### PR TITLE
fix: bump krkn-lib to 6.1.2 to resolve kubernetes 36.x incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ jaraco-context>=6.1.0  # Fixes GHSA-58pv-8j8x-9vj2
 cbor2<5.7.0  # Pinned by arcaflow-plugin-sdk
 lxml==6.1.0
 kubernetes>=35.0.0,<36.0.0
-krkn-lib==6.1.0
+krkn-lib==6.1.2
 numpy==1.26.4
 pandas==2.2.0
 openshift-client==1.0.21


### PR DESCRIPTION
## Summary

- Bump `krkn-lib` from `6.1.0` to `6.1.2` in `requirements.txt`
- `krkn-lib==6.1.2` pins `kubernetes>=35.0.0,<36.0.0`, preventing pip from resolving to kubernetes 36.x which breaks `ApiClient.call_api()` calls

## Context

`krkn-lib==6.1.0` declared `kubernetes>=34.1.0` (unbounded). When `kubernetes==36.0.0` was released (May 20, 2026), it renamed the `call_api()` parameter `response_type` → `response_types_map`, breaking krkn-lib's internal calls in environments where pip resolved to 36.x.

`krkn-lib==6.1.2` (https://github.com/krkn-chaos/krkn-lib/pull/294) fixes this by pinning `kubernetes>=35.0.0,<36.0.0`.

## Related Issues

- Fixes #1441
- Upstream fix: https://github.com/krkn-chaos/krkn-lib/pull/294 (merged)
- Upstream issue: https://github.com/krkn-chaos/krkn-lib/issues/293

## Test Plan

- [x] Verified `krkn-lib==6.1.2` resolves `kubernetes==35.0.0` in a fresh venv
- [x] Verified `create_token_for_sa()` works correctly with `krkn-lib==6.1.2`
- [x] Verified `run_kraken.py` cpu-hog scenario succeeds with `kubernetes==35.0.0` and fails with `kubernetes==36.x`


Made with [Cursor](https://cursor.com)