### PR TITLE
docs: align documented dependency versions with requirements.txt

### DIFF
--- a/AI_CONTRIBUTION_POLICY.md
+++ b/AI_CONTRIBUTION_POLICY.md
@@ -172,8 +172,8 @@ to generate scenario plugins **MUST** verify:
 AI tools may suggest dependency versions that conflict with Krkn's
 requirements. Contributors **MUST** verify:
 
-- `docker` package remains <7.0
-- `requests` package remains <2.32
+- `docker` package stays `>=7.0.0` (Unix socket support is native in docker 7+)
+- `requests` package stays `>=2.32.4` (required security fixes)
 - New dependencies are compatible with the existing dependency tree
 - Dependencies are pinned to specific versions in `requirements.txt`
 - Dependencies are checked for known security vulnerabilities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,12 +44,12 @@ python -m coverage run -a -m unittest discover -s tests -v
 ### Python Environment
 - **Python 3.11+** required
 - **NEVER install packages globally** - always use virtual environment
-- **CRITICAL**: `docker` must be <7.0 and `requests` must be <2.32 (Unix socket compatibility)
+- **CRITICAL**: `docker` must be >=7.0.0 and `requests` must be >=2.32.4 — match the pins in `requirements.txt` (docker 7+ handles Unix sockets natively; requests bumped for security fixes)
 
 ### Key Dependencies
-- **krkn-lib** (5.1.13): Core library for Kubernetes/OpenShift operations
-- **kubernetes** (34.1.0): Kubernetes Python client
-- **docker** (<7.0), **requests** (<2.32): DO NOT upgrade without verifying compatibility
+- **krkn-lib** (6.1.2): Core library for Kubernetes/OpenShift operations
+- **kubernetes** (>=35.0.0,<36.0.0): Kubernetes Python client
+- **docker** (>=7.0.0), **requests** (>=2.32.4): match `requirements.txt`; do not change without verifying Unix-socket compatibility
 - Cloud SDKs: boto3 (AWS), azure-mgmt-* (Azure), google-cloud-compute (GCP), ibm_vpc (IBM), pyVmomi (VMware)
 
 ## Plugin Architecture (CRITICAL)


### PR DESCRIPTION
# Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

# Description
Documentation-only change: aligns the dependency versions documented in `CLAUDE.md` and
`AI_CONTRIBUTION_POLICY.md` with the actual pins in `requirements.txt`. The docs had drifted —
and for `docker`/`requests` stated the inverted constraint:

| File | Was | Now (matches `requirements.txt`) |
|---|---|---|
| `CLAUDE.md`, `AI_CONTRIBUTION_POLICY.md` | `docker <7.0`, `requests <2.32` | `docker>=7.0.0`, `requests>=2.32.4` |
| `CLAUDE.md` | `krkn-lib 5.1.13` | `krkn-lib==6.1.2` |
| `CLAUDE.md` | `kubernetes 34.1.0` | `kubernetes>=35.0.0,<36.0.0` |

No code or dependency changes- only the docs are updated to reflect versions already pinned
in `requirements.txt`.

## Related Tickets & Documents

- Related Issue #1454 
- Closes #1454 

# Documentation
- [ ] **Is documentation needed for this update?**

Not needed, this PR *is* the in-repo documentation fix (`CLAUDE.md`, `AI_CONTRIBUTION_POLICY.md`);
no website-repo change is involved.

## Related Documentation PR (if applicable)
N/A

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [ ] I have performed a self-review of my code by running krkn and specific scenario. *(N/A - documentation-only change; no runtime behavior.)*
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage. *(N/A - documentation-only change.)*

*REQUIRED*:
No code paths change, so there is nothing to run. Verification is that every documented version
now matches `requirements.txt`:

```bash
$ grep -E '^(docker|requests|krkn-lib|kubernetes)\b' requirements.txt
docker>=7.0.0
kubernetes>=35.0.0,<36.0.0
krkn-lib==6.1.2
requests>=2.32.4

# CLAUDE.md and AI_CONTRIBUTION_POLICY.md now state these same versions
# (docker>=7.0.0, requests>=2.32.4, krkn-lib==6.1.2, kubernetes>=35.0.0,<36.0.0).