### PR TITLE
docs: add 'Try it in your browser' Killercoda tutorial link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Kraken injects deliberate failures into Kubernetes clusters to check if it is re
 ### How to Get Started
 Instructions on how to setup, configure and run Kraken can be found in the [documentation](https://krkn-chaos.dev/docs/).
 
+### Try it in your browser
+[![Try with Killercoda](https://img.shields.io/badge/Try%20it%20now-Killercoda-orange?logo=killercoda&logoColor=white)](https://killercoda.com/krkn-chaos)
+
+Want to try Krkn without setting up a cluster? Run the [interactive hands-on tutorial](https://killercoda.com/krkn-chaos) on Killercoda: deploy a target app on a real 2-node Kubernetes cluster, inject pod and node chaos with `krknctl`, and watch the cluster heal itself - all in your browser, in about 20 minutes.
+
 
 ### Blogs, podcasts and interviews
 Additional resources, including blog posts, podcasts, and community interviews, can be found on the [website](https://krkn-chaos.dev/blog)


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description

Adds a "Try it in your browser" section to the README (right after "How to Get Started") linking to a free interactive Killercoda tutorial: https://killercoda.com/saiyampathak/scenario/krkn

Anyone evaluating Krkn gets a real 2-node Kubernetes cluster in the browser and runs actual chaos in ~20 minutes, no setup: pod disruption with self-healing verification, a deliberate failure demo (naked pod that never recovers, non-zero exit code for CI/CD gating), node CPU hog, and multi-scenario `krknctl graph run` orchestration.

Scenario source: https://github.com/saiyam1814/katacoda-scenarios/tree/main/krkn

## Related Tickets & Documents

- Related Issue #: none yet - this PR doubles as the proposal per the maintainers' preference; happy to open a companion issue for discussion if you'd like it tracked separately.

## Notes for maintainers

- **Hosting**: the tutorial currently lives under my personal Killercoda profile (killercoda.com/saiyampathak). If the community prefers project-owned hosting, I am glad to donate the scenario source (https://github.com/saiyam1814/katacoda-scenarios/tree/main/krkn) to a krkn-chaos repo (e.g. `krkn-chaos/killercoda-scenarios`) backed by a project-controlled Killercoda account - the README link change is one line.
- **krknctl version pin**: the tutorial pins `krknctl v0.10.21-beta` because v0.11.0-beta writes the flattened kubeconfig with `0600` permissions, which the non-root `krkn` user (uid 1001) inside krkn-hub scenario containers cannot read when krknctl runs as root - breaking `krknctl run` in root/CI environments (regression of the fix in krknctl PR #72; related to krkn-chaos/krknctl#95). While testing we also found a nil-pointer panic in krknctl's quay.io metadata fetch on transient network failures (`getRegistryImages` ignores the `http.Get` error, then dereferences the nil response); the tutorial works around it with a safe retry. Happy to file both as krknctl issues with full analysis.

# Documentation

- [ ] **Is documentation needed for this update?**

README-only change. If maintainers would like the tutorial linked from krkn-chaos.dev as well, I am happy to open a follow-up PR in the website repository.

## Related Documentation PR (if applicable)

N/A

# Checklist before requesting a review

- [ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers (proposal included in this PR; will open a companion issue on request)
- [x] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage (N/A - README-only change)

*REQUIRED*:
Description of combination of tests performed and output of run

The tutorial itself (not this README change) was validated end-to-end on Killercoda across multiple fresh sessions, running krkn via krknctl/krkn-hub containers against the playground's 2-node kubeadm cluster (v1.35.1):

```
$ krknctl run pod-scenarios --namespace demo --pod-label "app=nginx" --disruption-count 1 --expected-recovery-time 120
...
2026-07-02 15:56:48,694 [INFO] Deleting pod nginx-56c45fd5ff-krcql
2026-07-02 15:56:49,975 [INFO] Deletion events (1) match new READY pods (1), all disrupted pods restored, stopping monitoring
"exit_status": 0,
"affected_pods": { "recovered": [ { "pod_name": "nginx-56c45fd5ff-w7sp8", "total_recovery_time": 1.3458633422851562, ... } ], "unrecovered": [] }
pod-scenarios ran for 1m11.403209551s

$ krknctl run pod-scenarios --namespace demo --pod-label "app=standalone" ... (naked pod failure demo)
2026-07-02 16:02:55,021 [ERROR] timeout while waiting for pods to come up
2026-07-02 16:02:55,021 [INFO] PodDisruptionScenarioPlugin failed with unrecovered pods
"exit_status": 1,
"affected_pods": { "recovered": [], "unrecovered": [ { "pod_name": "standalone", "namespace": "demo", ... } ] }

$ krknctl run node-cpu-hog --node-selector "kubernetes.io/hostname=node01" --chaos-duration 60 --cores 1 --cpu-percentage 90 --detached
$ ssh node01 "uptime && top -bn1 | head -5"
 06:20:32 up  1:37,  0 user,  load average: 1.77, 0.42, 0.14
%Cpu(s): 90.9 us,  9.1 sy,  0.0 ni,  0.0 id, ...
$ krknctl query-status krknctl-node-cpu-hog-193361701
{ "status": "exited", "exit_status": 0 }
```

Note: the tutorial pins `krknctl v0.10.21-beta` due to a kubeconfig-permissions regression in v0.11.0-beta that breaks scenario containers when krknctl runs as root (details in the linked issue); it can be unpinned once fixed upstream.

Assisted-by: Claude <noreply@anthropic.com>
