### PR TITLE
fix(deps): add upper bounds to loosely-bounded dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,21 @@
 aliyun-python-sdk-core==2.13.36
 aliyun-python-sdk-ecs==4.24.25
 arcaflow-plugin-sdk==0.14.3
-boto3>=1.34.0  # Updated to support urllib3 2.x
+boto3>=1.34.0,<2.0  # Updated to support urllib3 2.x
 azure-identity==1.16.1
 azure-keyvault==4.2.0
 azure-mgmt-compute==30.5.0
 azure-mgmt-network==27.0.0
 coverage==7.6.12
 datetime==5.4
-docker>=7.0.0  # Upgraded to support requests>=2.32; Unix socket support now native
+docker>=7.0.0,<8.0  # Upgraded to support requests>=2.32; Unix socket support now native
 gitpython==3.1.52
 google-auth==2.37.0
 google-cloud-compute==1.22.0
-ibm-cloud-sdk-core>=3.24.4  # Requires requests>=2.32.4
+ibm-cloud-sdk-core>=3.24.4,<4.0  # Requires requests>=2.32.4
 ibm_vpc==0.26.3  # Requires ibm_cloud_sdk_core
 jinja2==3.1.6
-jaraco-context>=6.1.0  # Fixes GHSA-58pv-8j8x-9vj2
+jaraco-context>=6.1.0,<7.0  # Fixes GHSA-58pv-8j8x-9vj2
 cbor2<5.7.0  # Pinned by arcaflow-plugin-sdk
 lxml==6.1.0
 kubernetes>=35.0.0,<36.0.0
@@ -23,21 +23,21 @@ krkn-lib==6.1.2
 numpy==1.26.4
 pandas==2.2.0
 openshift-client==1.0.21
-paramiko>=3.5.1  # Fixes GHSA-r374-rxx8-8654
+paramiko>=3.5.1,<6.0  # Fixes GHSA-r374-rxx8-8654
 pyVmomi==8.0.2.0.1
 pyfiglet==1.0.2
 pytest==9.0.3
 python-ipmi==0.5.4
 python-openstackclient==6.5.0
-requests>=2.32.4  # Fixes GHSA-9hjg-9r4m-mvj7, GHSA-9wx4-h78v-vm56, GHSA-gc5v-m9x4-r6x2
+requests>=2.32.4,<3.0  # Fixes GHSA-9hjg-9r4m-mvj7, GHSA-9wx4-h78v-vm56, GHSA-gc5v-m9x4-r6x2
 # requests-unixsocket removed - docker 7.0+ handles Unix sockets natively
-urllib3>=2.7.0  # Fixes GHSA-qccp-gfcp-xxvc, GHSA-38jv-5279-wg99, GHSA-gm62-xv2j-4w53, GHSA-2xpw-w6gg-jr37
+urllib3>=2.7.0,<3.0  # Fixes GHSA-qccp-gfcp-xxvc, GHSA-38jv-5279-wg99, GHSA-gm62-xv2j-4w53, GHSA-2xpw-w6gg-jr37
 service_identity==24.1.0
 PyYAML==6.0.1
 setuptools==83.0.0  # Has pkg_resources (required by VMware SDK) + newer vendored jaraco-context
-wheel>=0.46.2  # Fixes GHSA-8rrh-rw8j-w5fx
+wheel>=0.46.2,<1.0  # Fixes GHSA-8rrh-rw8j-w5fx
 colorlog==6.10.1
 
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
-cryptography>=46.0.7 # pinned to avoid multiple CVEs (subgroup attack, buffer overflow, DNS constraints)
-protobuf>=4.25.8 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=46.0.7,<50.0 # pinned to avoid multiple CVEs (subgroup attack, buffer overflow, DNS constraints)
+protobuf>=4.25.8,<8.0 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,23 @@
 setuptools<82.0.0  # Has pkg_resources (required by VMware SDK) + newer vendored jaraco-context
-wheel>=0.46.2  # Fixes GHSA-8rrh-rw8j-w5fx
+wheel>=0.46.2,<1.0  # Fixes GHSA-8rrh-rw8j-w5fx
 aliyun-python-sdk-core==2.13.36
 aliyun-python-sdk-ecs==4.24.25
 arcaflow-plugin-sdk==0.14.3
-boto3>=1.34.0  # Updated to support urllib3 2.x
+boto3>=1.34.0,<2.0  # Updated to support urllib3 2.x
 azure-identity==1.16.1
 azure-keyvault==4.2.0
 azure-mgmt-compute==30.5.0
 azure-mgmt-network==27.0.0
 coverage==7.6.12
 datetime==5.4
-docker>=7.0.0  # Upgraded to support requests>=2.32; Unix socket support now native
+docker>=7.0.0,<8.0  # Upgraded to support requests>=2.32; Unix socket support now native
 gitpython==3.1.52
 google-auth==2.37.0
 google-cloud-compute==1.22.0
-ibm-cloud-sdk-core>=3.24.4  # Requires requests>=2.32.4
+ibm-cloud-sdk-core>=3.24.4,<4.0  # Requires requests>=2.32.4
 ibm_vpc==0.26.3  # Requires ibm_cloud_sdk_core
 jinja2==3.1.6
-jaraco-context>=6.1.0  # Fixes GHSA-58pv-8j8x-9vj2
+jaraco-context>=6.1.0,<7.0  # Fixes GHSA-58pv-8j8x-9vj2
 reportlab>=4.0
 cbor2<5.7.0  # Pinned by arcaflow-plugin-sdk
 lxml==6.1.0
@@ -26,19 +26,19 @@ krkn-lib==6.1.2
 numpy==1.26.4
 pandas==2.2.0
 openshift-client==1.0.21
-paramiko>=3.5.1  # Fixes GHSA-r374-rxx8-8654
+paramiko>=3.5.1,<6.0  # Fixes GHSA-r374-rxx8-8654
 pyVmomi==8.0.2.0.1
 pyfiglet==1.0.2
 pytest==9.0.3
 python-ipmi==0.5.4
 python-openstackclient==6.5.0
-requests>=2.32.4  # Fixes GHSA-9hjg-9r4m-mvj7, GHSA-9wx4-h78v-vm56, GHSA-gc5v-m9x4-r6x2
+requests>=2.32.4,<3.0  # Fixes GHSA-9hjg-9r4m-mvj7, GHSA-9wx4-h78v-vm56, GHSA-gc5v-m9x4-r6x2
 # requests-unixsocket removed - docker 7.0+ handles Unix sockets natively
-urllib3>=2.7.0  # Fixes GHSA-qccp-gfcp-xxvc, GHSA-38jv-5279-wg99, GHSA-gm62-xv2j-4w53, GHSA-2xpw-w6gg-jr37
+urllib3>=2.7.0,<3.0  # Fixes GHSA-qccp-gfcp-xxvc, GHSA-38jv-5279-wg99, GHSA-gm62-xv2j-4w53, GHSA-2xpw-w6gg-jr37
 service_identity==24.1.0
 PyYAML==6.0.1
 colorlog==6.10.1
 
 git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
-cryptography>=46.0.7 # pinned to avoid multiple CVEs (subgroup attack, buffer overflow, DNS constraints)
-protobuf>=4.25.8 # not directly required, pinned by Snyk to avoid a vulnerability
+cryptography>=46.0.7,<50.0 # pinned to avoid multiple CVEs (subgroup attack, buffer overflow, DNS constraints)
+protobuf>=4.25.8,<8.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
# Type of change

- [x] Bug fix

# Description

Several dependencies in `requirements.txt` used open-ended `>=` ranges with no upper bound, so a fresh install or CI rebuild could pull in a breaking major release without warning.

This PR adds an upper cap to each loosely-bounded dependency, following the pattern already used in the repo for `kubernetes` (`>=35.0.0,<36.0.0`).

Design choices:
- Lower bounds are preserved: they carry the referenced CVE fixes (GHSA-* in the comments). Nothing is downgraded.
- Caps are set to the next major above the current latest release, so no version that is resolvable today is excluded (e.g. `protobuf` is already at 7.x, so the cap is `<8.0`, not `<5.0`).
- Existing inline comments are kept intact.

| Dependency | Before | After |
|---|---|---|
| boto3 | `>=1.34.0` | `>=1.34.0,<2.0` |
| docker | `>=7.0.0` | `>=7.0.0,<8.0` |
| ibm-cloud-sdk-core | `>=3.24.4` | `>=3.24.4,<4.0` |
| jaraco-context | `>=6.1.0` | `>=6.1.0,<7.0` |
| paramiko | `>=3.5.1` | `>=3.5.1,<6.0` |
| requests | `>=2.32.4` | `>=2.32.4,<3.0` |
| urllib3 | `>=2.7.0` | `>=2.7.0,<3.0` |
| wheel | `>=0.46.2` | `>=0.46.2,<1.0` |
| cryptography | `>=46.0.7` | `>=46.0.7,<50.0` |
| protobuf | `>=4.25.8` | `>=4.25.8,<8.0` |

Note: `kubernetes` already has a cap and `cbor2` already has an upper bound, so they were left unchanged.

## Related Tickets & Documents

- Related Issue #: 1315
- Closes #1315

# Documentation
- [ ] Is documentation needed for this update? No: this is a dependency-constraint change with no user-facing behavior change.

# Checklist before requesting a review

Validation performed: this change only narrows the allowed version ranges; it does not change which versions resolve today. I verified that:
1. Every line in `requirements.txt` parses as a valid PEP 508 requirement (via `packaging.requirements.Requirement`).
2. The latest published version of each capped dependency still satisfies its new range, so the resolver's current selection is unaffected.

I did not run a full scenario on a cluster because the resolved dependency set is unchanged by this PR; happy to add cluster output if maintainers prefer.

Supersedes #1449 (closed to resubmit with a cleaner commit).