### PR TITLE
feat: add standalone execution mode for chaos without Kubernetes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,32 @@
+{
+  "mcpServers": {
+    "krkn-analysis-mcp": {
+      "command": "/Users/sahil/krkn_analysis_mcp/krkn_analysis_mcp_env/bin/python",
+      "args": ["/Users/sahil/krkn_analysis_mcp/krkn_analysis_mcp.py"],
+      "disabled": true,
+      "env": {
+        "ES_SERVER": "https://search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com:443",
+        "ES_USER": "ocp-qe",
+        "ES_PASS": "Best-footballplayer-test8"
+      }
+    },
+    "prow-mcp-server": {
+      "command": "/Users/sahil/prow-mcp-server/.venv/bin/python",
+      "args": ["/Users/sahil/prow-mcp-server/main.py"],
+      "disabled": true,
+      "env": {
+        "DEFAULT_ORG_REPO": "redhat-chaos_prow-scripts",
+        "DEFAULT_JOB_NAME": "periodic-ci-redhat-chaos-*"
+      }
+    },
+    "orion-mcp": {
+      "command": "/Users/sahil/orion-mcp/.venv/bin/python3",
+      "args": ["/Users/sahil/orion-mcp/orion_mcp.py"],
+      "disabled": true,
+      "env": {
+        "ES_SERVER": "https://ocp-qe:Best-footballplayer-test8@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com",
+        "PYTHONUNBUFFERED": "1"
+      }
+    }
+  }
+}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,4 +1,5 @@
 kraken:
+    execution_mode: kubernetes                            # Execution mode: 'kubernetes' (default) or 'standalone' (no K8s required)
     kubeconfig_path: ~/.kube/config                     # Path to kubeconfig
     exit_on_failure: False                                 # Exit when a post action scenario fails
     auto_rollback: True                                    # Enable auto rollback for scenarios.

--- a/config/config_e2e_test.yaml
+++ b/config/config_e2e_test.yaml
@@ -1,0 +1,57 @@
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:
+    exit_on_failure: False
+    auto_rollback: True
+    rollback_versions_directory:
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        - standalone_disk_fill_scenarios:
+            - scenarios/standalone/e2e_disk_fill.yml
+tunings:
+    wait_duration: 2
+    iterations: 1
+    daemon_mode: False
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+elastic:
+    enable_elastic: False
+    elastic_url:
+    elastic_port: 32766
+    verify_certs: False
+    username:
+    password:
+    metrics_index: krkn-metrics
+    alerts_index: krkn-alerts
+    telemetry_index: krkn-telemetry
+telemetry:
+    enabled: False
+    api_url:
+    username:
+    password:
+    prometheus_backup: False
+    full_prometheus_backup: False
+    events_backup: False
+    logs_backup: False
+    backup_threads: 5
+    archive_path:
+    max_retries: 0
+    run_tag:
+    telemetry_group:
+resiliency:
+    resiliency_run_mode: disabled
+health_checks:
+kubevirt_checks:

--- a/config/config_standalone.yaml
+++ b/config/config_standalone.yaml
@@ -1,0 +1,71 @@
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:
+    exit_on_failure: False
+    auto_rollback: True
+    rollback_versions_directory:
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        - node_scenarios:
+            - scenarios/standalone/ssh_node_reboot.yml
+        - hog_scenarios:
+            - scenarios/standalone/hog_cpu.yml
+        - network_chaos_scenarios:
+            - scenarios/standalone/network_chaos_latency.yml
+        - time_scenarios:
+            - scenarios/standalone/time_skew.yml
+
+tunings:
+    wait_duration: 10
+    iterations: 1
+    daemon_mode: False
+
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+
+elastic:
+    enable_elastic: False
+    elastic_url:
+    elastic_port: 32766
+    verify_certs: False
+    username:
+    password:
+    metrics_index: krkn-metrics
+    alerts_index: krkn-alerts
+    telemetry_index: krkn-telemetry
+
+telemetry:
+    enabled: False
+    api_url:
+    username:
+    password:
+    prometheus_backup: False
+    full_prometheus_backup: False
+    events_backup: False
+    logs_backup: False
+    backup_threads: 5
+    archive_path:
+    max_retries: 0
+    run_tag:
+    telemetry_group:
+
+resiliency:
+    resiliency_run_mode: disabled
+
+health_checks:
+
+kubevirt_checks:

--- a/config/config_test_k8s.yaml
+++ b/config/config_test_k8s.yaml
@@ -1,0 +1,65 @@
+kraken:
+    execution_mode: kubernetes
+    kubeconfig_path: ~/.kube/config
+    exit_on_failure: False
+    auto_rollback: True
+    rollback_versions_directory:
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        - pod_disruption_scenarios:
+            - scenarios/test_pod_disruption.yml
+
+tunings:
+    wait_duration: 5
+    iterations: 1
+    daemon_mode: False
+
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+
+elastic:
+    enable_elastic: False
+    elastic_url:
+    elastic_port: 32766
+    verify_certs: False
+    username:
+    password:
+    metrics_index: krkn-metrics
+    alerts_index: krkn-alerts
+    telemetry_index: krkn-telemetry
+
+telemetry:
+    enabled: False
+    api_url:
+    username:
+    password:
+    prometheus_backup: False
+    full_prometheus_backup: False
+    events_backup: False
+    logs_backup: False
+    backup_threads: 5
+    archive_path:
+    max_retries: 0
+    run_tag:
+    telemetry_group:
+
+resiliency:
+    resiliency_run_mode: disabled
+
+health_checks:
+
+kubevirt_checks:

--- a/config/config_vmware_validation.yaml
+++ b/config/config_vmware_validation.yaml
@@ -1,0 +1,88 @@
+# VMware Migration Validation Config
+#
+# Run this after migrating VMs from VMware to OpenShift Virtualization.
+# Validates that migrated VMs survive common failure scenarios.
+#
+# Usage:
+#   1. Edit scenario YAMLs in scenarios/vmware_migration_validation/
+#      to match your node IPs and VM names
+#   2. Run: python run_kraken.py --config config/config_vmware_validation.yaml
+#
+# This runs 5 chaos scenarios in sequence:
+#   1. Reboot worker nodes (verify VMs restart)
+#   2. Network latency injection (verify connectivity)
+#   3. Storage IO burst (verify no VMI crash)
+#   4. CPU stress on hosts (verify virt-handler survives)
+#   5. Live migration under fault (verify no corruption)
+
+kraken:
+    execution_mode: standalone
+    kubeconfig_path:
+    exit_on_failure: False
+    auto_rollback: True
+    rollback_versions_directory:
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+        - node_scenarios:
+            - scenarios/vmware_migration_validation/01_reboot_all_vms.yml
+        - network_chaos_scenarios:
+            - scenarios/vmware_migration_validation/02_network_chaos.yml
+        - vm_storage_chaos_scenarios:
+            - scenarios/vmware_migration_validation/03_storage_stress.yml
+        - hog_scenarios:
+            - scenarios/vmware_migration_validation/04_host_cpu_stress.yml
+
+tunings:
+    wait_duration: 30
+    iterations: 1
+    daemon_mode: False
+
+performance_monitoring:
+    prometheus_url:
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile:
+    metrics_profile:
+    check_critical_alerts: False
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+
+elastic:
+    enable_elastic: False
+    elastic_url:
+    elastic_port: 32766
+    verify_certs: False
+    username:
+    password:
+    metrics_index: krkn-metrics
+    alerts_index: krkn-alerts
+    telemetry_index: krkn-telemetry
+
+telemetry:
+    enabled: False
+    api_url:
+    username:
+    password:
+    prometheus_backup: False
+    full_prometheus_backup: False
+    events_backup: False
+    logs_backup: False
+    backup_threads: 5
+    archive_path:
+    max_retries: 0
+    run_tag:
+    telemetry_group:
+
+resiliency:
+    resiliency_run_mode: disabled
+
+health_checks:
+
+kubevirt_checks:

--- a/config/vmware_test_config.yaml
+++ b/config/vmware_test_config.yaml
@@ -1,0 +1,76 @@
+kraken:
+    kubeconfig_path: ~/.kube/config
+    exit_on_failure: False
+    auto_rollback: True
+    rollback_versions_directory:
+    publish_kraken_status: False
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    chaos_scenarios:
+       - node_scenarios:
+           - scenarios/openshift/vmware_node_reboot_test.yml
+
+resiliency:
+  resiliency_run_mode: disabled
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+    check_application_routes: False
+
+performance_monitoring:
+    prometheus_url: ''
+    prometheus_bearer_token:
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile: config/alerts.yaml
+    metrics_profile: config/metrics-report.yaml
+    check_critical_alerts: False
+
+elastic:
+    enable_elastic: False
+    verify_certs: False
+    elastic_url: ""
+    elastic_port: 32766
+    username: "elastic"
+    password: "test"
+    metrics_index: "krkn-metrics"
+    alerts_index: "krkn-alerts"
+    telemetry_index: "krkn-telemetry"
+    run_tag: ""
+
+tunings:
+    wait_duration: 1
+    iterations: 1
+    daemon_mode: False
+
+telemetry:
+    enabled: False
+    api_url: https://ulnmf9xv7j.execute-api.us-west-2.amazonaws.com/production
+    username: username
+    password: password
+    prometheus_backup: False
+    full_prometheus_backup: False
+    backup_threads: 5
+    archive_path:
+    max_retries: 0
+    run_tag: ''
+    archive_size: 500000
+    telemetry_group: ''
+    logs_backup: False
+    logs_filter_patterns:
+     - "(\\w{3}\\s\\d{1,2}\\s\\d{2}:\\d{2}:\\d{2}\\.\\d+).+"
+     - "kinit (\\d+/\\d+/\\d+\\s\\d{2}:\\d{2}:\\d{2})\\s+"
+     - "(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z).+"
+    oc_cli_path: /opt/homebrew/bin/oc
+    events_backup: False
+
+health_checks:
+    interval:
+    config:
+        - url:
+          bearer_token:
+          auth:
+          exit_on_failure:

--- a/krkn/health_checks/standalone_host_health_check_plugin.py
+++ b/krkn/health_checks/standalone_host_health_check_plugin.py
@@ -130,6 +130,12 @@ class StandaloneHostHealthCheckPlugin(AbstractHealthCheckPlugin):
                             "start_timestamp": datetime.now(),
                             "url": "%s/%s" % (host, check_type),
                         }
+                        if not status and self.ret_value == 0:
+                            exit_on_failure = host_config.get(
+                                "exit_on_failure", False
+                            )
+                            if exit_on_failure:
+                                self.ret_value = 3
                     elif status != status_tracker[check_key]["status"]:
                         end_timestamp = datetime.now()
                         start_timestamp = status_tracker[check_key][

--- a/krkn/health_checks/standalone_host_health_check_plugin.py
+++ b/krkn/health_checks/standalone_host_health_check_plugin.py
@@ -1,0 +1,292 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Standalone Host Health Check Plugin
+
+Monitors remote host health (CPU, memory, disk, load, process, TCP port)
+via SSH during standalone chaos experiments. Produces HealthCheck telemetry
+compatible with the existing Elasticsearch pipeline.
+
+Example configuration in config.yaml:
+    standalone_health_checks:
+      interval: 5
+      ssh_user: root
+      ssh_private_key: ~/.ssh/id_rsa
+      ssh_port: 22
+      config:
+        - host: 192.168.1.100
+          checks:
+            - type: tcp
+              port: 8080
+            - type: process
+              name: nginx
+            - type: http
+              url: http://192.168.1.100:8080/health
+            - type: host_metrics
+"""
+
+import logging
+import os
+import queue
+import time
+from datetime import datetime
+from typing import Any
+
+import shlex
+
+import requests
+from krkn_lib.models.telemetry.models import HealthCheck
+from krkn_lib.utils.functions import is_host_reachable
+
+from krkn.health_checks.abstract_health_check_plugin import AbstractHealthCheckPlugin
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+
+class StandaloneHostHealthCheckPlugin(AbstractHealthCheckPlugin):
+    """
+    SSH-based host health check plugin that monitors remote hosts
+    during standalone chaos experiments.
+    """
+
+    def __init__(
+        self,
+        health_check_type: str = "standalone_host_health_check",
+        iterations: int = 1,
+        **kwargs,
+    ):
+        super().__init__(health_check_type)
+        self.iterations = iterations
+        self.current_iterations = 0
+
+    def get_health_check_types(self) -> list[str]:
+        return ["standalone_host_health_check"]
+
+    def get_config_key(self) -> str:
+        return "standalone_health_checks"
+
+    def increment_iterations(self) -> None:
+        self.current_iterations += 1
+
+    def run_health_check(
+        self,
+        config: dict[str, Any],
+        telemetry_queue: queue.Queue,
+    ) -> None:
+        if not config or not config.get("config"):
+            logging.info(
+                "Standalone host health check config not defined, skipping"
+            )
+            return
+
+        interval = config.get("interval", 5)
+        ssh_user = config.get("ssh_user", "root")
+        ssh_private_key = os.path.expanduser(
+            config.get("ssh_private_key", "~/.ssh/id_rsa")
+        )
+        ssh_port = config.get("ssh_port", 22)
+
+        ssh_executor = SSHExecutor(
+            ssh_user=ssh_user,
+            ssh_private_key=ssh_private_key,
+            ssh_port=ssh_port,
+        )
+
+        health_check_telemetry = []
+        status_tracker = {}
+
+        while (
+            self.current_iterations < self.iterations
+            and not self._stop_event.is_set()
+        ):
+            for host_config in config.get("config", []):
+                host = host_config.get("host", "")
+                if not host:
+                    continue
+
+                checks = host_config.get("checks", [{"type": "host_metrics"}])
+                for check in checks:
+                    check_type = check.get("type", "host_metrics")
+                    check_key = "%s:%s" % (host, check_type)
+
+                    status, status_code = self._run_check(
+                        ssh_executor, host, check
+                    )
+
+                    if check_key not in status_tracker:
+                        status_tracker[check_key] = {
+                            "status": status,
+                            "status_code": status_code,
+                            "start_timestamp": datetime.now(),
+                            "url": "%s/%s" % (host, check_type),
+                        }
+                    elif status != status_tracker[check_key]["status"]:
+                        end_timestamp = datetime.now()
+                        start_timestamp = status_tracker[check_key][
+                            "start_timestamp"
+                        ]
+                        duration = (
+                            end_timestamp - start_timestamp
+                        ).total_seconds()
+
+                        record = {
+                            "url": status_tracker[check_key]["url"],
+                            "status": status_tracker[check_key]["status"],
+                            "status_code": status_tracker[check_key][
+                                "status_code"
+                            ],
+                            "start_timestamp": start_timestamp.isoformat(),
+                            "end_timestamp": end_timestamp.isoformat(),
+                            "duration": duration,
+                        }
+                        health_check_telemetry.append(HealthCheck(record))
+
+                        status_tracker[check_key] = {
+                            "status": status,
+                            "status_code": status_code,
+                            "start_timestamp": end_timestamp,
+                            "url": "%s/%s" % (host, check_type),
+                        }
+
+                        if not status and self.ret_value == 0:
+                            exit_on_failure = host_config.get(
+                                "exit_on_failure", False
+                            )
+                            if exit_on_failure:
+                                self.ret_value = 3
+
+            time.sleep(interval)
+
+        end_timestamp = datetime.now()
+        for check_key, tracker in status_tracker.items():
+            duration = (
+                end_timestamp - tracker["start_timestamp"]
+            ).total_seconds()
+            record = {
+                "url": tracker["url"],
+                "status": tracker["status"],
+                "status_code": tracker["status_code"],
+                "start_timestamp": tracker["start_timestamp"].isoformat(),
+                "end_timestamp": end_timestamp.isoformat(),
+                "duration": duration,
+            }
+            health_check_telemetry.append(HealthCheck(record))
+
+        telemetry_queue.put(health_check_telemetry)
+
+    def _run_check(
+        self, ssh: SSHExecutor, host: str, check: dict
+    ) -> tuple[bool, int]:
+        """Run a single health check. Returns (status_bool, status_code_int)."""
+        check_type = check.get("type", "host_metrics")
+
+        try:
+            if check_type == "tcp":
+                return self._check_tcp(ssh, host, check.get("port", 80))
+            elif check_type == "process":
+                return self._check_process(
+                    ssh, host, check.get("name", "")
+                )
+            elif check_type == "http":
+                return self._check_http(check.get("url", ""))
+            elif check_type == "host_metrics":
+                return self._check_host_metrics(ssh, host)
+            elif check_type == "command":
+                return self._check_command(ssh, host, check.get("cmd", ""))
+            else:
+                logging.warning(
+                    "Unknown check type: %s" % check_type
+                )
+                return False, 500
+        except Exception as e:
+            logging.debug(
+                "[%s] Health check '%s' failed: %s" % (host, check_type, e)
+            )
+            return False, 500
+
+    def _check_tcp(
+        self, ssh: SSHExecutor, host: str, port: int
+    ) -> tuple[bool, int]:
+        reachable = is_host_reachable(host, port, timeout=3)
+        return reachable, 200 if reachable else 503
+
+    def _check_process(
+        self, ssh: SSHExecutor, host: str, process_name: str
+    ) -> tuple[bool, int]:
+        if not process_name:
+            return False, 400
+        exit_code, _, _ = ssh.execute(
+            host, "pgrep -f %s" % shlex.quote(process_name), timeout=10
+        )
+        return exit_code == 0, 200 if exit_code == 0 else 503
+
+    def _check_http(self, url: str) -> tuple[bool, int]:
+        try:
+            response = requests.get(url, timeout=5, verify=False)
+            return response.status_code == 200, response.status_code
+        except Exception:
+            return False, 503
+
+    def _check_host_metrics(
+        self, ssh: SSHExecutor, host: str
+    ) -> tuple[bool, int]:
+        exit_code, stdout, _ = ssh.execute(
+            host,
+            "cat /proc/loadavg | awk '{print $1}'; "
+            "free -b | awk '/Mem:/{printf \"%.0f %.0f\\n\", $3, $2}'; "
+            "df -B1 --output=pcent / | tail -1 | tr -d ' %%'",
+            timeout=10,
+        )
+        if exit_code != 0:
+            return False, 503
+
+        lines = stdout.strip().split("\n")
+        if len(lines) >= 3:
+            load_avg = float(lines[0])
+            mem_parts = lines[1].split()
+            mem_used = int(mem_parts[0])
+            mem_total = int(mem_parts[1])
+            disk_pct = int(lines[2])
+
+            logging.debug(
+                "[%s] load=%.1f mem=%d/%d (%.0f%%) disk=%d%%"
+                % (
+                    host,
+                    load_avg,
+                    mem_used,
+                    mem_total,
+                    (mem_used / mem_total * 100) if mem_total > 0 else 0,
+                    disk_pct,
+                )
+            )
+
+        return True, 200
+
+    ALLOWED_COMMAND_PREFIXES = (
+        "systemctl status", "systemctl is-active",
+        "pgrep", "pidof", "test", "cat /proc/loadavg",
+        "uptime", "df ", "free ", "who", "ss ", "ip ",
+    )
+
+    def _check_command(
+        self, ssh: SSHExecutor, host: str, cmd: str
+    ) -> tuple[bool, int]:
+        if not cmd:
+            return False, 400
+        if not any(cmd.startswith(prefix) for prefix in self.ALLOWED_COMMAND_PREFIXES):
+            logging.warning(
+                "[%s] Command not in allowed list: %s" % (host, cmd)
+            )
+            return False, 403
+        exit_code, _, _ = ssh.execute(host, cmd, timeout=30)
+        return exit_code == 0, 200 if exit_code == 0 else 503

--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -75,6 +75,16 @@ class AbstractScenarioPlugin(ABC):
         """
         pass
 
+    def supports_standalone(self) -> bool:
+        """Indicates whether this plugin can run in standalone mode (no Kubernetes).
+
+        Plugins that support standalone mode should override this and return True.
+        The default is False, meaning the plugin requires Kubernetes.
+
+        :return: True if standalone execution is supported
+        """
+        return False
+
     def run_scenarios(
         self,
         run_uuid: str,
@@ -150,15 +160,16 @@ class AbstractScenarioPlugin(ABC):
             scenario_telemetry.end_timestamp = time.time()
             start_time = int(scenario_telemetry.start_timestamp)
             end_time = int(scenario_telemetry.end_timestamp)
-            utils.collect_and_put_ocp_logs(
-                telemetry,
-                parsed_scenario_config,
-                telemetry.get_telemetry_request_id(),
-                start_time,
-                end_time
-            )
+            if telemetry.get_lib_kubernetes() is not None:
+                utils.collect_and_put_ocp_logs(
+                    telemetry,
+                    parsed_scenario_config,
+                    telemetry.get_telemetry_request_id(),
+                    start_time,
+                    end_time
+                )
 
-            if events_backup:
+            if events_backup and telemetry.get_lib_kubernetes() is not None:
                 utils.populate_cluster_events(
                     krkn_config,
                     parsed_scenario_config,

--- a/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
+++ b/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 import copy
 import logging
+import os
 import queue
 import random
 import re
+import shlex
 import threading
 import time
 
@@ -29,6 +31,7 @@ from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.utils import get_random_string
 
 from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
 from krkn.rollback.config import RollbackContent
 from krkn.rollback.handler import set_rollback_context_decorator
 
@@ -41,11 +44,22 @@ class HogsScenarioPlugin(AbstractScenarioPlugin):
         try:
             with open(scenario, "r") as f:
                 scenario = yaml.safe_load(f)
+
+            targets = scenario.get("targets", [])
+            if targets:
+                return self._run_standalone(scenario, targets)
+
+            if lib_telemetry.get_lib_kubernetes() is None:
+                logging.error(
+                    "hog_scenarios requires 'targets' field in standalone mode"
+                )
+                return 1
+
             scenario_config = HogConfig.from_yaml_dict(scenario)
-            
+
             # Get node-name if provided
             node_name = scenario.get('node-name')
-            
+
             has_selector = True
             if not scenario_config.node_selector or not re.match("^.+=.*$", scenario_config.node_selector):
                 if scenario_config.node_selector:
@@ -77,6 +91,107 @@ class HogsScenarioPlugin(AbstractScenarioPlugin):
         except Exception as e:
             logging.error(f"scenario exception: {e}")
             return 1
+
+    def _run_standalone(self, scenario: dict, targets: list[str]) -> int:
+        """Run hog scenario on standalone targets via SSH + stress-ng."""
+        if not targets:
+            raise ValueError("targets list cannot be empty for standalone hog scenario")
+        scenario_config = HogConfig.from_yaml_dict(scenario)
+        ssh_executor = SSHExecutor(
+            ssh_user=scenario.get("ssh_user", "root"),
+            ssh_private_key=os.path.expanduser(
+                scenario.get("ssh_private_key", "~/.ssh/id_rsa")
+            ),
+            ssh_port=scenario.get("ssh_port", 22),
+            connect_timeout=scenario.get("ssh_connect_timeout", 30),
+        )
+
+        exit_code, stdout, _ = ssh_executor.execute(
+            targets[0], "which stress-ng", timeout=10
+        )
+        if exit_code != 0:
+            raise Exception(
+                "stress-ng not found on %s. Install: "
+                "apt-get install stress-ng / yum install stress-ng" % targets[0]
+            )
+        logging.info("stress-ng found on %s: %s" % (targets[0], stdout.strip()))
+
+        if scenario_config.number_of_nodes and len(targets) > scenario_config.number_of_nodes:
+            targets = random.sample(targets, scenario_config.number_of_nodes)
+
+        exception_queue = queue.Queue()
+        workers = []
+        logging.info(f"running {scenario_config.type.value} hog scenario (standalone SSH)")
+        logging.info(f"targeting hosts: [{','.join(targets)}]")
+        for target in targets:
+            config_copy = copy.deepcopy(scenario_config)
+            worker = threading.Thread(
+                target=self._run_standalone_worker,
+                args=(config_copy, ssh_executor, target, exception_queue),
+            )
+            worker.daemon = True
+            worker.start()
+            workers.append(worker)
+
+        for worker in workers:
+            worker.join()
+
+        errors = []
+        while not exception_queue.empty():
+            errors.append(exception_queue.get_nowait())
+        if errors:
+            for err in errors:
+                logging.error("standalone hog failure: %s" % err)
+            raise errors[0]
+
+        return 0
+
+    def _run_standalone_worker(
+        self, config: HogConfig, ssh: SSHExecutor, host: str,
+        exception_queue: queue.Queue,
+    ) -> None:
+        """Execute stress-ng on a remote host via SSH."""
+        try:
+            if not config.workers:
+                exit_code, stdout, _ = ssh.execute(host, "nproc", timeout=10)
+                try:
+                    config.workers = int(stdout.strip()) if exit_code == 0 and stdout.strip() else 1
+                except ValueError:
+                    config.workers = 1
+                logging.info(f"[{host}] detected {config.workers} cpus")
+
+            cmd = self._build_stress_command(config)
+            logging.info(f"[{host}] executing: {cmd}")
+            exit_code, stdout, stderr = ssh.execute(
+                host, cmd, timeout=config.duration + 120
+            )
+            if exit_code != 0:
+                raise Exception(f"[{host}] stress-ng failed (exit {exit_code}): {stderr}")
+            logging.info(f"[{host}] stress-ng completed successfully")
+        except Exception as e:
+            exception_queue.put(e)
+
+    @staticmethod
+    def _build_stress_command(config: HogConfig) -> str:
+        """Build stress-ng command from HogConfig."""
+        if config.type == HogType.cpu:
+            return (
+                "stress-ng --cpu %d --cpu-load %d --timeout %ds --metrics-brief"
+                % (config.workers, config.cpu_load_percentage, config.duration)
+            )
+        elif config.type == HogType.memory:
+            return (
+                "stress-ng --vm %d --vm-bytes %s --vm-keep --timeout %ds --metrics-brief"
+                % (config.workers, shlex.quote(str(config.memory_vm_bytes)), config.duration)
+            )
+        elif config.type == HogType.io:
+            return (
+                "stress-ng --iomix %d --iomix-bytes %s --timeout %ds --metrics-brief"
+                % (config.workers, shlex.quote(str(config.io_write_bytes)), config.duration)
+            )
+
+    def supports_standalone(self) -> bool:
+        return True
 
     def get_scenario_types(self) -> list[str]:
         return ["hog_scenarios"]

--- a/krkn/scenario_plugins/network_chaos/network_chaos_scenario_plugin.py
+++ b/krkn/scenario_plugins/network_chaos/network_chaos_scenario_plugin.py
@@ -14,6 +14,7 @@
 import logging
 import os
 import random
+import re
 import time
 
 import yaml
@@ -24,6 +25,7 @@ from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 from krkn_lib.utils import get_yaml_item_value, log_exception
 
 from krkn.scenario_plugins.node_actions import common_node_functions
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
 from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
 
 
@@ -37,9 +39,20 @@ class NetworkChaosScenarioPlugin(AbstractScenarioPlugin):
     ) -> int:
         try:
             with open(scenario, "r") as file:
-                param_lst = ["latency", "loss", "bandwidth"]
                 test_config = yaml.safe_load(file)
                 test_dict = test_config["network_chaos"]
+
+                targets = get_yaml_item_value(test_dict, "targets", [])
+                if targets:
+                    return self._run_standalone(test_dict, targets)
+
+                if lib_telemetry.get_lib_kubernetes() is None:
+                    logging.error(
+                        "network_chaos_scenarios requires 'targets' field in standalone mode"
+                    )
+                    return 1
+
+                param_lst = ["latency", "loss", "bandwidth"]
                 test_duration = int(get_yaml_item_value(test_dict, "duration", 300))
                 test_interface = get_yaml_item_value(test_dict, "interfaces", [])
                 test_node = get_yaml_item_value(test_dict, "node_name", "")
@@ -242,22 +255,101 @@ class NetworkChaosScenarioPlugin(AbstractScenarioPlugin):
             kubecli.delete_job(name=jobname, namespace="default")
 
     def get_egress_cmd(self, execution, test_interface, mod, vallst, duration=30):
+        import shlex
         tc_set = tc_unset = tc_ls = ""
         param_map = {"latency": "delay", "loss": "loss", "bandwidth": "rate"}
         for i in test_interface:
-            tc_set = "{0} tc qdisc add dev {1} root netem".format(tc_set, i)
-            tc_unset = "{0} tc qdisc del dev {1} root ;".format(tc_unset, i)
-            tc_ls = "{0} tc qdisc ls dev {1} ;".format(tc_ls, i)
+            safe_iface = shlex.quote(i)
+            tc_set = "{0} tc qdisc add dev {1} root netem".format(tc_set, safe_iface)
+            tc_unset = "{0} tc qdisc del dev {1} root ;".format(tc_unset, safe_iface)
+            tc_ls = "{0} tc qdisc ls dev {1} ;".format(tc_ls, safe_iface)
             if execution == "parallel":
                 for val in vallst.keys():
-                    tc_set += " {0} {1} ".format(param_map[val], vallst[val])
+                    tc_set += " {0} {1} ".format(param_map[val], shlex.quote(str(vallst[val])))
                 tc_set += ";"
             else:
-                tc_set += " {0} {1} ;".format(param_map[mod], vallst[mod])
+                tc_set += " {0} {1} ;".format(param_map[mod], shlex.quote(str(vallst[mod])))
         exec_cmd = "sleep 30;{0} {1} sleep {2};{3} sleep 20;{4}".format(
             tc_set, tc_ls, duration, tc_unset, tc_ls
         )
         return exec_cmd
+
+    @staticmethod
+    def _validate_egress_params(egress: dict) -> None:
+        """Validate egress parameters to prevent injection."""
+        if "latency" in egress:
+            if not re.match(r"^\d+m?s$", str(egress["latency"])):
+                raise ValueError("Invalid latency format: %s" % egress["latency"])
+        if "bandwidth" in egress:
+            if not re.match(r"^\d+[kmg]?bit$", str(egress["bandwidth"]), re.IGNORECASE):
+                raise ValueError("Invalid bandwidth format: %s" % egress["bandwidth"])
+        if "loss" in egress:
+            if not re.match(r"^\d+(\.\d+)?%?$", str(egress["loss"])):
+                raise ValueError("Invalid loss format: %s" % egress["loss"])
+
+    def _run_standalone(self, test_dict: dict, targets: list[str]) -> int:
+        """Run network chaos on standalone targets via SSH + tc/iptables."""
+        test_duration = int(get_yaml_item_value(test_dict, "duration", 300))
+        test_interface = get_yaml_item_value(test_dict, "interfaces", [])
+        test_execution = get_yaml_item_value(test_dict, "execution", "serial")
+        test_egress = get_yaml_item_value(
+            test_dict, "egress", {"bandwidth": "100mbit"}
+        )
+        self._validate_egress_params(test_egress)
+
+        ssh_executor = SSHExecutor(
+            ssh_user=get_yaml_item_value(test_dict, "ssh_user", "root"),
+            ssh_private_key=os.path.expanduser(
+                get_yaml_item_value(test_dict, "ssh_private_key", "~/.ssh/id_rsa")
+            ),
+            ssh_port=get_yaml_item_value(test_dict, "ssh_port", 22),
+        )
+
+        if not test_interface:
+            exit_code, stdout, _ = ssh_executor.execute(
+                targets[0],
+                "ip r | grep default | awk '{print $5}' | head -1",
+                timeout=10,
+            )
+            if exit_code != 0 or not stdout.strip():
+                raise Exception(
+                    "Cannot detect default interface on %s" % targets[0]
+                )
+            detected_iface = stdout.strip()
+            if not re.match(r"^[a-zA-Z0-9._-]+$", detected_iface):
+                raise ValueError(
+                    "Invalid interface name detected on %s: %s"
+                    % (targets[0], detected_iface)
+                )
+            test_interface = [detected_iface]
+            logging.info("Auto-detected interface: %s" % test_interface)
+
+        param_lst = ["latency", "loss", "bandwidth"]
+        egress_lst = [i for i in param_lst if i in test_egress]
+        exec_cmd = self.get_egress_cmd(
+            test_execution, test_interface, egress_lst[0] if egress_lst else "latency",
+            test_egress, duration=test_duration
+        )
+
+        logging.info("Standalone network chaos on %d target(s)" % len(targets))
+
+        for target in targets:
+            logging.info("[%s] Executing: %s" % (target, exec_cmd))
+            exit_code, stdout, stderr = ssh_executor.execute(
+                target, exec_cmd, timeout=test_duration + 120
+            )
+            if exit_code != 0:
+                logging.error("[%s] Network chaos failed: %s" % (target, stderr))
+                return 1
+            logging.info("[%s] Network chaos completed" % target)
+
+            if test_execution == "serial":
+                continue
+
+        return 0
+
+    def supports_standalone(self) -> bool:
+        return True
 
     def get_scenario_types(self) -> list[str]:
         return ["network_chaos_scenarios"]

--- a/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/aws_node_scenarios.py
@@ -383,12 +383,13 @@ class aws_node_scenarios(abstract_node_scenarios):
                 )
                 self.aws.terminate_instances(instance_id)
                 self.aws.wait_until_terminated(instance_id, timeout=timeout, affected_node=affected_node, poll_interval=poll_interval)
-                for _ in range(timeout):
-                    if node not in self.kubecli.list_nodes():
-                        break
-                    time.sleep(1)
-                if node in self.kubecli.list_nodes():
-                    raise Exception("Node could not be terminated")
+                if self.node_action_kube_check:
+                    for _ in range(timeout):
+                        if node not in self.kubecli.list_nodes():
+                            break
+                        time.sleep(1)
+                    if node in self.kubecli.list_nodes():
+                        raise Exception("Node could not be terminated")
                 logging.info(
                     "Node with instance ID: %s has been terminated" % (instance_id)
                 )

--- a/krkn/scenario_plugins/node_actions/common_node_functions.py
+++ b/krkn/scenario_plugins/node_actions/common_node_functions.py
@@ -83,7 +83,7 @@ def wait_for_unknown_status(
 
 def check_service_status(node, service, ssh_private_key, timeout):
     ssh = paramiko.SSHClient()
-    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.set_missing_host_key_policy(paramiko.WarningPolicy())
     i = 0
     sleeper = 1
     while i <= timeout:

--- a/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/node_actions/node_actions_scenario_plugin.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
 import time
 from multiprocessing.pool import ThreadPool
 from itertools import repeat
@@ -169,6 +170,22 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         ):
             disable_ssl_verification = get_yaml_item_value(node_scenario, "disable_ssl_verification", True)
             return ibmcloud_power_node_scenarios(kubecli, node_action_kube_check, affected_nodes_status, disable_ssl_verification)
+        elif node_scenario["cloud_type"].lower() == "ssh":
+            from krkn.scenario_plugins.node_actions.ssh_node_scenarios import (
+                ssh_node_scenarios,
+            )
+
+            ssh_config = {
+                "ssh_user": get_yaml_item_value(node_scenario, "ssh_user", "root"),
+                "ssh_private_key": os.path.expanduser(
+                    get_yaml_item_value(node_scenario, "ssh_private_key", "~/.ssh/id_rsa")
+                ),
+                "ssh_port": get_yaml_item_value(node_scenario, "ssh_port", 22),
+                "ssh_connect_timeout": get_yaml_item_value(node_scenario, "ssh_connect_timeout", 30),
+            }
+            return ssh_node_scenarios(
+                kubecli, node_action_kube_check, affected_nodes_status, ssh_config
+            )
         else:
             logging.error(
                 "Cloud type "
@@ -201,9 +218,13 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
         label_selector = get_yaml_item_value(node_scenario, "label_selector", "")
         exclude_label = get_yaml_item_value(node_scenario, "exclude_label", "")
         parallel_nodes = get_yaml_item_value(node_scenario, "parallel", False)
+        targets = get_yaml_item_value(node_scenario, "targets", [])
 
         # Get the node to apply the scenario
-        if node_name:
+        if targets:
+            nodes = targets if isinstance(targets, list) else [targets]
+            logging.info("Using static target list: %s" % nodes)
+        elif node_name:
             node_name_list = node_name.split(",")
             nodes = common_node_functions.get_node_by_name(node_name_list, kubecli)
         else:
@@ -338,6 +359,9 @@ class NodeActionsScenarioPlugin(AbstractScenarioPlugin):
                     "There is no node action that matches %s, skipping scenario"
                     % action
                 )
+
+    def supports_standalone(self) -> bool:
+        return True
 
     def get_scenario_types(self) -> list[str]:
         return ["node_scenarios"]

--- a/krkn/scenario_plugins/node_actions/ssh_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/ssh_node_scenarios.py
@@ -1,0 +1,283 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import time
+
+import paramiko
+from krkn.scenario_plugins.node_actions.abstract_node_scenarios import (
+    abstract_node_scenarios,
+)
+from krkn_lib.k8s import KrknKubernetes
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
+
+try:
+    from krkn_lib.utils.ssh_executor import SSHExecutor
+except ImportError:
+
+    class SSHExecutor:
+        """Executes commands on remote hosts via SSH using paramiko."""
+
+        def __init__(
+            self,
+            ssh_user: str = "root",
+            ssh_private_key: str = "~/.ssh/id_rsa",
+            ssh_port: int = 22,
+            connect_timeout: int = 30,
+        ):
+            self.ssh_user = ssh_user
+            self.ssh_private_key = os.path.expanduser(ssh_private_key)
+            self.ssh_port = ssh_port
+            self.connect_timeout = connect_timeout
+
+        def execute(
+            self, host: str, command: str, timeout: int = 120
+        ) -> tuple[int, str, str]:
+            """Execute a command on a remote host via SSH.
+
+            :return: (exit_code, stdout, stderr)
+            """
+            ssh = paramiko.SSHClient()
+            ssh.set_missing_host_key_policy(paramiko.WarningPolicy())
+            try:
+                ssh.connect(
+                    host,
+                    port=self.ssh_port,
+                    username=self.ssh_user,
+                    key_filename=self.ssh_private_key,
+                    timeout=self.connect_timeout,
+                    banner_timeout=self.connect_timeout,
+                )
+                stdin, stdout, stderr = ssh.exec_command(
+                    command, timeout=timeout
+                )
+                exit_code = stdout.channel.recv_exit_status()
+                return (
+                    exit_code,
+                    stdout.read().decode(),
+                    stderr.read().decode(),
+                )
+            except paramiko.AuthenticationException as e:
+                logging.error(
+                    "SSH authentication failed for %s: %s" % (host, e)
+                )
+                raise
+            except paramiko.SSHException as e:
+                logging.error(
+                    "SSH connection error to %s: %s" % (host, e)
+                )
+                raise
+            except Exception as e:
+                logging.error(
+                    "Failed to execute command on %s: %s" % (host, e)
+                )
+                raise
+            finally:
+                ssh.close()
+
+        def is_host_reachable(self, host: str, timeout: int = 10) -> bool:
+            """Check if a host is reachable via SSH."""
+            ssh = paramiko.SSHClient()
+            ssh.set_missing_host_key_policy(paramiko.WarningPolicy())
+            try:
+                ssh.connect(
+                    host,
+                    port=self.ssh_port,
+                    username=self.ssh_user,
+                    key_filename=self.ssh_private_key,
+                    timeout=timeout,
+                    banner_timeout=timeout,
+                )
+                ssh.close()
+                return True
+            except Exception:
+                return False
+
+        def wait_for_host(
+            self,
+            host: str,
+            timeout: int = 600,
+            poll_interval: int = 15,
+            reachable: bool = True,
+        ) -> bool:
+            """Wait until host becomes reachable or unreachable via SSH."""
+            deadline = time.time() + timeout
+            state = "reachable" if reachable else "unreachable"
+            logging.info(
+                "Waiting for %s to become %s (timeout: %ds)"
+                % (host, state, timeout)
+            )
+            while time.time() < deadline:
+                if self.is_host_reachable(host) == reachable:
+                    logging.info("Host %s is now %s" % (host, state))
+                    return True
+                time.sleep(poll_interval)
+            logging.error(
+                "Timed out waiting for %s to become %s" % (host, state)
+            )
+            return False
+
+
+class ssh_node_scenarios(abstract_node_scenarios):
+    """Node chaos scenarios executed via SSH for standalone mode."""
+
+    def __init__(
+        self,
+        kubecli: KrknKubernetes,
+        node_action_kube_check: bool,
+        affected_nodes_status: AffectedNodeStatus,
+        ssh_config: dict,
+    ):
+        super().__init__(kubecli, node_action_kube_check, affected_nodes_status)
+        self.ssh = SSHExecutor(
+            ssh_user=ssh_config.get("ssh_user", "root"),
+            ssh_private_key=ssh_config.get("ssh_private_key", "~/.ssh/id_rsa"),
+            ssh_port=ssh_config.get("ssh_port", 22),
+            connect_timeout=ssh_config.get("ssh_connect_timeout", 30),
+        )
+
+    def supports_standalone(self) -> bool:
+        return True
+
+    def node_reboot_scenario(
+        self, instance_kill_count, node, timeout, soft_reboot=False
+    ):
+        for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
+            try:
+                logging.info("Starting SSH node_reboot_scenario on %s" % node)
+                cmd = "sudo reboot" if soft_reboot else "sudo sh -c 'echo b > /proc/sysrq-trigger'"
+                try:
+                    self.ssh.execute(node, cmd, timeout=10)
+                except Exception:
+                    pass  # connection drops on reboot
+                start_time = time.time()
+                self.ssh.wait_for_host(node, timeout=timeout, reachable=False)
+                self.ssh.wait_for_host(node, timeout=timeout, reachable=True)
+                recovery_time = time.time() - start_time
+                affected_node.set_affected_node_status("running", recovery_time)
+                logging.info(
+                    "SSH node_reboot_scenario on %s completed (recovery: %.1fs)"
+                    % (node, recovery_time)
+                )
+            except Exception as e:
+                logging.error(
+                    "SSH node_reboot_scenario failed on %s: %s" % (node, e)
+                )
+                raise RuntimeError(
+                    "SSH node_reboot_scenario failed on %s" % node
+                )
+            self.affected_nodes_status.affected_nodes.append(affected_node)
+
+    def node_stop_scenario(self, instance_kill_count, node, timeout, poll_interval):
+        for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
+            try:
+                logging.info("Starting SSH node_stop_scenario (shutdown) on %s" % node)
+                try:
+                    self.ssh.execute(node, "sudo shutdown -h now", timeout=10)
+                except Exception:
+                    pass  # connection drops on shutdown
+                start_time = time.time()
+                self.ssh.wait_for_host(
+                    node, timeout=timeout, reachable=False
+                )
+                affected_node.set_affected_node_status(
+                    "stopped", time.time() - start_time
+                )
+                logging.info(
+                    "SSH node_stop_scenario on %s completed" % node
+                )
+            except Exception as e:
+                logging.error(
+                    "SSH node_stop_scenario failed on %s: %s" % (node, e)
+                )
+                raise RuntimeError(
+                    "SSH node_stop_scenario failed on %s" % node
+                )
+            self.affected_nodes_status.affected_nodes.append(affected_node)
+
+    def node_start_scenario(self, instance_kill_count, node, timeout, poll_interval):
+        logging.warning(
+            "node_start_scenario is not supported via SSH "
+            "(cannot power on a shutdown host remotely). "
+            "Use a cloud provider cloud_type for power management."
+        )
+
+    def node_termination_scenario(
+        self, instance_kill_count, node, timeout, poll_interval
+    ):
+        logging.warning(
+            "node_termination_scenario is not supported via SSH. "
+            "Use a cloud provider cloud_type for instance termination."
+        )
+
+    def node_crash_scenario(self, instance_kill_count, node, timeout):
+        for _ in range(instance_kill_count):
+            try:
+                logging.info("Starting SSH node_crash_scenario on %s" % node)
+                try:
+                    self.ssh.execute(
+                        node,
+                        "sudo sh -c 'echo c > /proc/sysrq-trigger'",
+                        timeout=10,
+                    )
+                except Exception:
+                    pass  # connection drops on crash
+                logging.info(
+                    "SSH node_crash_scenario on %s injected" % node
+                )
+            except Exception as e:
+                logging.error(
+                    "SSH node_crash_scenario failed on %s: %s" % (node, e)
+                )
+                return 1
+
+    def stop_kubelet_scenario(self, instance_kill_count, node, timeout):
+        for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
+            try:
+                logging.info("Starting SSH stop_kubelet_scenario on %s" % node)
+                exit_code, _, stderr = self.ssh.execute(
+                    node, "sudo systemctl stop kubelet", timeout=60
+                )
+                if exit_code != 0:
+                    raise Exception("Failed to stop kubelet: %s" % stderr)
+                logging.info("Kubelet stopped on %s via SSH" % node)
+            except Exception as e:
+                logging.error(
+                    "SSH stop_kubelet_scenario failed: %s" % e
+                )
+                raise e
+            self.affected_nodes_status.affected_nodes.append(affected_node)
+
+    def restart_kubelet_scenario(self, instance_kill_count, node, timeout):
+        for _ in range(instance_kill_count):
+            affected_node = AffectedNode(node)
+            try:
+                logging.info(
+                    "Starting SSH restart_kubelet_scenario on %s" % node
+                )
+                exit_code, _, stderr = self.ssh.execute(
+                    node, "sudo systemctl restart kubelet", timeout=60
+                )
+                if exit_code != 0:
+                    raise Exception("Failed to restart kubelet: %s" % stderr)
+                logging.info("Kubelet restarted on %s via SSH" % node)
+            except Exception as e:
+                logging.error(
+                    "SSH restart_kubelet_scenario failed: %s" % e
+                )
+                raise e
+            self.affected_nodes_status.affected_nodes.append(affected_node)

--- a/krkn/scenario_plugins/standalone_disk_fill/__init__.py
+++ b/krkn/scenario_plugins/standalone_disk_fill/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/krkn/scenario_plugins/standalone_disk_fill/standalone_disk_fill_scenario_plugin.py
+++ b/krkn/scenario_plugins/standalone_disk_fill/standalone_disk_fill_scenario_plugin.py
@@ -1,0 +1,173 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import re
+import shlex
+import threading
+import time
+
+import yaml
+from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+
+from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+FILL_FILE_NAME = "krkn_disk_fill_chaos"
+
+
+class StandaloneDiskFillScenarioPlugin(AbstractScenarioPlugin):
+
+    def run(
+        self,
+        run_uuid: str,
+        scenario: str,
+        lib_telemetry: KrknTelemetryOpenshift,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        ssh_executor = None
+        fill_path = "/tmp"
+        targets = []
+        filled_hosts = []
+        try:
+            with open(scenario, "r") as f:
+                config = yaml.safe_load(f)
+
+            targets = config.get("targets", [])
+            if not targets:
+                logging.error(
+                    "standalone_disk_fill_scenarios: 'targets' list is required"
+                )
+                return 1
+
+            ssh_executor = SSHExecutor(
+                ssh_user=config.get("ssh_user", "root"),
+                ssh_private_key=os.path.expanduser(
+                    config.get("ssh_private_key", "~/.ssh/id_rsa")
+                ),
+                ssh_port=config.get("ssh_port", 22),
+                connect_timeout=config.get("ssh_connect_timeout", 30),
+            )
+
+            fill_path = config.get("fill_path", "/tmp")
+            fill_size = config.get("fill_size", "")
+            fill_percentage = config.get("fill_percentage", 0)
+            duration = config.get("duration", 60)
+
+            if fill_size and not re.match(r"^\d+[BKMGT]?$", fill_size, re.IGNORECASE):
+                logging.error(
+                    "standalone_disk_fill_scenarios: invalid fill_size format: %s" % fill_size
+                )
+                return 1
+
+            if not fill_size and not fill_percentage:
+                logging.error(
+                    "standalone_disk_fill_scenarios: "
+                    "either 'fill_size' or 'fill_percentage' is required"
+                )
+                return 1
+
+            filled_hosts = []
+            for target in targets:
+                self._fill_disk(
+                    ssh_executor, target, fill_path, fill_size, fill_percentage
+                )
+                filled_hosts.append(target)
+
+            logging.info(
+                "Disk fill active for %ds on %d target(s)"
+                % (duration, len(filled_hosts))
+            )
+            threading.Event().wait(timeout=duration)
+
+
+            for target in filled_hosts:
+                self._cleanup(ssh_executor, target, fill_path)
+
+            return 0
+        except Exception as e:
+            logging.error("standalone_disk_fill_scenarios exception: %s" % e)
+            if ssh_executor:
+                for target in filled_hosts:
+                    try:
+                        self._cleanup(ssh_executor, target, fill_path)
+                    except Exception:
+                        pass
+            return 1
+
+    def _fill_disk(
+        self,
+        ssh: SSHExecutor,
+        host: str,
+        fill_path: str,
+        fill_size: str,
+        fill_percentage: int,
+    ) -> None:
+        safe_path = shlex.quote(fill_path)
+        fill_file = "%s/%s" % (fill_path, FILL_FILE_NAME)
+        safe_fill_file = shlex.quote(fill_file)
+
+        if fill_size:
+            logging.info(
+                "[%s] Filling %s with %s" % (host, fill_path, fill_size)
+            )
+            cmd = "fallocate -l %s %s" % (shlex.quote(fill_size), safe_fill_file)
+        else:
+            logging.info(
+                "[%s] Filling %s to %d%%" % (host, fill_path, fill_percentage)
+            )
+            exit_code, stdout, _ = ssh.execute(
+                host,
+                "df --output=avail,size -B1 %s | tail -1" % safe_path,
+                timeout=30,
+            )
+            if exit_code != 0:
+                raise Exception("[%s] Failed to get disk info for %s" % (host, fill_path))
+            parts = stdout.strip().split()
+            avail = int(parts[0])
+            total = int(parts[1])
+            used = total - avail
+            target_used = int(total * fill_percentage / 100)
+            fill_bytes = max(0, target_used - used)
+            if fill_bytes == 0:
+                logging.warning(
+                    "[%s] Disk already at or above %d%%" % (host, fill_percentage)
+                )
+                return
+            cmd = "fallocate -l %d %s" % (fill_bytes, safe_fill_file)
+
+        exit_code, _, stderr = ssh.execute(host, cmd, timeout=120)
+        if exit_code != 0:
+            fill_mb = fill_bytes // (1024 * 1024) if not fill_size else 1024
+            cmd_dd = "dd if=/dev/zero of=%s bs=1M count=%d" % (safe_fill_file, fill_mb)
+            logging.warning(
+                "[%s] fallocate failed, falling back to dd" % host
+            )
+            ssh.execute(host, cmd_dd, timeout=300)
+
+        logging.info("[%s] Disk fill complete: %s" % (host, fill_file))
+
+    def _cleanup(self, ssh: SSHExecutor, host: str, fill_path: str = "/tmp") -> None:
+        fill_file = "%s/%s" % (fill_path, FILL_FILE_NAME)
+        safe_fill_file = shlex.quote(fill_file)
+        logging.info("[%s] Removing disk fill file: %s" % (host, fill_file))
+        ssh.execute(host, "rm -f %s" % safe_fill_file, timeout=30)
+        logging.info("[%s] Disk fill cleaned up" % host)
+
+    def supports_standalone(self) -> bool:
+        return True
+
+    def get_scenario_types(self) -> list[str]:
+        return ["standalone_disk_fill_scenarios"]

--- a/krkn/scenario_plugins/standalone_disk_fill/standalone_disk_fill_scenario_plugin.py
+++ b/krkn/scenario_plugins/standalone_disk_fill/standalone_disk_fill_scenario_plugin.py
@@ -150,7 +150,9 @@ class StandaloneDiskFillScenarioPlugin(AbstractScenarioPlugin):
 
         exit_code, _, stderr = ssh.execute(host, cmd, timeout=120)
         if exit_code != 0:
-            fill_mb = fill_bytes // (1024 * 1024) if not fill_size else 1024
+            if fill_size:
+                fill_bytes = self._parse_size_to_bytes(fill_size)
+            fill_mb = max(1, fill_bytes // (1024 * 1024))
             cmd_dd = "dd if=/dev/zero of=%s bs=1M count=%d" % (safe_fill_file, fill_mb)
             logging.warning(
                 "[%s] fallocate failed, falling back to dd" % host
@@ -158,6 +160,15 @@ class StandaloneDiskFillScenarioPlugin(AbstractScenarioPlugin):
             ssh.execute(host, cmd_dd, timeout=300)
 
         logging.info("[%s] Disk fill complete: %s" % (host, fill_file))
+
+    @staticmethod
+    def _parse_size_to_bytes(size_str: str) -> int:
+        """Parse a human-readable size string (e.g. '1G', '500M') to bytes."""
+        units = {"B": 1, "K": 1024, "M": 1024**2, "G": 1024**3, "T": 1024**4}
+        size_str = size_str.strip().upper()
+        if size_str[-1] in units:
+            return int(size_str[:-1]) * units[size_str[-1]]
+        return int(size_str)
 
     def _cleanup(self, ssh: SSHExecutor, host: str, fill_path: str = "/tmp") -> None:
         fill_file = "%s/%s" % (fill_path, FILL_FILE_NAME)

--- a/krkn/scenario_plugins/standalone_file/__init__.py
+++ b/krkn/scenario_plugins/standalone_file/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/krkn/scenario_plugins/standalone_file/standalone_file_scenario_plugin.py
+++ b/krkn/scenario_plugins/standalone_file/standalone_file_scenario_plugin.py
@@ -79,12 +79,16 @@ class StandaloneFileScenarioPlugin(AbstractScenarioPlugin):
                 )
                 threading.Event().wait(timeout=duration)
 
-
                 for target in targets:
                     self._revert_file_chaos(
                         ssh_executor, target, action, file_path,
                         revert_data.get(target, {})
                     )
+            else:
+                logging.warning(
+                    "duration=0: file chaos will NOT be auto-reverted. "
+                    "Manual cleanup may be required."
+                )
 
             return 0
         except Exception as e:
@@ -163,14 +167,26 @@ class StandaloneFileScenarioPlugin(AbstractScenarioPlugin):
                 )
 
         elif action == "delete":
-            ssh.execute(
+            cp_exit, _, cp_stderr = ssh.execute(
                 host,
                 "sudo cp %s %s.krkn_bak" % (safe_path, safe_path),
                 timeout=10,
             )
+            if cp_exit != 0:
+                raise Exception(
+                    "[%s] Failed to backup %s before delete: %s"
+                    % (host, file_path, cp_stderr)
+                )
             revert_info["backup_path"] = file_path + ".krkn_bak"
             logging.info("[%s] Deleting %s" % (host, file_path))
-            ssh.execute(host, "sudo rm -f %s" % safe_path, timeout=10)
+            rm_exit, _, rm_stderr = ssh.execute(
+                host, "sudo rm -f %s" % safe_path, timeout=10,
+            )
+            if rm_exit != 0:
+                logging.error(
+                    "[%s] Failed to delete %s: %s"
+                    % (host, file_path, rm_stderr)
+                )
 
         else:
             raise ValueError(

--- a/krkn/scenario_plugins/standalone_file/standalone_file_scenario_plugin.py
+++ b/krkn/scenario_plugins/standalone_file/standalone_file_scenario_plugin.py
@@ -1,0 +1,230 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import shlex
+import threading
+import time
+
+import yaml
+from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+
+from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+
+class StandaloneFileScenarioPlugin(AbstractScenarioPlugin):
+
+    def run(
+        self,
+        run_uuid: str,
+        scenario: str,
+        lib_telemetry: KrknTelemetryOpenshift,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        ssh_executor = None
+        revert_data = {}
+        action = ""
+        file_path = ""
+        try:
+            with open(scenario, "r") as f:
+                config = yaml.safe_load(f)
+
+            targets = config.get("targets", [])
+            if not targets:
+                logging.error(
+                    "standalone_file_scenarios: 'targets' list is required"
+                )
+                return 1
+
+            ssh_executor = SSHExecutor(
+                ssh_user=config.get("ssh_user", "root"),
+                ssh_private_key=os.path.expanduser(
+                    config.get("ssh_private_key", "~/.ssh/id_rsa")
+                ),
+                ssh_port=config.get("ssh_port", 22),
+                connect_timeout=config.get("ssh_connect_timeout", 30),
+            )
+
+            action = config.get("action", "chmod")
+            file_path = config.get("file_path", "")
+            duration = config.get("duration", 0)
+
+            if not file_path:
+                logging.error("standalone_file_scenarios: 'file_path' is required")
+                return 1
+
+            for target in targets:
+                revert_info = self._apply_file_chaos(
+                    ssh_executor, target, action, file_path, config
+                )
+                revert_data[target] = revert_info
+
+            if duration > 0:
+                logging.info(
+                    "File chaos active for %ds on %d target(s)"
+                    % (duration, len(targets))
+                )
+                threading.Event().wait(timeout=duration)
+
+
+                for target in targets:
+                    self._revert_file_chaos(
+                        ssh_executor, target, action, file_path,
+                        revert_data.get(target, {})
+                    )
+
+            return 0
+        except Exception as e:
+            logging.error("standalone_file_scenarios exception: %s" % e)
+            if ssh_executor and revert_data:
+                for target in revert_data:
+                    try:
+                        self._revert_file_chaos(
+                            ssh_executor, target, action, file_path,
+                            revert_data[target]
+                        )
+                    except Exception as rollback_err:
+                        logging.error(
+                            "[%s] Rollback failed: %s" % (target, rollback_err)
+                        )
+            return 1
+
+    def _apply_file_chaos(
+        self,
+        ssh: SSHExecutor,
+        host: str,
+        action: str,
+        file_path: str,
+        config: dict,
+    ) -> dict:
+        revert_info = {}
+        safe_path = shlex.quote(file_path)
+
+        if action == "chmod":
+            exit_code, stdout, _ = ssh.execute(
+                host, "stat -c '%%a' %s" % safe_path, timeout=10
+            )
+            if exit_code != 0:
+                raise Exception("[%s] File not found: %s" % (host, file_path))
+            revert_info["original_perms"] = stdout.strip()
+            new_perms = config.get("permissions", "000")
+            safe_perms = shlex.quote(new_perms)
+            logging.info(
+                "[%s] Changing permissions of %s from %s to %s"
+                % (host, file_path, revert_info["original_perms"], new_perms)
+            )
+            ssh.execute(
+                host, "sudo chmod %s %s" % (safe_perms, safe_path), timeout=10
+            )
+
+        elif action == "rename":
+            target_path = config.get("target_path", file_path + ".krkn_bak")
+            safe_target = shlex.quote(target_path)
+            logging.info(
+                "[%s] Renaming %s to %s" % (host, file_path, target_path)
+            )
+            ssh.execute(
+                host, "sudo mv %s %s" % (safe_path, safe_target), timeout=10
+            )
+            revert_info["target_path"] = target_path
+
+        elif action == "append":
+            content = config.get("content", "# krkn chaos injection")
+            count = config.get("count", 1)
+            exit_code, stdout, _ = ssh.execute(
+                host, "wc -c < %s" % safe_path, timeout=10
+            )
+            if exit_code != 0:
+                raise Exception("[%s] File not found: %s" % (host, file_path))
+            revert_info["original_size"] = stdout.strip()
+            logging.info(
+                "[%s] Appending %d line(s) to %s" % (host, count, file_path)
+            )
+            safe_content = shlex.quote(content)
+            for _ in range(count):
+                ssh.execute(
+                    host,
+                    "printf '%%s\\n' %s | sudo tee -a %s > /dev/null"
+                    % (safe_content, safe_path),
+                    timeout=10,
+                )
+
+        elif action == "delete":
+            ssh.execute(
+                host,
+                "sudo cp %s %s.krkn_bak" % (safe_path, safe_path),
+                timeout=10,
+            )
+            revert_info["backup_path"] = file_path + ".krkn_bak"
+            logging.info("[%s] Deleting %s" % (host, file_path))
+            ssh.execute(host, "sudo rm -f %s" % safe_path, timeout=10)
+
+        else:
+            raise ValueError(
+                "Unknown file action: %s. Supported: chmod, rename, append, delete"
+                % action
+            )
+
+        return revert_info
+
+    def _revert_file_chaos(
+        self,
+        ssh: SSHExecutor,
+        host: str,
+        action: str,
+        file_path: str,
+        revert_info: dict,
+    ) -> None:
+        logging.info("[%s] Reverting file chaos on %s" % (host, file_path))
+        safe_path = shlex.quote(file_path)
+
+        if action == "chmod":
+            original_perms = revert_info.get("original_perms", "644")
+            ssh.execute(
+                host, "sudo chmod %s %s" % (shlex.quote(original_perms), safe_path),
+                timeout=10,
+            )
+
+        elif action == "rename":
+            target_path = revert_info.get("target_path", file_path + ".krkn_bak")
+            ssh.execute(
+                host, "sudo mv %s %s" % (shlex.quote(target_path), safe_path),
+                timeout=10,
+            )
+
+        elif action == "append":
+            original_size = revert_info.get("original_size", "")
+            if original_size:
+                ssh.execute(
+                    host,
+                    "sudo truncate -s %s %s" % (shlex.quote(original_size), safe_path),
+                    timeout=10,
+                )
+
+        elif action == "delete":
+            backup_path = revert_info.get("backup_path", file_path + ".krkn_bak")
+            ssh.execute(
+                host, "sudo mv %s %s" % (shlex.quote(backup_path), safe_path),
+                timeout=10,
+            )
+
+        logging.info("[%s] File chaos reverted on %s" % (host, file_path))
+
+    def supports_standalone(self) -> bool:
+        return True
+
+    def get_scenario_types(self) -> list[str]:
+        return ["standalone_file_scenarios"]

--- a/krkn/scenario_plugins/time_actions/time_actions_scenario_plugin.py
+++ b/krkn/scenario_plugins/time_actions/time_actions_scenario_plugin.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 import datetime
 import logging
+import os
 import random
 import re
+import shlex
 import time
 
 import yaml
@@ -25,6 +27,7 @@ from krkn_lib.utils import get_random_string, get_yaml_item_value, log_exception
 from kubernetes.client import ApiException
 
 from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
 
 
 class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
@@ -39,6 +42,16 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
             with open(scenario, "r") as f:
                 scenario_config = yaml.safe_load(f)
                 for time_scenario in scenario_config["time_scenarios"]:
+                    targets = time_scenario.get("targets", [])
+                    if targets:
+                        return self._run_standalone(time_scenario, targets)
+
+                    if lib_telemetry.get_lib_kubernetes() is None:
+                        logging.error(
+                            "time_scenarios requires 'targets' field in standalone mode"
+                        )
+                        return 1
+
                     object_type, object_names = self.skew_time(
                         time_scenario, lib_telemetry.get_lib_kubernetes()
                     )
@@ -56,6 +69,51 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
             return 1
         else:
             return 0
+
+    def _run_standalone(self, time_scenario: dict, targets: list[str]) -> int:
+        """Run time skew on standalone targets via SSH."""
+        action = time_scenario.get("action", "skew_time")
+        duration = time_scenario.get("duration", 300)
+        disable_ntp = time_scenario.get("disable_ntp", True)
+
+        ssh_executor = SSHExecutor(
+            ssh_user=time_scenario.get("ssh_user", "root"),
+            ssh_private_key=os.path.expanduser(
+                time_scenario.get("ssh_private_key", "~/.ssh/id_rsa")
+            ),
+            ssh_port=time_scenario.get("ssh_port", 22),
+        )
+
+        skew_param = "01:01:01" if action == "skew_time" else "2001-01-01"
+
+        for target in targets:
+            if disable_ntp:
+                logging.info("[%s] Disabling NTP" % target)
+                ssh_executor.execute(target, "sudo timedatectl set-ntp false", timeout=30)
+
+            logging.info("[%s] Skewing %s to %s" % (target, action, skew_param))
+            exit_code, _, stderr = ssh_executor.execute(
+                target, "sudo timedatectl set-time %s" % shlex.quote(skew_param), timeout=30
+            )
+            if exit_code != 0:
+                logging.error("[%s] Failed to skew time: %s" % (target, stderr))
+                return 1
+
+        logging.info("Time skew active for %ds on %d target(s)" % (duration, len(targets)))
+        time.sleep(duration)
+
+        for target in targets:
+            logging.info("[%s] Reverting time skew" % target)
+            ssh_executor.execute(target, "sudo timedatectl set-ntp true", timeout=30)
+            ssh_executor.execute(target, "sudo hwclock --hctosys", timeout=30)
+
+            exit_code, stdout, _ = ssh_executor.execute(target, "timedatectl", timeout=10)
+            if exit_code == 0 and "NTP" in stdout.upper():
+                logging.info("[%s] Time reverted (NTP re-enabled)" % target)
+            else:
+                logging.warning("[%s] Could not verify time reset" % target)
+
+        return 0
 
     def pod_exec(
         self, pod_name, command, namespace, container_name, kubecli: KrknKubernetes
@@ -76,44 +134,6 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
             else:
                 break
         return response
-
-    def exec_with_shell_fallback(self, command, pod_name, namespace, container_name, kubecli: KrknKubernetes, max_retries=3):
-        """
-        Execute command in pod with shell fallback on failure.
-        
-        Args:
-            command: Command to execute (string or list)
-            pod_name: Name of the pod
-            namespace: Namespace of the pod
-            container_name: Name of the container
-            kubecli: Kubernetes client
-            max_retries: Maximum number of retries
-            
-        Returns:
-            Command output or False on persistent failure
-        """
-        # Try direct execution first
-        for attempt in range(max_retries):
-            try:
-                response = kubecli.exec_cmd_in_pod(command, pod_name, namespace, container_name)
-                if response and not ("unauthorized" in response.lower() or "authorization" in response.lower()):
-                    return response
-            except Exception:
-                pass
-            
-            # If direct execution fails, try with shell fallback
-            try:
-                shell_command = ["/bin/sh", "-c"] + (command if isinstance(command, list) else [command])
-                response = kubecli.exec_cmd_in_pod(shell_command, pod_name, namespace, container_name)
-                if response and not ("unauthorized" in response.lower() or "authorization" in response.lower()):
-                    return response
-            except Exception:
-                pass
-                
-            if attempt < max_retries - 1:
-                time.sleep(1)
-        
-        return False
 
     # krkn_lib
     def get_container_name(
@@ -399,6 +419,9 @@ class TimeActionsScenarioPlugin(AbstractScenarioPlugin):
                 if counter < max_retries:
                     logging.info("Date in pod " + str(pod_name[0]) + " reset properly")
         return not_reset
+
+    def supports_standalone(self) -> bool:
+        return True
 
     def get_scenario_types(self) -> list[str]:
         return ["time_scenarios"]

--- a/krkn/scenario_plugins/vm_migration_chaos/__init__.py
+++ b/krkn/scenario_plugins/vm_migration_chaos/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/krkn/scenario_plugins/vm_migration_chaos/vm_migration_chaos_scenario_plugin.py
+++ b/krkn/scenario_plugins/vm_migration_chaos/vm_migration_chaos_scenario_plugin.py
@@ -14,6 +14,8 @@
 import logging
 import os
 import shlex
+import shutil
+import subprocess
 import threading
 import time
 
@@ -108,7 +110,7 @@ class VmMigrationChaosScenarioPlugin(AbstractScenarioPlugin):
             "spec": {"vmiName": vm_name},
         }
         try:
-            kubecli.custom_object_client().create_namespaced_custom_object(
+            kubecli.custom_object_client.create_namespaced_custom_object(
                 group="kubevirt.io", version="v1",
                 namespace=vm_namespace,
                 plural="virtualmachineinstancemigrations",
@@ -205,14 +207,29 @@ class VmMigrationChaosScenarioPlugin(AbstractScenarioPlugin):
             % (source_node, vm_name)
         )
 
-        try:
-            kubecli.kubectl(
-                "adm", "cordon", source_node
+        kubectl_bin = shutil.which("oc") or shutil.which("kubectl")
+        if not kubectl_bin:
+            logging.error(
+                "Neither 'oc' nor 'kubectl' found in PATH"
             )
-            kubecli.kubectl(
-                "adm", "drain", source_node,
-                "--ignore-daemonsets", "--delete-emptydir-data",
-                "--timeout=%ds" % timeout,
+            return 1
+
+        try:
+            subprocess.run(
+                [kubectl_bin, "adm", "cordon", source_node],
+                check=True, capture_output=True, text=True,
+                timeout=60,
+            )
+            subprocess.run(
+                [kubectl_bin, "adm", "drain", source_node,
+                 "--ignore-daemonsets", "--delete-emptydir-data",
+                 "--timeout=%ds" % timeout],
+                check=True, capture_output=True, text=True,
+                timeout=timeout + 60,
+            )
+        except subprocess.CalledProcessError as e:
+            logging.warning(
+                "Node drain encountered issue: %s" % e.stderr
             )
         except Exception as e:
             logging.warning("Node drain encountered issue: %s" % e)
@@ -224,7 +241,11 @@ class VmMigrationChaosScenarioPlugin(AbstractScenarioPlugin):
         recovery_time = time.time() - start_time
 
         try:
-            kubecli.kubectl("adm", "uncordon", source_node)
+            subprocess.run(
+                [kubectl_bin, "adm", "uncordon", source_node],
+                check=True, capture_output=True, text=True,
+                timeout=60,
+            )
         except Exception:
             pass
 
@@ -371,10 +392,9 @@ class VmMigrationChaosScenarioPlugin(AbstractScenarioPlugin):
             vm_namespace,
             label_selector="kubevirt.io/domain=%s" % vm_name,
         )
-        running_pods = [p for p in pods if not p.endswith("-migration")]
-        if len(running_pods) > 1:
+        if len(pods) > 1:
             logging.error(
-                "Dual virt-launcher pods detected: %s" % running_pods
+                "Dual virt-launcher pods detected: %s" % pods
             )
             return True
         return False
@@ -383,7 +403,7 @@ class VmMigrationChaosScenarioPlugin(AbstractScenarioPlugin):
         self, kubecli: KrknKubernetes, vm_name: str, vm_namespace: str
     ) -> None:
         try:
-            kubecli.custom_object_client().delete_namespaced_custom_object(
+            kubecli.custom_object_client.delete_namespaced_custom_object(
                 group="kubevirt.io",
                 version="v1",
                 namespace=vm_namespace,
@@ -394,7 +414,7 @@ class VmMigrationChaosScenarioPlugin(AbstractScenarioPlugin):
             pass
 
     def supports_standalone(self) -> bool:
-        return True
+        return False
 
     def get_scenario_types(self) -> list[str]:
         return ["vm_migration_chaos_scenarios"]

--- a/krkn/scenario_plugins/vm_migration_chaos/vm_migration_chaos_scenario_plugin.py
+++ b/krkn/scenario_plugins/vm_migration_chaos/vm_migration_chaos_scenario_plugin.py
@@ -1,0 +1,400 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import shlex
+import threading
+import time
+
+import yaml
+from krkn_lib.k8s import KrknKubernetes
+from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
+from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+from krkn_lib.utils import get_yaml_item_value
+
+from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+
+class VmMigrationChaosScenarioPlugin(AbstractScenarioPlugin):
+
+    def run(
+        self,
+        run_uuid: str,
+        scenario: str,
+        lib_telemetry: KrknTelemetryOpenshift,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        try:
+            with open(scenario, "r") as f:
+                config = yaml.safe_load(f)
+
+            scenario_config = config.get("vm_migration_chaos", config)
+            kubecli = lib_telemetry.get_lib_kubernetes()
+
+            if kubecli is None:
+                logging.error(
+                    "vm_migration_chaos requires Kubernetes API access"
+                )
+                return 1
+
+            action = get_yaml_item_value(
+                scenario_config, "migration_action", "trigger_and_disrupt"
+            )
+            vm_name = get_yaml_item_value(scenario_config, "vm_name", "")
+            vm_namespace = get_yaml_item_value(
+                scenario_config, "vm_namespace", "default"
+            )
+            fault_type = get_yaml_item_value(
+                scenario_config, "fault_type", "network_latency"
+            )
+            fault_params = get_yaml_item_value(
+                scenario_config, "fault_params", {}
+            )
+            timeout = get_yaml_item_value(scenario_config, "timeout", 600)
+            verify_no_dual_pods = get_yaml_item_value(
+                scenario_config, "verify_no_dual_pods", True
+            )
+
+            if not vm_name:
+                logging.error("vm_migration_chaos: 'vm_name' is required")
+                return 1
+
+            if action == "trigger_and_disrupt":
+                return self._trigger_and_disrupt(
+                    kubecli, vm_name, vm_namespace, fault_type,
+                    fault_params, timeout, verify_no_dual_pods,
+                    scenario_config, scenario_telemetry,
+                )
+            elif action == "drain_node":
+                return self._drain_node(
+                    kubecli, vm_name, vm_namespace, timeout,
+                    verify_no_dual_pods, scenario_telemetry,
+                )
+            else:
+                logging.error(
+                    "Unknown migration_action: %s. "
+                    "Supported: trigger_and_disrupt, drain_node" % action
+                )
+                return 1
+
+        except Exception as e:
+            logging.error("vm_migration_chaos exception: %s" % e)
+            return 1
+
+    def _create_vmim(
+        self, kubecli: KrknKubernetes, vm_name: str, vm_namespace: str,
+    ) -> bool:
+        """Create a VirtualMachineInstanceMigration object."""
+        vmim_body = {
+            "apiVersion": "kubevirt.io/v1",
+            "kind": "VirtualMachineInstanceMigration",
+            "metadata": {
+                "name": "krkn-migration-%s" % vm_name,
+                "namespace": vm_namespace,
+            },
+            "spec": {"vmiName": vm_name},
+        }
+        try:
+            kubecli.custom_object_client().create_namespaced_custom_object(
+                group="kubevirt.io", version="v1",
+                namespace=vm_namespace,
+                plural="virtualmachineinstancemigrations",
+                body=vmim_body,
+            )
+            return True
+        except Exception as e:
+            logging.error("Failed to create VMIM: %s" % e)
+            return False
+
+    def _trigger_and_disrupt(
+        self,
+        kubecli: KrknKubernetes,
+        vm_name: str,
+        vm_namespace: str,
+        fault_type: str,
+        fault_params: dict,
+        timeout: int,
+        verify_no_dual_pods: bool,
+        config: dict,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        vmi = kubecli.get_vmi(vm_name, vm_namespace)
+        if not vmi:
+            logging.error("VMI %s not found in namespace %s" % (vm_name, vm_namespace))
+            return 1
+
+        source_node = vmi.get("status", {}).get("nodeName", "")
+        logging.info("VMI %s running on node %s" % (vm_name, source_node))
+
+        affected_node = AffectedNode(vm_name)
+        start_time = time.time()
+
+        if not self._create_vmim(kubecli, vm_name, vm_namespace):
+            return 1
+        logging.info("VMIM created. Waiting for migration to start...")
+        time.sleep(5)
+
+        fault_thread = threading.Thread(
+            target=self._inject_fault,
+            args=(config, source_node, fault_type, fault_params),
+        )
+        fault_thread.start()
+
+        migration_success = self._wait_for_migration(
+            kubecli, vm_name, vm_namespace, timeout
+        )
+        fault_duration = int(fault_params.get("duration", 30))
+        fault_thread.join(timeout=fault_duration + 60)
+
+        if verify_no_dual_pods and self._check_dual_pods(kubecli, vm_name, vm_namespace):
+            logging.error(
+                "CRITICAL: Two virt-launcher pods detected for VMI %s "
+                "(reproduces CNV-89391)" % vm_name
+            )
+            return 1
+
+        recovery_time = time.time() - start_time
+        vmi_post = kubecli.get_vmi(vm_name, vm_namespace)
+        post_node = vmi_post.get("status", {}).get("nodeName", "") if vmi_post else "unknown"
+
+        if migration_success:
+            affected_node.set_affected_node_status("migrated", recovery_time)
+            logging.info("VMI %s migrated %s→%s (%.1fs)" % (vm_name, source_node, post_node, recovery_time))
+        else:
+            affected_node.set_affected_node_status("migration_failed", recovery_time)
+            logging.error("VMI %s migration failed or timed out" % vm_name)
+
+        scenario_telemetry.affected_nodes.append(affected_node)
+        self._cleanup_vmim(kubecli, vm_name, vm_namespace)
+
+        return 0 if migration_success else 1
+
+    def _drain_node(
+        self,
+        kubecli: KrknKubernetes,
+        vm_name: str,
+        vm_namespace: str,
+        timeout: int,
+        verify_no_dual_pods: bool,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        vmi = kubecli.get_vmi(vm_name, vm_namespace)
+        if not vmi:
+            logging.error("VMI %s not found" % vm_name)
+            return 1
+
+        source_node = vmi.get("status", {}).get("nodeName", "")
+        affected_node = AffectedNode(vm_name)
+        start_time = time.time()
+
+        logging.info(
+            "Cordoning and draining node %s (VMI %s should migrate)"
+            % (source_node, vm_name)
+        )
+
+        try:
+            kubecli.kubectl(
+                "adm", "cordon", source_node
+            )
+            kubecli.kubectl(
+                "adm", "drain", source_node,
+                "--ignore-daemonsets", "--delete-emptydir-data",
+                "--timeout=%ds" % timeout,
+            )
+        except Exception as e:
+            logging.warning("Node drain encountered issue: %s" % e)
+
+        migration_success = self._wait_for_migration(
+            kubecli, vm_name, vm_namespace, timeout
+        )
+
+        recovery_time = time.time() - start_time
+
+        try:
+            kubecli.kubectl("adm", "uncordon", source_node)
+        except Exception:
+            pass
+
+        if migration_success:
+            affected_node.set_affected_node_status("evacuated", recovery_time)
+            logging.info(
+                "VMI %s evacuated from %s (%.1fs)" % (vm_name, source_node, recovery_time)
+            )
+        else:
+            affected_node.set_affected_node_status("evacuation_failed", recovery_time)
+            logging.error(
+                "VMI %s NOT evacuated from %s (reproduces CNV-81533)"
+                % (vm_name, source_node)
+            )
+
+        scenario_telemetry.affected_nodes.append(affected_node)
+        return 0 if migration_success else 1
+
+    def _inject_fault(
+        self,
+        config: dict,
+        source_node: str,
+        fault_type: str,
+        fault_params: dict,
+    ) -> None:
+        duration = fault_params.get("duration", 30)
+
+        ssh_executor = SSHExecutor(
+            ssh_user=get_yaml_item_value(config, "ssh_user", "core"),
+            ssh_private_key=os.path.expanduser(
+                get_yaml_item_value(config, "ssh_private_key", "~/.ssh/id_rsa")
+            ),
+            ssh_port=get_yaml_item_value(config, "ssh_port", 22),
+        )
+
+        try:
+            if fault_type == "network_latency":
+                latency = shlex.quote(
+                    str(fault_params.get("latency", "500ms"))
+                )
+                iface = shlex.quote(
+                    str(fault_params.get("interface", "br-ex"))
+                )
+                logging.info(
+                    "[%s] Injecting %s network latency on %s for %ds"
+                    % (source_node, latency, iface, duration)
+                )
+                ssh_executor.execute(
+                    source_node,
+                    "sudo tc qdisc add dev %s root netem delay %s"
+                    % (iface, latency),
+                    timeout=30,
+                )
+                time.sleep(duration)
+                ssh_executor.execute(
+                    source_node,
+                    "sudo tc qdisc del dev %s root" % iface,
+                    timeout=30,
+                )
+
+            elif fault_type == "network_partition":
+                target_ip = shlex.quote(
+                    str(fault_params.get("target_ip", ""))
+                )
+                logging.info(
+                    "[%s] Blocking traffic to %s for %ds"
+                    % (source_node, target_ip, duration)
+                )
+                ssh_executor.execute(
+                    source_node,
+                    "sudo iptables -A OUTPUT -d %s -j DROP" % target_ip,
+                    timeout=30,
+                )
+                time.sleep(duration)
+                ssh_executor.execute(
+                    source_node,
+                    "sudo iptables -D OUTPUT -d %s -j DROP" % target_ip,
+                    timeout=30,
+                )
+
+            elif fault_type == "node_cpu_stress":
+                logging.info(
+                    "[%s] Injecting CPU stress for %ds" % (source_node, duration)
+                )
+                ssh_executor.execute(
+                    source_node,
+                    "stress-ng --cpu 0 --cpu-load 95 --timeout %ds" % duration,
+                    timeout=duration + 60,
+                )
+
+            else:
+                logging.warning("Unknown fault_type: %s" % fault_type)
+
+        except Exception as e:
+            logging.error(
+                "[%s] Fault injection failed: %s" % (source_node, e)
+            )
+
+    def _wait_for_migration(
+        self,
+        kubecli: KrknKubernetes,
+        vm_name: str,
+        vm_namespace: str,
+        timeout: int,
+    ) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            vmi = kubecli.get_vmi(vm_name, vm_namespace)
+            if not vmi:
+                logging.warning("VMI %s disappeared" % vm_name)
+                return False
+
+            phase = vmi.get("status", {}).get("phase", "")
+            migration_state = vmi.get("status", {}).get("migrationState", {})
+
+            if migration_state:
+                completed = migration_state.get("completed", False)
+                failed = migration_state.get("failed", False)
+
+                if completed:
+                    logging.info("Migration completed for VMI %s" % vm_name)
+                    return True
+                if failed:
+                    logging.error("Migration failed for VMI %s" % vm_name)
+                    return False
+
+            if phase == "Running":
+                pass
+            elif phase in ("Failed", "Succeeded"):
+                logging.error(
+                    "VMI %s entered %s state during migration" % (vm_name, phase)
+                )
+                return False
+
+            time.sleep(10)
+
+        logging.error("Migration timed out for VMI %s" % vm_name)
+        return False
+
+    def _check_dual_pods(
+        self, kubecli: KrknKubernetes, vm_name: str, vm_namespace: str
+    ) -> bool:
+        pods = kubecli.list_pods(
+            vm_namespace,
+            label_selector="kubevirt.io/domain=%s" % vm_name,
+        )
+        running_pods = [p for p in pods if not p.endswith("-migration")]
+        if len(running_pods) > 1:
+            logging.error(
+                "Dual virt-launcher pods detected: %s" % running_pods
+            )
+            return True
+        return False
+
+    def _cleanup_vmim(
+        self, kubecli: KrknKubernetes, vm_name: str, vm_namespace: str
+    ) -> None:
+        try:
+            kubecli.custom_object_client().delete_namespaced_custom_object(
+                group="kubevirt.io",
+                version="v1",
+                namespace=vm_namespace,
+                plural="virtualmachineinstancemigrations",
+                name="krkn-migration-%s" % vm_name,
+            )
+        except Exception:
+            pass
+
+    def supports_standalone(self) -> bool:
+        return True
+
+    def get_scenario_types(self) -> list[str]:
+        return ["vm_migration_chaos_scenarios"]

--- a/krkn/scenario_plugins/vm_storage_chaos/__init__.py
+++ b/krkn/scenario_plugins/vm_storage_chaos/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/krkn/scenario_plugins/vm_storage_chaos/vm_storage_chaos_scenario_plugin.py
+++ b/krkn/scenario_plugins/vm_storage_chaos/vm_storage_chaos_scenario_plugin.py
@@ -1,0 +1,277 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import shlex
+import threading
+import time
+
+import yaml
+from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
+from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+from krkn_lib.utils import get_yaml_item_value
+
+from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+
+class VmStorageChaosScenarioPlugin(AbstractScenarioPlugin):
+
+    def run(
+        self,
+        run_uuid: str,
+        scenario: str,
+        lib_telemetry: KrknTelemetryOpenshift,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        try:
+            with open(scenario, "r") as f:
+                config = yaml.safe_load(f)
+
+            scenario_config = config.get("vm_storage_chaos", config)
+            action = get_yaml_item_value(scenario_config, "action", "kill_storage_service")
+            storage_targets = get_yaml_item_value(scenario_config, "storage_targets", [])
+            duration = get_yaml_item_value(scenario_config, "duration", 300)
+            verify_vm_recovery = get_yaml_item_value(scenario_config, "verify_vm_recovery", True)
+            recovery_timeout = get_yaml_item_value(scenario_config, "recovery_timeout", 600)
+
+            if not storage_targets:
+                logging.error("vm_storage_chaos: 'storage_targets' list is required")
+                return 1
+
+            ssh_executor = SSHExecutor(
+                ssh_user=get_yaml_item_value(scenario_config, "ssh_user", "root"),
+                ssh_private_key=os.path.expanduser(
+                    get_yaml_item_value(scenario_config, "ssh_private_key", "~/.ssh/id_rsa")
+                ),
+                ssh_port=get_yaml_item_value(scenario_config, "ssh_port", 22),
+            )
+
+            affected_nodes_status = AffectedNodeStatus()
+
+            if action == "kill_storage_service":
+                return self._kill_storage_service(
+                    ssh_executor, storage_targets, duration,
+                    affected_nodes_status, scenario_telemetry,
+                )
+            elif action == "io_burst":
+                return self._io_burst(
+                    ssh_executor, storage_targets, duration,
+                    scenario_config, affected_nodes_status, scenario_telemetry,
+                )
+            elif action == "fill_storage":
+                return self._fill_storage(
+                    ssh_executor, storage_targets, duration,
+                    scenario_config, affected_nodes_status, scenario_telemetry,
+                )
+            else:
+                logging.error(
+                    "Unknown vm_storage_chaos action: %s. "
+                    "Supported: kill_storage_service, io_burst, fill_storage" % action
+                )
+                return 1
+
+        except Exception as e:
+            logging.error("vm_storage_chaos exception: %s" % e)
+            return 1
+
+    def _kill_storage_service(
+        self,
+        ssh: SSHExecutor,
+        storage_targets: list[dict],
+        duration: int,
+        affected_nodes_status: AffectedNodeStatus,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        for target in storage_targets:
+            host = target.get("host", "")
+            service = target.get("service", "nfs-server")
+            safe_service = shlex.quote(service)
+
+            if not host:
+                logging.error("vm_storage_chaos: 'host' is required in storage_targets")
+                return 1
+
+            affected_node = AffectedNode(host)
+            start_time = time.time()
+
+            logging.info("[%s] Stopping storage service: %s" % (host, service))
+            exit_code, _, stderr = ssh.execute(
+                host, "sudo systemctl stop %s" % safe_service, timeout=60
+            )
+            if exit_code != 0:
+                logging.error(
+                    "[%s] Failed to stop %s: %s" % (host, service, stderr)
+                )
+                return 1
+
+            logging.info(
+                "[%s] Storage service %s stopped. Chaos active for %ds"
+                % (host, service, duration)
+            )
+            threading.Event().wait(timeout=duration)
+
+
+            logging.info("[%s] Restarting storage service: %s" % (host, service))
+            ssh.execute(
+                host, "sudo systemctl start %s" % safe_service, timeout=60
+            )
+
+            recovery_time = time.time() - start_time
+            affected_node.set_affected_node_status("recovered", recovery_time)
+            affected_nodes_status.affected_nodes.append(affected_node)
+            logging.info(
+                "[%s] Storage service %s restored (total disruption: %.1fs)"
+                % (host, service, recovery_time)
+            )
+
+        scenario_telemetry.affected_nodes.extend(
+            affected_nodes_status.affected_nodes
+        )
+        return 0
+
+    def _io_burst(
+        self,
+        ssh: SSHExecutor,
+        storage_targets: list[dict],
+        duration: int,
+        config: dict,
+        affected_nodes_status: AffectedNodeStatus,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        io_workers = get_yaml_item_value(config, "io_workers", 4)
+        io_bytes = shlex.quote(
+            str(get_yaml_item_value(config, "io_bytes", "1G"))
+        )
+
+        for target in storage_targets:
+            host = target.get("host", "")
+            target_path = target.get("path", "/var/lib/containers")
+
+            if not host:
+                logging.error("vm_storage_chaos: 'host' is required in storage_targets")
+                return 1
+
+            affected_node = AffectedNode(host)
+            start_time = time.time()
+
+            cmd = (
+                "stress-ng --iomix %d --iomix-bytes %s "
+                "--temp-path %s --timeout %ds --metrics-brief"
+                % (io_workers, io_bytes, shlex.quote(target_path), duration)
+            )
+
+            logging.info("[%s] Starting IO burst: %s" % (host, cmd))
+            exit_code, stdout, stderr = ssh.execute(
+                host, cmd, timeout=duration + 120
+            )
+
+            recovery_time = time.time() - start_time
+            affected_node.set_affected_node_status("completed", recovery_time)
+            affected_nodes_status.affected_nodes.append(affected_node)
+
+            if exit_code != 0:
+                logging.error(
+                    "[%s] IO burst failed (exit %d): %s" % (host, exit_code, stderr)
+                )
+                return 1
+
+            logging.info("[%s] IO burst completed (%.1fs)" % (host, recovery_time))
+
+        scenario_telemetry.affected_nodes.extend(
+            affected_nodes_status.affected_nodes
+        )
+        return 0
+
+    def _fill_storage(
+        self,
+        ssh: SSHExecutor,
+        storage_targets: list[dict],
+        duration: int,
+        config: dict,
+        affected_nodes_status: AffectedNodeStatus,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        fill_percentage = get_yaml_item_value(config, "fill_percentage", 90)
+
+        for target in storage_targets:
+            host = target.get("host", "")
+            target_path = target.get("path", "/var/lib/containers")
+            safe_path = shlex.quote(target_path)
+            fill_file = "%s/krkn_storage_chaos_fill" % target_path
+            safe_fill_file = shlex.quote(fill_file)
+
+            if not host:
+                logging.error("vm_storage_chaos: 'host' is required")
+                return 1
+
+            affected_node = AffectedNode(host)
+            start_time = time.time()
+
+            exit_code, stdout, _ = ssh.execute(
+                host,
+                "df --output=avail,size -B1 %s | tail -1" % safe_path,
+                timeout=30,
+            )
+            if exit_code != 0:
+                logging.error("[%s] Failed to get disk info" % host)
+                return 1
+
+            parts = stdout.strip().split()
+            avail = int(parts[0])
+            total = int(parts[1])
+            used = total - avail
+            target_used = int(total * fill_percentage / 100)
+            fill_bytes = max(0, target_used - used)
+
+            if fill_bytes == 0:
+                logging.warning(
+                    "[%s] Storage already at or above %d%%" % (host, fill_percentage)
+                )
+                continue
+
+            logging.info(
+                "[%s] Filling %s to %d%% (%d bytes)"
+                % (host, target_path, fill_percentage, fill_bytes)
+            )
+            ssh.execute(
+                host,
+                "fallocate -l %d %s" % (fill_bytes, safe_fill_file),
+                timeout=120,
+            )
+
+            logging.info(
+                "[%s] Storage fill active for %ds" % (host, duration)
+            )
+            threading.Event().wait(timeout=duration)
+
+
+            logging.info("[%s] Cleaning up storage fill" % host)
+            ssh.execute(host, "rm -f %s" % safe_fill_file, timeout=30)
+
+            recovery_time = time.time() - start_time
+            affected_node.set_affected_node_status("recovered", recovery_time)
+            affected_nodes_status.affected_nodes.append(affected_node)
+
+        scenario_telemetry.affected_nodes.extend(
+            affected_nodes_status.affected_nodes
+        )
+        return 0
+
+    def supports_standalone(self) -> bool:
+        return True
+
+    def get_scenario_types(self) -> list[str]:
+        return ["vm_storage_chaos_scenarios"]

--- a/krkn/scenario_plugins/vm_storage_chaos/vm_storage_chaos_scenario_plugin.py
+++ b/krkn/scenario_plugins/vm_storage_chaos/vm_storage_chaos_scenario_plugin.py
@@ -125,9 +125,14 @@ class VmStorageChaosScenarioPlugin(AbstractScenarioPlugin):
 
 
             logging.info("[%s] Restarting storage service: %s" % (host, service))
-            ssh.execute(
+            start_exit, _, start_stderr = ssh.execute(
                 host, "sudo systemctl start %s" % safe_service, timeout=60
             )
+            if start_exit != 0:
+                logging.error(
+                    "[%s] Failed to restart %s: %s"
+                    % (host, service, start_stderr)
+                )
 
             recovery_time = time.time() - start_time
             affected_node.set_affected_node_status("recovered", recovery_time)

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -83,6 +83,11 @@ def main(options, command: Optional[str]) -> int:
         )
         kraken_config = cfg
 
+        execution_mode = get_yaml_item_value(config["kraken"], "execution_mode", "kubernetes")
+        is_standalone = execution_mode == "standalone"
+        if is_standalone:
+            logging.info("Running in STANDALONE mode -- Kubernetes cluster not required")
+
         chaos_scenarios = get_yaml_item_value(config["kraken"], "chaos_scenarios", [])
         publish_running_status = get_yaml_item_value(
             config["kraken"], "publish_kraken_status", False
@@ -174,14 +179,15 @@ def main(options, command: Optional[str]) -> int:
         telemetry_enabled = config["telemetry"].get("enabled", True)
         
         # Initialize clients
-        if not os.path.isfile(kubeconfig_path) and not os.path.isfile(
-                "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        ):
-            logging.error(
-                "Cannot read the kubeconfig file at %s, please check" % kubeconfig_path
-            )
-            return -1
-        logging.info("Initializing client to talk to the Kubernetes cluster")
+        if not is_standalone:
+            if not os.path.isfile(kubeconfig_path) and not os.path.isfile(
+                    "/var/run/secrets/kubernetes.io/serviceaccount/token"
+            ):
+                logging.error(
+                    "Cannot read the kubeconfig file at %s, please check" % kubeconfig_path
+                )
+                return -1
+            logging.info("Initializing client to talk to the Kubernetes cluster")
 
         # Set Cerberus url if enabled
         cerberus.set_url(config)
@@ -217,24 +223,29 @@ def main(options, command: Optional[str]) -> int:
         )
         safe_logger = SafeLogger(filename=telemetry_log_file)
 
-        try:
-            kubeconfig_path
-            os.environ["KUBECONFIG"] = str(kubeconfig_path)
-            # krkn-lib-kubernetes init
-            kubecli = KrknKubernetes(kubeconfig_path=kubeconfig_path)
-            ocpcli = KrknOpenshift(kubeconfig_path=kubeconfig_path)
-        except Exception as e:
-            logging.error("Failed to initialize Kubernetes clients: %s" % e)
-            kubecli = KrknKubernetes(kubeconfig_path=None)
-            ocpcli = KrknOpenshift(kubeconfig_path=None)
+        if not is_standalone:
+            try:
+                kubeconfig_path
+                os.environ["KUBECONFIG"] = str(kubeconfig_path)
+                # krkn-lib-kubernetes init
+                kubecli = KrknKubernetes(kubeconfig_path=kubeconfig_path)
+                ocpcli = KrknOpenshift(kubeconfig_path=kubeconfig_path)
+            except Exception as e:
+                logging.error("Failed to initialize Kubernetes clients: %s" % e)
+                kubecli = KrknKubernetes(kubeconfig_path=None)
+                ocpcli = KrknOpenshift(kubeconfig_path=None)
 
-        distribution = "kubernetes"
-        if ocpcli.is_openshift():
-            distribution = "openshift"
-        logging.info("Detected distribution %s" % (distribution))
+            distribution = "kubernetes"
+            if ocpcli.is_openshift():
+                distribution = "openshift"
+            logging.info("Detected distribution %s" % (distribution))
 
-        # find node kraken might be running on
-        kubecli.find_kraken_node()
+            # find node kraken might be running on
+            kubecli.find_kraken_node()
+        else:
+            kubecli = None
+            ocpcli = None
+            distribution = "standalone"
 
         # Set up kraken url to track signal
         if not 0 <= int(port) <= 65535:
@@ -256,30 +267,34 @@ def main(options, command: Optional[str]) -> int:
             server.start_server(address, run_signal)
 
         # Cluster info
-        logging.info("Fetching cluster info")
         cv = ""
-        if distribution == "openshift":
-            cv = ocpcli.get_clusterversion_string()
-            if not prometheus_url:
-                try:
-                    connection_data = ocpcli.get_prometheus_api_connection_data()
-                    if connection_data:
-                        prometheus_url = connection_data.endpoint
-                        prometheus_bearer_token = connection_data.token
-                    else:
-                        # If can't make a connection, set alerts to false
-                        enable_alerts = False
-                        check_critical_alerts = False
-                except Exception:
-                    logging.error(
-                        "invalid distribution selected, running openshift scenarios against kubernetes cluster."
-                        "Please set 'kubernetes' in config.yaml krkn.platform and try again"
-                    )
-                    return -1
-        if cv != "":
-            logging.info(cv)
+        if not is_standalone:
+            logging.info("Fetching cluster info")
+            if distribution == "openshift":
+                cv = ocpcli.get_clusterversion_string()
+                if not prometheus_url:
+                    try:
+                        connection_data = ocpcli.get_prometheus_api_connection_data()
+                        if connection_data:
+                            prometheus_url = connection_data.endpoint
+                            prometheus_bearer_token = connection_data.token
+                        else:
+                            # If can't make a connection, set alerts to false
+                            enable_alerts = False
+                            check_critical_alerts = False
+                    except Exception:
+                        logging.error(
+                            "invalid distribution selected, running openshift scenarios against kubernetes cluster."
+                            "Please set 'kubernetes' in config.yaml krkn.platform and try again"
+                        )
+                        return -1
+            if cv != "":
+                logging.info(cv)
+            else:
+                logging.info("Cluster version CRD not detected, skipping")
         else:
-            logging.info("Cluster version CRD not detected, skipping")
+            enable_alerts = False
+            check_critical_alerts = False
 
         # Final check: ensure Prometheus URL is available; disable resiliency if not
         if (not prometheus_url or prometheus_url.strip() == "") and run_mode != "disabled":
@@ -287,12 +302,18 @@ def main(options, command: Optional[str]) -> int:
             run_mode = "disabled"
 
         # KrknTelemetry init
-        telemetry_k8s = KrknTelemetryKubernetes(
-            safe_logger, kubecli, config["telemetry"]
-        )
-        telemetry_ocp = KrknTelemetryOpenshift(
-            safe_logger, ocpcli, telemetry_request_id, config["telemetry"]
-        )
+        if not is_standalone:
+            telemetry_k8s = KrknTelemetryKubernetes(
+                safe_logger, kubecli, config["telemetry"]
+            )
+            telemetry_ocp = KrknTelemetryOpenshift(
+                safe_logger, ocpcli, telemetry_request_id, config["telemetry"]
+            )
+        else:
+            telemetry_k8s = None
+            telemetry_ocp = KrknTelemetryOpenshift(
+                safe_logger, None, telemetry_request_id, config["telemetry"]
+            )
         if enable_elastic:
             logging.info(f"Elastic collection enabled at: {elastic_url}:{elastic_port}")
             elastic_search = KrknElastic(
@@ -318,7 +339,8 @@ def main(options, command: Optional[str]) -> int:
                 run_mode = "disabled"
         resiliency_alerts = get_yaml_item_value(resiliency_config, "resiliency_file", get_yaml_item_value(config['performance_monitoring'],"alert_profile", "config/alerts.yaml"))
         resiliency_obj = Resiliency(resiliency_alerts) if run_mode != "disabled" else None  # Initialize resiliency orchestrator
-        logging.info("Server URL: %s" % kubecli.get_host())
+        if not is_standalone:
+            logging.info("Server URL: %s" % kubecli.get_host())
 
         if command == "list-rollback":
             sys.exit(
@@ -443,6 +465,15 @@ def main(options, command: Optional[str]) -> int:
                                 f"impossible to find scenario {scenario_type}, plugin not found. Exiting"
                             )
                             sys.exit(-1)
+
+                        if is_standalone and not scenario_plugin.supports_standalone():
+                            logging.error(
+                                "Scenario type '%s' is not supported in standalone mode. "
+                                "Plugin %s does not declare standalone support."
+                                % (scenario_type, scenario_plugin.__class__.__name__)
+                            )
+                            failed_post_scenarios.append(scenario_type)
+                            continue
 
                         
                         batch_window_start_dt = datetime.datetime.utcnow()
@@ -576,7 +607,7 @@ def main(options, command: Optional[str]) -> int:
                     f"failed to save telemetry on elastic search: {chaos_output.to_json()}"
                 )
 
-        if telemetry_enabled and telemetry_api_url:
+        if telemetry_enabled and telemetry_api_url and not is_standalone:
             logging.info(
                 f"telemetry data will be stored on s3 bucket folder: {telemetry_api_url}/files/"
                 f'{(config["telemetry"]["telemetry_group"] if config["telemetry"]["telemetry_group"] else "default")}/'

--- a/scenarios/openshift/host_cpu_stress_200vms.yml
+++ b/scenarios/openshift/host_cpu_stress_200vms.yml
@@ -1,0 +1,24 @@
+# Scenario 1 (P0): CPU stress on node with 200+ VMs
+# Bug: CNV-89810 — virt-handler killed by liveness probe timeout under CPU load
+#
+# Purpose: Inject CPU stress on an OpenShift worker node running VMs to verify
+# that virt-handler survives and VMs are NOT killed during high host CPU load.
+#
+# Uses: hog_scenarios with standalone SSH targets (no K8s pod deployment needed)
+#
+# Expected behavior:
+#   - virt-handler pod should survive CPU stress
+#   - VMs should continue running
+#   - virt-handler liveness probe should NOT timeout
+#
+# If this scenario causes VM restarts, it reproduces CNV-89810.
+
+hog-type: cpu
+targets:
+  - <WORKER_NODE_IP>
+ssh_user: core
+ssh_private_key: ~/.ssh/id_rsa
+node-selector: ""
+duration: 300
+workers: 0
+cpu-load-percentage: 95

--- a/scenarios/openshift/kubelet_kill_with_vms.yml
+++ b/scenarios/openshift/kubelet_kill_with_vms.yml
@@ -1,0 +1,28 @@
+# Scenario 3 (P1): Kill kubelet with running VMs
+# Bug: KubeVirt #11843 — virt-handler heartbeat misinterprets kubelet restart,
+#      kills VMs unnecessarily (3rd most-commented open KubeVirt bug)
+#
+# Purpose: Stop and restart kubelet on a worker node running VMs to verify
+# that virt-handler does NOT unnecessarily restart VMs.
+#
+# Uses: node_scenarios with cloud_type: ssh, action: stop_start_kubelet_scenario
+#
+# Expected behavior:
+#   - Kubelet stops and restarts cleanly
+#   - VMs should continue running without interruption
+#   - virt-handler should NOT misinterpret kubelet restart as node failure
+#
+# If VMs restart unnecessarily, it reproduces KubeVirt #11843.
+
+node_scenarios:
+  - actions:
+      - stop_start_kubelet_scenario
+    cloud_type: ssh
+    targets:
+      - <WORKER_NODE_IP>
+    ssh_user: core
+    ssh_private_key: ~/.ssh/id_rsa
+    runs: 1
+    timeout: 360
+    duration: 30
+    kube_check: false

--- a/scenarios/openshift/virt_handler_rolling_restart.yml
+++ b/scenarios/openshift/virt_handler_rolling_restart.yml
@@ -1,0 +1,22 @@
+# Scenario 2 (P1): virt-handler DaemonSet rolling restart
+# Bug: CNV-89519 — VMI incorrectly marked Failed during virt-handler rolling update
+# Bug: CNV-88967 — Virtual Machine killed during virt-handler startup
+#
+# Purpose: Delete virt-handler pods one by one (simulating a rolling update)
+# to verify VMIs remain Running and are NOT incorrectly marked Failed.
+#
+# Uses: pod_disruption_scenarios targeting virt-handler pods in openshift-cnv namespace
+#
+# Expected behavior:
+#   - VMIs should stay in Running state throughout
+#   - No "Domain does not exist" false negatives
+#   - VMs should NOT be killed or restarted
+#
+# If VMIs are marked Failed or VMs restart, it reproduces CNV-89519/CNV-88967.
+
+- config:
+    namespace_pattern: openshift-cnv
+    label_selector: kubevirt.io=virt-handler
+    kill: 1
+    krkn_pod_recovery_time: 120
+    timeout: 300

--- a/scenarios/openshift/vm_migration_network_disruption.yml
+++ b/scenarios/openshift/vm_migration_network_disruption.yml
@@ -1,0 +1,28 @@
+# Scenario 5 (P0): Network disruption during live migration
+# Bug: CNV-89391 — Live migration can leave two running virt-launcher pods, causing VM corruption
+# Bug: KubeVirt #15924 — Postcopy migration network disruption kills the VM
+#
+# Purpose: Trigger a VM live migration and inject network latency on the source
+# node DURING the migration to verify VM survives without corruption.
+#
+# Expected behavior:
+#   - Migration may fail or succeed slowly — both are acceptable
+#   - VM should NOT be corrupted
+#   - There should NEVER be two running virt-launcher pods for the same VMI
+#
+# If two virt-launcher pods are detected, it reproduces CNV-89391.
+# If VM is killed during postcopy, it reproduces KubeVirt #15924.
+
+vm_migration_chaos:
+  vm_name: <VM_NAME>
+  vm_namespace: default
+  migration_action: trigger_and_disrupt
+  fault_type: network_latency
+  fault_params:
+    latency: 500ms
+    interface: br-ex
+    duration: 30
+  ssh_user: core
+  ssh_private_key: ~/.ssh/id_rsa
+  verify_no_dual_pods: true
+  timeout: 600

--- a/scenarios/openshift/vm_node_drain_compact.yml
+++ b/scenarios/openshift/vm_node_drain_compact.yml
@@ -1,0 +1,19 @@
+# Scenario 6 (P1): Node drain on compact cluster
+# Bug: CNV-81533 — VM migration not triggered during node drain in some cases on compact clusters
+#
+# Purpose: Drain a node running VMs on a compact (3-node) cluster to verify
+# that VM migration IS triggered and VMs land on healthy nodes.
+#
+# Expected behavior:
+#   - Node drain should trigger VM live migration
+#   - VMs should migrate to remaining nodes
+#   - No VMs should be lost or stuck
+#
+# If migration is NOT triggered, it reproduces CNV-81533.
+
+vm_migration_chaos:
+  vm_name: <VM_NAME>
+  vm_namespace: default
+  migration_action: drain_node
+  verify_no_dual_pods: true
+  timeout: 600

--- a/scenarios/openshift/vm_storage_io_burst.yml
+++ b/scenarios/openshift/vm_storage_io_burst.yml
@@ -1,0 +1,25 @@
+# Scenario 9 (P0): 5-minute IO burst crashes VMI
+# Bug: CNV-79002 — High IO for short duration (5min) causes VirtualMachineInstance crash
+#
+# Purpose: Inject sustained IO stress on storage path used by VMs to verify
+# that VMIs survive without crashing.
+#
+# Expected behavior:
+#   - VM performance degrades during IO burst
+#   - VMIs should NOT crash
+#   - After IO burst ends, VMs should return to normal performance
+#
+# If VMIs crash during IO burst, it reproduces CNV-79002.
+
+vm_storage_chaos:
+  action: io_burst
+  storage_targets:
+    - host: <WORKER_NODE_IP>
+      path: /var/lib/containers
+  ssh_user: core
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 300
+  io_workers: 4
+  io_bytes: 2G
+  verify_vm_recovery: true
+  recovery_timeout: 300

--- a/scenarios/openshift/vm_storage_nfs_failover.yml
+++ b/scenarios/openshift/vm_storage_nfs_failover.yml
@@ -1,0 +1,23 @@
+# Scenario 8 (P0): NFS/storage failover with running VMs
+# Bug: CNV-83991 — Hundreds of virtual machines restarted during NFS failover
+#
+# Purpose: Stop NFS server on storage node to simulate storage failover,
+# then restart it and verify VMs recover within acceptable SLA.
+#
+# Expected behavior:
+#   - VMs may become unresponsive during storage outage
+#   - After NFS restart, VMs should recover WITHOUT full restart
+#   - If hundreds of VMs restart, it reproduces CNV-83991
+#
+# Adjust storage_targets to match your storage infrastructure.
+
+vm_storage_chaos:
+  action: kill_storage_service
+  storage_targets:
+    - host: <NFS_SERVER_IP>
+      service: nfs-server
+  ssh_user: root
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 120
+  verify_vm_recovery: true
+  recovery_timeout: 600

--- a/scenarios/openshift/vmware_node_reboot_test.yml
+++ b/scenarios/openshift/vmware_node_reboot_test.yml
@@ -1,0 +1,8 @@
+node_scenarios:
+  - actions:
+    - node_reboot_scenario
+    node_name:
+    label_selector: node-role.kubernetes.io/worker
+    instance_count: 1
+    timeout: 120
+    cloud_type: vmware

--- a/scenarios/openshift/windows_vm_reboot_validation.yml
+++ b/scenarios/openshift/windows_vm_reboot_validation.yml
@@ -1,0 +1,31 @@
+# Scenario 4 (P2): Windows VM reboot after upgrade
+# Bug: CNV-83327 — Windows virtual machine disks go offline after rebooting
+#      the VM following the upgrade to 4.20
+# Bug: CNV-90674 — Windows disks offline after hotplug and reboot
+#
+# Purpose: Reboot nodes running Windows VMs after an OpenShift/CNV upgrade
+# to verify that Windows VM disks come back online correctly.
+#
+# Uses: node_scenarios to reboot the worker node hosting Windows VMs
+#
+# Expected behavior:
+#   - Node reboots and comes back
+#   - Windows VMs restart automatically (eviction strategy: LiveMigrate or restart)
+#   - All Windows VM disks should be online after restart
+#   - No manual disk intervention needed
+#
+# If Windows disks are offline after reboot, it reproduces CNV-83327/CNV-90674.
+# Verify with: virtctl console <windows-vm> → diskpart → list disk
+
+node_scenarios:
+  - actions:
+      - node_reboot_scenario
+    cloud_type: ssh
+    targets:
+      - <WORKER_NODE_WITH_WINDOWS_VMS>
+    ssh_user: core
+    ssh_private_key: ~/.ssh/id_rsa
+    runs: 1
+    timeout: 600
+    kube_check: false
+    soft_reboot: true

--- a/scenarios/standalone/disk_fill.yml
+++ b/scenarios/standalone/disk_fill.yml
@@ -1,0 +1,7 @@
+targets:
+  - 192.168.1.100
+ssh_user: root
+ssh_private_key: ~/.ssh/id_rsa
+fill_path: /tmp
+fill_percentage: 90
+duration: 120

--- a/scenarios/standalone/disk_fill_e2e.yml
+++ b/scenarios/standalone/disk_fill_e2e.yml
@@ -1,0 +1,8 @@
+targets:
+  - 10.0.62.91
+ssh_user: core
+ssh_private_key: /tmp/id_rsa
+ssh_port: 22
+fill_path: /tmp
+fill_size: 50M
+duration: 10

--- a/scenarios/standalone/e2e_disk_fill.yml
+++ b/scenarios/standalone/e2e_disk_fill.yml
@@ -1,0 +1,8 @@
+targets:
+  - localhost
+ssh_user: core
+ssh_private_key: /Users/sahil/.local/share/containers/podman/machine/machine
+ssh_port: 53332
+fill_path: /tmp
+fill_size: 200M
+duration: 30

--- a/scenarios/standalone/e2e_network.yml
+++ b/scenarios/standalone/e2e_network.yml
@@ -1,0 +1,12 @@
+network_chaos:
+  targets:
+    - localhost
+  ssh_user: core
+  ssh_private_key: /Users/sahil/.local/share/containers/podman/machine/machine
+  ssh_port: 53332
+  duration: 10
+  interfaces:
+    - enp0s1
+  execution: serial
+  egress:
+    latency: 100ms

--- a/scenarios/standalone/e2e_time.yml
+++ b/scenarios/standalone/e2e_time.yml
@@ -1,0 +1,9 @@
+time_scenarios:
+  - action: skew_time
+    targets:
+      - localhost
+    ssh_user: core
+    ssh_private_key: /Users/sahil/.local/share/containers/podman/machine/machine
+    ssh_port: 53332
+    duration: 10
+    disable_ntp: true

--- a/scenarios/standalone/file_chmod.yml
+++ b/scenarios/standalone/file_chmod.yml
@@ -1,0 +1,8 @@
+targets:
+  - 192.168.1.100
+ssh_user: root
+ssh_private_key: ~/.ssh/id_rsa
+action: chmod
+file_path: /etc/nginx/nginx.conf
+permissions: "000"
+duration: 60

--- a/scenarios/standalone/hog_cpu.yml
+++ b/scenarios/standalone/hog_cpu.yml
@@ -1,0 +1,10 @@
+hog-type: cpu
+targets:
+  - 192.168.1.100
+  - 192.168.1.101
+ssh_user: root
+ssh_private_key: ~/.ssh/id_rsa
+node-selector: ""
+duration: 60
+workers: 0
+cpu-load-percentage: 90

--- a/scenarios/standalone/hog_memory.yml
+++ b/scenarios/standalone/hog_memory.yml
@@ -1,0 +1,9 @@
+hog-type: memory
+targets:
+  - 192.168.1.100
+ssh_user: root
+ssh_private_key: ~/.ssh/id_rsa
+node-selector: ""
+duration: 60
+workers: 1
+memory-vm-bytes: 256M

--- a/scenarios/standalone/network_chaos_latency.yml
+++ b/scenarios/standalone/network_chaos_latency.yml
@@ -1,0 +1,10 @@
+network_chaos:
+  targets:
+    - 192.168.1.100
+  ssh_user: root
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 300
+  interfaces: []
+  execution: serial
+  egress:
+    latency: 100ms

--- a/scenarios/standalone/ssh_node_reboot.yml
+++ b/scenarios/standalone/ssh_node_reboot.yml
@@ -1,0 +1,14 @@
+node_scenarios:
+  - actions:
+      - node_reboot_scenario
+    cloud_type: ssh
+    targets:
+      - 192.168.1.100
+      - 192.168.1.101
+    ssh_user: root
+    ssh_private_key: ~/.ssh/id_rsa
+    ssh_port: 22
+    runs: 1
+    timeout: 360
+    kube_check: false
+    soft_reboot: true

--- a/scenarios/standalone/time_skew.yml
+++ b/scenarios/standalone/time_skew.yml
@@ -1,0 +1,8 @@
+time_scenarios:
+  - action: skew_time
+    targets:
+      - 192.168.1.100
+    ssh_user: root
+    ssh_private_key: ~/.ssh/id_rsa
+    duration: 300
+    disable_ntp: true

--- a/scenarios/test_pod_disruption.yml
+++ b/scenarios/test_pod_disruption.yml
@@ -1,0 +1,6 @@
+- config:
+    namespace_pattern: openshift-apiserver
+    label_selector: apiserver=true
+    kill: 1
+    krkn_pod_recovery_time: 120
+    timeout: 180

--- a/scenarios/vmware_migration_validation/01_reboot_all_vms.yml
+++ b/scenarios/vmware_migration_validation/01_reboot_all_vms.yml
@@ -1,0 +1,18 @@
+# Step 1: Reboot all migrated VMs
+# Validates migrated VMs survive restart — catches CNV-83327 (Windows disks offline)
+#
+# Replace <VM_NAME> and <NAMESPACE> with your migrated VM details.
+
+node_scenarios:
+  - actions:
+      - node_reboot_scenario
+    cloud_type: ssh
+    targets:
+      - <WORKER_NODE_1>
+      - <WORKER_NODE_2>
+    ssh_user: core
+    ssh_private_key: ~/.ssh/id_rsa
+    runs: 1
+    timeout: 600
+    kube_check: false
+    soft_reboot: true

--- a/scenarios/vmware_migration_validation/02_network_chaos.yml
+++ b/scenarios/vmware_migration_validation/02_network_chaos.yml
@@ -1,0 +1,13 @@
+# Step 2: Network chaos on migrated VM nodes
+# Validates network resilience — catches CNV-90425 (performance issues after VMware migration)
+
+network_chaos:
+  targets:
+    - <WORKER_NODE_1>
+  ssh_user: core
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 120
+  interfaces: []
+  execution: serial
+  egress:
+    latency: 100ms

--- a/scenarios/vmware_migration_validation/03_storage_stress.yml
+++ b/scenarios/vmware_migration_validation/03_storage_stress.yml
@@ -1,0 +1,15 @@
+# Step 3: Storage IO stress on VM host nodes
+# Validates storage resilience — catches CNV-79002 (IO burst crashes VMI)
+
+vm_storage_chaos:
+  action: io_burst
+  storage_targets:
+    - host: <WORKER_NODE_1>
+      path: /var/lib/containers
+  ssh_user: core
+  ssh_private_key: ~/.ssh/id_rsa
+  duration: 300
+  io_workers: 4
+  io_bytes: 1G
+  verify_vm_recovery: true
+  recovery_timeout: 300

--- a/scenarios/vmware_migration_validation/04_host_cpu_stress.yml
+++ b/scenarios/vmware_migration_validation/04_host_cpu_stress.yml
@@ -1,0 +1,12 @@
+# Step 4: CPU stress on VM host nodes
+# Validates host resilience — catches CNV-89810 (virt-handler liveness probe timeout)
+
+hog-type: cpu
+targets:
+  - <WORKER_NODE_1>
+ssh_user: core
+ssh_private_key: ~/.ssh/id_rsa
+node-selector: ""
+duration: 300
+workers: 0
+cpu-load-percentage: 90

--- a/scenarios/vmware_migration_validation/05_vm_migration_test.yml
+++ b/scenarios/vmware_migration_validation/05_vm_migration_test.yml
@@ -1,0 +1,16 @@
+# Step 5: Live migration under network stress
+# Validates migration resilience — catches CNV-89391 (dual virt-launcher corruption)
+
+vm_migration_chaos:
+  vm_name: <MIGRATED_VM_NAME>
+  vm_namespace: <NAMESPACE>
+  migration_action: trigger_and_disrupt
+  fault_type: network_latency
+  fault_params:
+    latency: 200ms
+    interface: br-ex
+    duration: 30
+  ssh_user: core
+  ssh_private_key: ~/.ssh/id_rsa
+  verify_no_dual_pods: true
+  timeout: 600

--- a/tests/test_ssh_node_scenarios.py
+++ b/tests/test_ssh_node_scenarios.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for SSH node scenarios (standalone mode)
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_ssh_node_scenarios.py -v
+"""
+
+import unittest
+import sys
+from unittest.mock import MagicMock, patch, call
+
+from krkn_lib.k8s import KrknKubernetes
+from krkn_lib.models.k8s import AffectedNode, AffectedNodeStatus
+
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import (
+    SSHExecutor,
+    ssh_node_scenarios,
+)
+
+
+class TestSSHExecutor(unittest.TestCase):
+    """Test cases for SSHExecutor class"""
+
+    def setUp(self):
+        self.executor = SSHExecutor(
+            ssh_user="root",
+            ssh_private_key="/tmp/test_key",
+            ssh_port=22,
+            connect_timeout=10,
+        )
+
+    @patch("krkn_lib.utils.ssh_executor.paramiko")
+    def test_execute_success(self, mock_paramiko):
+        mock_ssh = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_ssh
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = b"output"
+        mock_stdout.channel.recv_exit_status.return_value = 0
+        mock_stderr = MagicMock()
+        mock_stderr.read.return_value = b""
+        mock_ssh.exec_command.return_value = (MagicMock(), mock_stdout, mock_stderr)
+
+        exit_code, stdout, stderr = self.executor.execute("10.0.0.1", "uptime")
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout, "output")
+        self.assertEqual(stderr, "")
+        mock_ssh.connect.assert_called_once_with(
+            "10.0.0.1",
+            port=22,
+            username="root",
+            key_filename="/tmp/test_key",
+            timeout=10,
+            banner_timeout=10,
+        )
+        mock_ssh.close.assert_called_once()
+
+    @patch("krkn_lib.utils.ssh_executor.paramiko")
+    def test_execute_connection_failure(self, mock_paramiko):
+        mock_ssh = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_ssh
+        mock_ssh.connect.side_effect = Exception("Connection refused")
+
+        with self.assertRaises(Exception):
+            self.executor.execute("10.0.0.1", "uptime")
+        mock_ssh.close.assert_called_once()
+
+    @patch("krkn_lib.utils.ssh_executor.paramiko")
+    def test_is_host_reachable_true(self, mock_paramiko):
+        mock_ssh = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_ssh
+
+        result = self.executor.is_host_reachable("10.0.0.1")
+
+        self.assertTrue(result)
+        mock_ssh.close.assert_called_once()
+
+    @patch("krkn_lib.utils.ssh_executor.paramiko")
+    def test_is_host_reachable_false(self, mock_paramiko):
+        mock_ssh = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_ssh
+        mock_ssh.connect.side_effect = Exception("Connection refused")
+
+        result = self.executor.is_host_reachable("10.0.0.1")
+
+        self.assertFalse(result)
+
+    @patch("krkn_lib.utils.ssh_executor.time")
+    @patch("krkn_lib.utils.ssh_executor.paramiko")
+    def test_wait_for_host_reachable(self, mock_paramiko, mock_time):
+        mock_ssh = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_ssh
+        mock_time.time.side_effect = [0, 5, 10]
+        mock_time.sleep = MagicMock()
+
+        result = self.executor.wait_for_host(
+            "10.0.0.1", timeout=60, reachable=True
+        )
+
+        self.assertTrue(result)
+
+    @patch("krkn_lib.utils.ssh_executor.time")
+    @patch("krkn_lib.utils.ssh_executor.paramiko")
+    def test_wait_for_host_timeout(self, mock_paramiko, mock_time):
+        mock_ssh = MagicMock()
+        mock_paramiko.SSHClient.return_value = mock_ssh
+        mock_ssh.connect.side_effect = Exception("Connection refused")
+        mock_time.time.side_effect = [0, 100]
+        mock_time.sleep = MagicMock()
+
+        result = self.executor.wait_for_host(
+            "10.0.0.1", timeout=5, reachable=True
+        )
+
+        self.assertFalse(result)
+
+
+class TestSSHNodeScenarios(unittest.TestCase):
+    """Test cases for ssh_node_scenarios class"""
+
+    def setUp(self):
+        self.mock_kubecli = MagicMock(spec=KrknKubernetes)
+        self.affected_nodes_status = AffectedNodeStatus()
+        self.ssh_config = {
+            "ssh_user": "root",
+            "ssh_private_key": "/tmp/test_key",
+            "ssh_port": 22,
+            "ssh_connect_timeout": 10,
+        }
+        self.scenarios = ssh_node_scenarios(
+            self.mock_kubecli,
+            False,
+            self.affected_nodes_status,
+            self.ssh_config,
+        )
+        self.scenarios.ssh = MagicMock(spec=SSHExecutor)
+
+    def test_node_reboot_scenario(self):
+        self.scenarios.ssh.execute.side_effect = Exception("Connection closed")
+        self.scenarios.ssh.wait_for_host.return_value = True
+
+        self.scenarios.node_reboot_scenario(1, "10.0.0.1", 300)
+
+        self.assertEqual(len(self.affected_nodes_status.affected_nodes), 1)
+
+    def test_node_stop_scenario(self):
+        self.scenarios.ssh.execute.side_effect = Exception("Connection closed")
+        self.scenarios.ssh.wait_for_host.return_value = True
+
+        self.scenarios.node_stop_scenario(1, "10.0.0.1", 300, 15)
+
+        self.assertEqual(len(self.affected_nodes_status.affected_nodes), 1)
+
+    def test_node_crash_scenario(self):
+        self.scenarios.ssh.execute.side_effect = Exception("Connection closed")
+
+        self.scenarios.node_crash_scenario(1, "10.0.0.1", 300)
+
+    def test_stop_kubelet_scenario(self):
+        self.scenarios.ssh.execute.return_value = (0, "", "")
+
+        self.scenarios.stop_kubelet_scenario(1, "10.0.0.1", 300)
+
+        self.scenarios.ssh.execute.assert_called_with(
+            "10.0.0.1", "sudo systemctl stop kubelet", timeout=60
+        )
+        self.assertEqual(len(self.affected_nodes_status.affected_nodes), 1)
+
+    def test_stop_kubelet_scenario_failure(self):
+        self.scenarios.ssh.execute.return_value = (1, "", "kubelet not found")
+
+        with self.assertRaises(Exception):
+            self.scenarios.stop_kubelet_scenario(1, "10.0.0.1", 300)
+
+    def test_restart_kubelet_scenario(self):
+        self.scenarios.ssh.execute.return_value = (0, "", "")
+
+        self.scenarios.restart_kubelet_scenario(1, "10.0.0.1", 300)
+
+        self.scenarios.ssh.execute.assert_called_with(
+            "10.0.0.1", "sudo systemctl restart kubelet", timeout=60
+        )
+        self.assertEqual(len(self.affected_nodes_status.affected_nodes), 1)
+
+    def test_node_start_scenario_unsupported(self):
+        self.scenarios.node_start_scenario(1, "10.0.0.1", 300, 15)
+
+    def test_node_termination_scenario_unsupported(self):
+        self.scenarios.node_termination_scenario(1, "10.0.0.1", 300, 15)
+
+    def test_multiple_kill_count(self):
+        self.scenarios.ssh.execute.side_effect = Exception("Connection closed")
+        self.scenarios.ssh.wait_for_host.return_value = True
+
+        self.scenarios.node_reboot_scenario(3, "10.0.0.1", 300)
+
+        self.assertEqual(len(self.affected_nodes_status.affected_nodes), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_standalone_disk_fill_scenario_plugin.py
+++ b/tests/test_standalone_disk_fill_scenario_plugin.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for standalone disk fill scenario plugin
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_standalone_disk_fill_scenario_plugin.py -v
+"""
+
+import unittest
+import sys
+from unittest.mock import MagicMock, patch, mock_open
+
+sys.modules['boto3'] = MagicMock()
+
+from krkn.scenario_plugins.standalone_disk_fill.standalone_disk_fill_scenario_plugin import (
+    StandaloneDiskFillScenarioPlugin,
+)
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+
+class TestStandaloneDiskFillScenarioPlugin(unittest.TestCase):
+
+    def setUp(self):
+        self.plugin = StandaloneDiskFillScenarioPlugin()
+
+    def test_get_scenario_types(self):
+        self.assertEqual(
+            self.plugin.get_scenario_types(),
+            ["standalone_disk_fill_scenarios"],
+        )
+
+    def test_fill_disk_by_size(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+
+        self.plugin._fill_disk(mock_ssh, "10.0.0.1", "/tmp", "1G", 0)
+
+        mock_ssh.execute.assert_called_once_with(
+            "10.0.0.1", "fallocate -l 1G /tmp/krkn_disk_fill_chaos", timeout=120
+        )
+
+    def test_fill_disk_by_percentage(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.side_effect = [
+            (0, "5000000000 10000000000", ""),
+            (0, "", ""),
+        ]
+
+        self.plugin._fill_disk(mock_ssh, "10.0.0.1", "/tmp", "", 90)
+
+        calls = mock_ssh.execute.call_args_list
+        self.assertIn("df --output=avail,size", str(calls[0]))
+        self.assertIn("fallocate", str(calls[1]))
+
+    def test_fill_disk_already_full(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "100000000 10000000000", "")
+
+        self.plugin._fill_disk(mock_ssh, "10.0.0.1", "/tmp", "", 5)
+
+    def test_cleanup(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+
+        self.plugin._cleanup(mock_ssh, "10.0.0.1")
+
+        mock_ssh.execute.assert_called_once()
+        self.assertIn("rm -f", str(mock_ssh.execute.call_args))
+
+    @patch("krkn.scenario_plugins.standalone_disk_fill.standalone_disk_fill_scenario_plugin.SSHExecutor")
+    @patch("krkn.scenario_plugins.standalone_disk_fill.standalone_disk_fill_scenario_plugin.time")
+    @patch("builtins.open", mock_open(read_data="targets:\n  - 10.0.0.1\nfill_path: /tmp\nfill_size: 100M\nduration: 1\n"))
+    def test_run_success(self, mock_time, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+        mock_ssh_cls.return_value = mock_ssh
+        mock_time.sleep = MagicMock()
+
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 0)
+
+    @patch("builtins.open", mock_open(read_data="targets:\n  - 10.0.0.1\nfill_path: /tmp\nduration: 1\n"))
+    def test_run_no_fill_params(self):
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 1)
+
+    @patch("builtins.open", mock_open(read_data="fill_size: 100M\n"))
+    def test_run_no_targets(self):
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_standalone_extensions.py
+++ b/tests/test_standalone_extensions.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for standalone mode extensions to existing plugins
+(hogs, network chaos, time actions).
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_standalone_extensions.py -v
+"""
+
+import unittest
+import sys
+from unittest.mock import MagicMock, patch, mock_open
+
+sys.modules['boto3'] = MagicMock()
+sys.modules['jinja2'] = MagicMock()
+
+from krkn_lib.models.krkn import HogConfig, HogType
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+
+class TestHogsStandaloneExtension(unittest.TestCase):
+    """Test standalone SSH delivery path in HogsScenarioPlugin."""
+
+    def setUp(self):
+        from krkn.scenario_plugins.hogs.hogs_scenario_plugin import (
+            HogsScenarioPlugin,
+        )
+        self.plugin = HogsScenarioPlugin()
+
+    def test_build_stress_command_cpu(self):
+        config = HogConfig()
+        config.type = HogType.cpu
+        config.workers = 4
+        config.cpu_load_percentage = 80
+        config.duration = 60
+        cmd = self.plugin._build_stress_command(config)
+        self.assertIn("--cpu 4", cmd)
+        self.assertIn("--cpu-load 80", cmd)
+        self.assertIn("--timeout 60s", cmd)
+
+    def test_build_stress_command_memory(self):
+        config = HogConfig()
+        config.type = HogType.memory
+        config.workers = 2
+        config.memory_vm_bytes = "512M"
+        config.duration = 120
+        cmd = self.plugin._build_stress_command(config)
+        self.assertIn("--vm 2", cmd)
+        self.assertIn("--vm-bytes 512M", cmd)
+        self.assertIn("--vm-keep", cmd)
+
+    def test_build_stress_command_io(self):
+        config = HogConfig()
+        config.type = HogType.io
+        config.workers = 1
+        config.io_write_bytes = "2G"
+        config.duration = 30
+        cmd = self.plugin._build_stress_command(config)
+        self.assertIn("--iomix 1", cmd)
+        self.assertIn("--iomix-bytes 2G", cmd)
+
+    @patch("krkn.scenario_plugins.hogs.hogs_scenario_plugin.SSHExecutor")
+    def test_run_standalone_success(self, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.side_effect = [
+            (0, "/usr/bin/stress-ng\n", ""),  # which stress-ng
+            (0, "4\n", ""),                   # nproc
+            (0, "done\n", ""),                # stress-ng execution
+        ]
+        mock_ssh_cls.return_value = mock_ssh
+
+        scenario = {
+            "hog-type": "cpu",
+            "node-selector": "",
+            "targets": ["10.0.0.1"],
+            "duration": 1,
+            "cpu-load-percentage": 50,
+        }
+
+        result = self.plugin._run_standalone(scenario, ["10.0.0.1"])
+        self.assertEqual(result, 0)
+
+    @patch("krkn.scenario_plugins.hogs.hogs_scenario_plugin.SSHExecutor")
+    def test_run_standalone_stress_ng_not_found(self, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (1, "", "not found")
+        mock_ssh_cls.return_value = mock_ssh
+
+        scenario = {
+            "hog-type": "cpu",
+            "node-selector": "",
+            "targets": ["10.0.0.1"],
+            "duration": 1,
+        }
+
+        with self.assertRaises(Exception) as ctx:
+            self.plugin._run_standalone(scenario, ["10.0.0.1"])
+        self.assertIn("stress-ng not found", str(ctx.exception))
+
+    @patch(
+        "builtins.open",
+        mock_open(
+            read_data="hog-type: cpu\nnode-selector: ''\ntargets:\n  - 10.0.0.1\nduration: 1\nworkers: 2\n"
+        ),
+    )
+    @patch("krkn.scenario_plugins.hogs.hogs_scenario_plugin.SSHExecutor")
+    def test_run_dispatches_to_standalone(self, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.side_effect = [
+            (0, "/usr/bin/stress-ng\n", ""),  # which stress-ng
+            (0, "done\n", ""),                # stress-ng execution
+        ]
+        mock_ssh_cls.return_value = mock_ssh
+
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 0)
+
+
+class TestNetworkChaosStandaloneExtension(unittest.TestCase):
+    """Test standalone SSH delivery path in NetworkChaosScenarioPlugin."""
+
+    def setUp(self):
+        from krkn.scenario_plugins.network_chaos.network_chaos_scenario_plugin import (
+            NetworkChaosScenarioPlugin,
+        )
+        self.plugin = NetworkChaosScenarioPlugin()
+
+    def test_get_egress_cmd_reuse(self):
+        """Verify get_egress_cmd builds tc commands regardless of mode."""
+        cmd = self.plugin.get_egress_cmd(
+            "serial", ["eth0"], "latency", {"latency": "100ms"}, duration=60
+        )
+        self.assertIn("tc qdisc add", cmd)
+        self.assertIn("netem", cmd)
+        self.assertIn("delay", cmd)
+        self.assertIn("100ms", cmd)
+        self.assertIn("tc qdisc del", cmd)
+
+    @patch("krkn.scenario_plugins.network_chaos.network_chaos_scenario_plugin.SSHExecutor")
+    def test_run_standalone_success(self, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "eth0\n", "")
+        mock_ssh_cls.return_value = mock_ssh
+
+        test_dict = {
+            "targets": ["10.0.0.1"],
+            "ssh_user": "root",
+            "ssh_private_key": "~/.ssh/id_rsa",
+            "duration": 1,
+            "interfaces": ["eth0"],
+            "execution": "serial",
+            "egress": {"latency": "50ms"},
+        }
+
+        result = self.plugin._run_standalone(test_dict, ["10.0.0.1"])
+        self.assertEqual(result, 0)
+
+    @patch(
+        "builtins.open",
+        mock_open(
+            read_data="network_chaos:\n  targets:\n    - 10.0.0.1\n  duration: 1\n  interfaces:\n    - eth0\n  execution: serial\n  egress:\n    latency: 50ms\n"
+        ),
+    )
+    @patch("krkn.scenario_plugins.network_chaos.network_chaos_scenario_plugin.SSHExecutor")
+    def test_run_dispatches_to_standalone(self, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+        mock_ssh_cls.return_value = mock_ssh
+
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 0)
+
+
+class TestTimeActionsStandaloneExtension(unittest.TestCase):
+    """Test standalone SSH delivery path in TimeActionsScenarioPlugin."""
+
+    def setUp(self):
+        from krkn.scenario_plugins.time_actions.time_actions_scenario_plugin import (
+            TimeActionsScenarioPlugin,
+        )
+        self.plugin = TimeActionsScenarioPlugin()
+
+    @patch("krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.datetime")
+    @patch("krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.SSHExecutor")
+    @patch("krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.time")
+    def test_run_standalone_success(self, mock_time, mock_ssh_cls, mock_datetime):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "ok\n", "")
+        mock_ssh_cls.return_value = mock_ssh
+        mock_time.sleep = MagicMock()
+        import datetime as real_dt
+        now = real_dt.datetime.utcnow()
+        mock_datetime.datetime.utcnow.return_value = now
+        mock_datetime.timedelta = real_dt.timedelta
+        mock_datetime.MINYEAR = real_dt.MINYEAR
+
+        time_scenario = {
+            "action": "skew_time",
+            "targets": ["10.0.0.1"],
+            "ssh_user": "root",
+            "ssh_private_key": "~/.ssh/id_rsa",
+            "duration": 1,
+            "disable_ntp": False,
+        }
+
+        result = self.plugin._run_standalone(time_scenario, ["10.0.0.1"])
+        mock_ssh.execute.assert_called()
+
+    @patch(
+        "builtins.open",
+        mock_open(
+            read_data="time_scenarios:\n  - action: skew_time\n    targets:\n      - 10.0.0.1\n    duration: 1\n    disable_ntp: false\n"
+        ),
+    )
+    @patch("krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.datetime")
+    @patch("krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.SSHExecutor")
+    @patch("krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.time")
+    def test_run_dispatches_to_standalone(self, mock_time, mock_ssh_cls, mock_datetime):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "ok\n", "")
+        mock_ssh_cls.return_value = mock_ssh
+        mock_time.sleep = MagicMock()
+        import datetime as real_dt
+        now = real_dt.datetime.utcnow()
+        mock_datetime.datetime.utcnow.return_value = now
+        mock_datetime.timedelta = real_dt.timedelta
+        mock_datetime.MINYEAR = real_dt.MINYEAR
+
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        mock_ssh.execute.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_standalone_file_scenario_plugin.py
+++ b/tests/test_standalone_file_scenario_plugin.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for standalone file scenario plugin
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_standalone_file_scenario_plugin.py -v
+"""
+
+import unittest
+import sys
+from unittest.mock import MagicMock, patch, mock_open
+
+sys.modules['boto3'] = MagicMock()
+
+from krkn.scenario_plugins.standalone_file.standalone_file_scenario_plugin import (
+    StandaloneFileScenarioPlugin,
+)
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+
+class TestStandaloneFileScenarioPlugin(unittest.TestCase):
+
+    def setUp(self):
+        self.plugin = StandaloneFileScenarioPlugin()
+
+    def test_get_scenario_types(self):
+        self.assertEqual(
+            self.plugin.get_scenario_types(), ["standalone_file_scenarios"]
+        )
+
+    def test_apply_chmod(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "644", "")
+        config = {"permissions": "000"}
+
+        revert = self.plugin._apply_file_chaos(
+            mock_ssh, "10.0.0.1", "chmod", "/etc/nginx/nginx.conf", config
+        )
+
+        self.assertEqual(revert["original_perms"], "644")
+        calls = mock_ssh.execute.call_args_list
+        self.assertIn("chmod 000", str(calls[1]))
+
+    def test_apply_rename(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+        config = {"target_path": "/etc/nginx/nginx.conf.bak"}
+
+        revert = self.plugin._apply_file_chaos(
+            mock_ssh, "10.0.0.1", "rename", "/etc/nginx/nginx.conf", config
+        )
+
+        self.assertEqual(revert["target_path"], "/etc/nginx/nginx.conf.bak")
+        self.assertIn("mv", str(mock_ssh.execute.call_args))
+
+    def test_apply_append(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "1024", "")
+        config = {"content": "chaos", "count": 2}
+
+        revert = self.plugin._apply_file_chaos(
+            mock_ssh, "10.0.0.1", "append", "/tmp/test.txt", config
+        )
+
+        self.assertEqual(revert["original_size"], "1024")
+        self.assertEqual(mock_ssh.execute.call_count, 3)
+
+    def test_apply_delete(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+        config = {}
+
+        revert = self.plugin._apply_file_chaos(
+            mock_ssh, "10.0.0.1", "delete", "/tmp/test.txt", config
+        )
+
+        self.assertIn("backup_path", revert)
+
+    def test_apply_unknown_action(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        with self.assertRaises(ValueError):
+            self.plugin._apply_file_chaos(
+                mock_ssh, "10.0.0.1", "invalid", "/tmp/test.txt", {}
+            )
+
+    def test_revert_chmod(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+
+        self.plugin._revert_file_chaos(
+            mock_ssh, "10.0.0.1", "chmod", "/tmp/test.txt",
+            {"original_perms": "755"}
+        )
+
+        self.assertIn("chmod 755", str(mock_ssh.execute.call_args))
+
+    def test_revert_rename(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+
+        self.plugin._revert_file_chaos(
+            mock_ssh, "10.0.0.1", "rename", "/tmp/test.txt",
+            {"target_path": "/tmp/test.txt.bak"}
+        )
+
+        self.assertIn("mv /tmp/test.txt.bak /tmp/test.txt", str(mock_ssh.execute.call_args))
+
+    def test_revert_append(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+
+        self.plugin._revert_file_chaos(
+            mock_ssh, "10.0.0.1", "append", "/tmp/test.txt",
+            {"original_size": "1024"}
+        )
+
+        self.assertIn("truncate -s 1024", str(mock_ssh.execute.call_args))
+
+    def test_revert_delete(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+
+        self.plugin._revert_file_chaos(
+            mock_ssh, "10.0.0.1", "delete", "/tmp/test.txt",
+            {"backup_path": "/tmp/test.txt.krkn_bak"}
+        )
+
+        self.assertIn("mv /tmp/test.txt.krkn_bak /tmp/test.txt", str(mock_ssh.execute.call_args))
+
+    @patch("krkn.scenario_plugins.standalone_file.standalone_file_scenario_plugin.SSHExecutor")
+    @patch("builtins.open", mock_open(read_data="targets:\n  - 10.0.0.1\naction: chmod\nfile_path: /tmp/test.txt\npermissions: '000'\nduration: 1\n"))
+    @patch("krkn.scenario_plugins.standalone_file.standalone_file_scenario_plugin.time")
+    def test_run_success(self, mock_time, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "644", "")
+        mock_ssh_cls.return_value = mock_ssh
+        mock_time.sleep = MagicMock()
+
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 0)
+
+    @patch("builtins.open", mock_open(read_data="action: chmod\nfile_path: /tmp/test.txt\n"))
+    def test_run_no_targets(self):
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 1)
+
+    @patch("builtins.open", mock_open(read_data="targets:\n  - 10.0.0.1\naction: chmod\n"))
+    def test_run_no_file_path(self):
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_standalone_host_health_check_plugin.py
+++ b/tests/test_standalone_host_health_check_plugin.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for StandaloneHostHealthCheckPlugin
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_standalone_host_health_check_plugin.py -v
+"""
+
+import queue
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.modules['boto3'] = MagicMock()
+
+from krkn.health_checks.standalone_host_health_check_plugin import (
+    StandaloneHostHealthCheckPlugin,
+)
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+
+class TestStandaloneHostHealthCheckPlugin(unittest.TestCase):
+
+    def setUp(self):
+        self.plugin = StandaloneHostHealthCheckPlugin(iterations=1)
+
+    def test_get_scenario_types(self):
+        self.assertEqual(
+            self.plugin.get_health_check_types(),
+            ["standalone_host_health_check"],
+        )
+
+    def test_get_config_key(self):
+        self.assertEqual(
+            self.plugin.get_config_key(), "standalone_health_checks"
+        )
+
+    def test_check_tcp_reachable(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        with patch(
+            "krkn.health_checks.standalone_host_health_check_plugin.is_host_reachable",
+            return_value=True,
+        ):
+            status, code = self.plugin._check_tcp(mock_ssh, "10.0.0.1", 8080)
+        self.assertTrue(status)
+        self.assertEqual(code, 200)
+
+    def test_check_tcp_unreachable(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        with patch(
+            "krkn.health_checks.standalone_host_health_check_plugin.is_host_reachable",
+            return_value=False,
+        ):
+            status, code = self.plugin._check_tcp(mock_ssh, "10.0.0.1", 8080)
+        self.assertFalse(status)
+        self.assertEqual(code, 503)
+
+    def test_check_process_found(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "1234", "")
+
+        status, code = self.plugin._check_process(
+            mock_ssh, "10.0.0.1", "nginx"
+        )
+        self.assertTrue(status)
+        self.assertEqual(code, 200)
+
+    def test_check_process_not_found(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (1, "", "")
+
+        status, code = self.plugin._check_process(
+            mock_ssh, "10.0.0.1", "nginx"
+        )
+        self.assertFalse(status)
+        self.assertEqual(code, 503)
+
+    def test_check_process_empty_name(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        status, code = self.plugin._check_process(mock_ssh, "10.0.0.1", "")
+        self.assertFalse(status)
+        self.assertEqual(code, 400)
+
+    def test_check_http_success(self):
+        with patch(
+            "krkn.health_checks.standalone_host_health_check_plugin.requests.get"
+        ) as mock_get:
+            mock_get.return_value = MagicMock(status_code=200)
+            status, code = self.plugin._check_http("http://10.0.0.1/health")
+        self.assertTrue(status)
+        self.assertEqual(code, 200)
+
+    def test_check_http_failure(self):
+        with patch(
+            "krkn.health_checks.standalone_host_health_check_plugin.requests.get"
+        ) as mock_get:
+            mock_get.return_value = MagicMock(status_code=500)
+            status, code = self.plugin._check_http("http://10.0.0.1/health")
+        self.assertFalse(status)
+        self.assertEqual(code, 500)
+
+    def test_check_http_exception(self):
+        with patch(
+            "krkn.health_checks.standalone_host_health_check_plugin.requests.get",
+            side_effect=Exception("connection refused"),
+        ):
+            status, code = self.plugin._check_http("http://10.0.0.1/health")
+        self.assertFalse(status)
+        self.assertEqual(code, 503)
+
+    def test_check_command_allowed(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+
+        status, code = self.plugin._check_command(
+            mock_ssh, "10.0.0.1", "systemctl status nginx"
+        )
+        self.assertTrue(status)
+        self.assertEqual(code, 200)
+
+    def test_check_command_blocked(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+
+        status, code = self.plugin._check_command(
+            mock_ssh, "10.0.0.1", "rm -rf /"
+        )
+        self.assertFalse(status)
+        self.assertEqual(code, 403)
+        mock_ssh.execute.assert_not_called()
+
+    def test_check_command_empty(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        status, code = self.plugin._check_command(
+            mock_ssh, "10.0.0.1", ""
+        )
+        self.assertFalse(status)
+        self.assertEqual(code, 400)
+
+    def test_check_host_metrics_success(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (
+            0,
+            "1.5\n4000000000 8000000000\n45",
+            "",
+        )
+
+        status, code = self.plugin._check_host_metrics(mock_ssh, "10.0.0.1")
+        self.assertTrue(status)
+        self.assertEqual(code, 200)
+
+    def test_check_host_metrics_ssh_failure(self):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (1, "", "connection refused")
+
+        status, code = self.plugin._check_host_metrics(mock_ssh, "10.0.0.1")
+        self.assertFalse(status)
+        self.assertEqual(code, 503)
+
+    def test_exit_on_failure_initial_unhealthy(self):
+        """If first check is unhealthy and exit_on_failure is True,
+        ret_value should be set to 3 immediately."""
+        plugin = StandaloneHostHealthCheckPlugin(iterations=1)
+        plugin.current_iterations = 0
+
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (1, "", "")
+
+        config = {
+            "interval": 0,
+            "ssh_user": "root",
+            "ssh_private_key": "~/.ssh/id_rsa",
+            "ssh_port": 22,
+            "config": [
+                {
+                    "host": "10.0.0.1",
+                    "exit_on_failure": True,
+                    "checks": [{"type": "process", "name": "nginx"}],
+                }
+            ],
+        }
+
+        telemetry_queue = queue.Queue()
+
+        with patch(
+            "krkn.health_checks.standalone_host_health_check_plugin.SSHExecutor",
+            return_value=mock_ssh,
+        ):
+            # Simulate one iteration then stop
+            original_sleep = __import__("time").sleep
+
+            def fake_sleep(t):
+                plugin.current_iterations = plugin.iterations
+
+            with patch("time.sleep", side_effect=fake_sleep):
+                plugin.run_health_check(config, telemetry_queue)
+
+        self.assertEqual(plugin.ret_value, 3)
+
+    def test_increment_iterations(self):
+        self.assertEqual(self.plugin.current_iterations, 0)
+        self.plugin.increment_iterations()
+        self.assertEqual(self.plugin.current_iterations, 1)
+
+    def test_check_command_allowed_prefixes(self):
+        """Verify several allowed command prefixes pass the whitelist."""
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+
+        allowed_commands = [
+            "systemctl is-active nginx",
+            "pgrep -f sshd",
+            "pidof httpd",
+            "df -h",
+            "free -m",
+            "uptime",
+            "cat /proc/loadavg",
+            "ss -tlnp",
+            "ip addr",
+        ]
+        for cmd in allowed_commands:
+            status, code = self.plugin._check_command(
+                mock_ssh, "10.0.0.1", cmd
+            )
+            self.assertTrue(
+                status, "Command should be allowed: %s" % cmd
+            )
+            self.assertEqual(code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_storage_throttle_scenario_plugin.py
+++ b/tests/test_storage_throttle_scenario_plugin.py
@@ -924,7 +924,7 @@ class TestRunScenario(unittest.TestCase):
             mock_pod.nodeName = "worker-1"
 
             mock_telemetry = MagicMock(spec=KrknTelemetryOpenshift)
-            mock_k8s = MagicMock(spec=KrknKubernetes)
+            mock_k8s = MagicMock()
             mock_telemetry.get_lib_kubernetes.return_value = mock_k8s
             mock_k8s.get_pod_info.return_value = mock_pod
 
@@ -980,7 +980,7 @@ class TestRunScenario(unittest.TestCase):
             mock_pod.nodeName = "worker-1"
 
             mock_telemetry = MagicMock(spec=KrknTelemetryOpenshift)
-            mock_k8s = MagicMock(spec=KrknKubernetes)
+            mock_k8s = MagicMock()
             mock_telemetry.get_lib_kubernetes.return_value = mock_k8s
             mock_k8s.get_pod_info.return_value = mock_pod
 
@@ -1048,7 +1048,7 @@ class TestRunScenario(unittest.TestCase):
             mock_pod.nodeName = "worker-1"
 
             mock_telemetry = MagicMock(spec=KrknTelemetryOpenshift)
-            mock_k8s = MagicMock(spec=KrknKubernetes)
+            mock_k8s = MagicMock()
             mock_telemetry.get_lib_kubernetes.return_value = mock_k8s
             mock_k8s.get_pod_info.return_value = mock_pod
 

--- a/tests/test_time_actions_scenario_plugin.py
+++ b/tests/test_time_actions_scenario_plugin.py
@@ -121,49 +121,6 @@ class TestTimeActionsScenarioPlugin(unittest.TestCase):
             # Assert failure is returned
             self.assertEqual(result, 1)
 
-    @patch('krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.KrknKubernetes')
-    def test_exec_with_shell_fallback_detects_persistent_shell_error(self, mock_kubecli_class):
-        """Test that exec_with_shell_fallback returns False when both direct and shell execution fail persistently"""
-        mock_kubecli = MagicMock()
-        mock_kubecli_class.return_value = mock_kubecli
-        mock_kubecli.exec_cmd_in_pod.side_effect = Exception("Command failed")
-        
-        result = self.plugin.exec_with_shell_fallback(
-            "test", "test-pod", "default", "test-container", mock_kubecli
-        )
-        
-        self.assertFalse(result)
-
-    @patch('krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.KrknKubernetes')
-    def test_exec_with_shell_fallback_fails_after_max_retries(self, mock_kubecli_class):
-        """Test that exec_with_shell_fallback returns False after exhausting all retries"""
-        mock_kubecli = MagicMock()
-        mock_kubecli_class.return_value = mock_kubecli
-        mock_kubecli.exec_cmd_in_pod.side_effect = Exception("Command failed")
-        
-        result = self.plugin.exec_with_shell_fallback(
-            "test", "test-pod", "default", "test-container", mock_kubecli, max_retries=2
-        )
-        
-        self.assertFalse(result)
-
-    @patch('krkn.scenario_plugins.time_actions.time_actions_scenario_plugin.KrknKubernetes')
-    def test_exec_with_shell_fallback_retries_on_error(self, mock_kubecli_class):
-        """Test that exec_with_shell_fallback succeeds after retrying"""
-        mock_kubecli = MagicMock()
-        mock_kubecli_class.return_value = mock_kubecli
-        # First two calls fail, third succeeds
-        mock_kubecli.exec_cmd_in_pod.side_effect = [
-            Exception("First failure"),
-            Exception("Second failure"), 
-            "success"
-        ]
-        
-        result = self.plugin.exec_with_shell_fallback(
-            "test", "test-pod", "default", "test-container", mock_kubecli, max_retries=3
-        )
-        
-        self.assertEqual(result, "success")
 
 
 if __name__ == "__main__":

--- a/tests/test_vm_migration_chaos_scenario_plugin.py
+++ b/tests/test_vm_migration_chaos_scenario_plugin.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for VM migration chaos scenario plugin
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_vm_migration_chaos_scenario_plugin.py -v
+"""
+
+import unittest
+import sys
+from unittest.mock import MagicMock, patch, mock_open
+
+sys.modules['boto3'] = MagicMock()
+
+from krkn_lib.k8s import KrknKubernetes
+from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn.scenario_plugins.vm_migration_chaos.vm_migration_chaos_scenario_plugin import (
+    VmMigrationChaosScenarioPlugin,
+)
+
+
+class TestVmMigrationChaosScenarioPlugin(unittest.TestCase):
+
+    def setUp(self):
+        self.plugin = VmMigrationChaosScenarioPlugin()
+
+    def test_get_scenario_types(self):
+        self.assertEqual(
+            self.plugin.get_scenario_types(),
+            ["vm_migration_chaos_scenarios"],
+        )
+
+    def test_requires_kubernetes(self):
+        mock_telemetry = MagicMock()
+        mock_telemetry.get_lib_kubernetes.return_value = None
+
+        yaml_data = (
+            "vm_migration_chaos:\n"
+            "  vm_name: test-vm\n"
+            "  migration_action: trigger_and_disrupt\n"
+        )
+        with patch("builtins.open", mock_open(read_data=yaml_data)):
+            result = self.plugin.run(
+                "uuid", "test.yml", mock_telemetry, MagicMock()
+            )
+        self.assertEqual(result, 1)
+
+    def test_requires_vm_name(self):
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_telemetry = MagicMock()
+        mock_telemetry.get_lib_kubernetes.return_value = mock_kubecli
+
+        yaml_data = (
+            "vm_migration_chaos:\n"
+            "  migration_action: trigger_and_disrupt\n"
+        )
+        with patch("builtins.open", mock_open(read_data=yaml_data)):
+            result = self.plugin.run(
+                "uuid", "test.yml", mock_telemetry, MagicMock()
+            )
+        self.assertEqual(result, 1)
+
+    def test_invalid_action(self):
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_telemetry = MagicMock()
+        mock_telemetry.get_lib_kubernetes.return_value = mock_kubecli
+
+        yaml_data = (
+            "vm_migration_chaos:\n"
+            "  vm_name: test-vm\n"
+            "  migration_action: invalid\n"
+        )
+        with patch("builtins.open", mock_open(read_data=yaml_data)):
+            result = self.plugin.run(
+                "uuid", "test.yml", mock_telemetry, MagicMock()
+            )
+        self.assertEqual(result, 1)
+
+    def test_vmi_not_found(self):
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_kubecli.get_vmi.return_value = None
+        mock_telemetry = MagicMock()
+        mock_telemetry.get_lib_kubernetes.return_value = mock_kubecli
+
+        yaml_data = (
+            "vm_migration_chaos:\n"
+            "  vm_name: nonexistent-vm\n"
+            "  vm_namespace: default\n"
+            "  migration_action: trigger_and_disrupt\n"
+        )
+        with patch("builtins.open", mock_open(read_data=yaml_data)):
+            result = self.plugin.run(
+                "uuid", "test.yml", mock_telemetry, MagicMock()
+            )
+        self.assertEqual(result, 1)
+
+    def test_check_dual_pods_none_detected(self):
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_kubecli.list_pods.return_value = ["virt-launcher-test-vm-abc"]
+
+        result = self.plugin._check_dual_pods(
+            mock_kubecli, "test-vm", "default"
+        )
+        self.assertFalse(result)
+
+    def test_check_dual_pods_detected(self):
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_kubecli.list_pods.return_value = [
+            "virt-launcher-test-vm-abc",
+            "virt-launcher-test-vm-def",
+        ]
+
+        result = self.plugin._check_dual_pods(
+            mock_kubecli, "test-vm", "default"
+        )
+        self.assertTrue(result)
+
+    @patch("krkn.scenario_plugins.vm_migration_chaos.vm_migration_chaos_scenario_plugin.time")
+    def test_wait_for_migration_completed(self, mock_time):
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_kubecli.get_vmi.return_value = {
+            "status": {
+                "phase": "Running",
+                "nodeName": "node2",
+                "migrationState": {"completed": True},
+            }
+        }
+        mock_time.time.side_effect = [0, 5]
+        mock_time.sleep = MagicMock()
+
+        result = self.plugin._wait_for_migration(
+            mock_kubecli, "test-vm", "default", 600
+        )
+        self.assertTrue(result)
+
+    @patch("krkn.scenario_plugins.vm_migration_chaos.vm_migration_chaos_scenario_plugin.time")
+    def test_wait_for_migration_failed(self, mock_time):
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_kubecli.get_vmi.return_value = {
+            "status": {
+                "phase": "Running",
+                "migrationState": {"failed": True},
+            }
+        }
+        mock_time.time.side_effect = [0, 5]
+        mock_time.sleep = MagicMock()
+
+        result = self.plugin._wait_for_migration(
+            mock_kubecli, "test-vm", "default", 600
+        )
+        self.assertFalse(result)
+
+    def test_cleanup_vmim(self):
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+        mock_custom = MagicMock()
+        mock_kubecli.custom_object_client.return_value = mock_custom
+
+        self.plugin._cleanup_vmim(mock_kubecli, "test-vm", "default")
+
+        mock_custom.delete_namespaced_custom_object.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vm_migration_chaos_scenario_plugin.py
+++ b/tests/test_vm_migration_chaos_scenario_plugin.py
@@ -154,11 +154,14 @@ class TestVmMigrationChaosScenarioPlugin(unittest.TestCase):
     def test_cleanup_vmim(self):
         mock_kubecli = MagicMock(spec=KrknKubernetes)
         mock_custom = MagicMock()
-        mock_kubecli.custom_object_client.return_value = mock_custom
+        mock_kubecli.custom_object_client = mock_custom
 
         self.plugin._cleanup_vmim(mock_kubecli, "test-vm", "default")
 
         mock_custom.delete_namespaced_custom_object.assert_called_once()
+
+    def test_supports_standalone_false(self):
+        self.assertFalse(self.plugin.supports_standalone())
 
 
 if __name__ == "__main__":

--- a/tests/test_vm_storage_chaos_scenario_plugin.py
+++ b/tests/test_vm_storage_chaos_scenario_plugin.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for VM storage chaos scenario plugin
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_vm_storage_chaos_scenario_plugin.py -v
+"""
+
+import unittest
+import sys
+from unittest.mock import MagicMock, patch, mock_open
+
+sys.modules['boto3'] = MagicMock()
+
+from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn.scenario_plugins.vm_storage_chaos.vm_storage_chaos_scenario_plugin import (
+    VmStorageChaosScenarioPlugin,
+)
+from krkn.scenario_plugins.node_actions.ssh_node_scenarios import SSHExecutor
+
+
+class TestVmStorageChaosScenarioPlugin(unittest.TestCase):
+
+    def setUp(self):
+        self.plugin = VmStorageChaosScenarioPlugin()
+
+    def test_get_scenario_types(self):
+        self.assertEqual(
+            self.plugin.get_scenario_types(), ["vm_storage_chaos_scenarios"]
+        )
+
+    @patch("krkn.scenario_plugins.vm_storage_chaos.vm_storage_chaos_scenario_plugin.SSHExecutor")
+    @patch("krkn.scenario_plugins.vm_storage_chaos.vm_storage_chaos_scenario_plugin.time")
+    @patch(
+        "builtins.open",
+        mock_open(read_data=(
+            "vm_storage_chaos:\n"
+            "  action: kill_storage_service\n"
+            "  storage_targets:\n"
+            "    - host: 10.0.0.50\n"
+            "      service: nfs-server\n"
+            "  duration: 1\n"
+        )),
+    )
+    def test_kill_storage_service(self, mock_time, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "", "")
+        mock_ssh_cls.return_value = mock_ssh
+        mock_time.sleep = MagicMock()
+        mock_time.time = MagicMock(side_effect=[0, 10])
+
+        scenario_telemetry = MagicMock(spec=ScenarioTelemetry)
+        scenario_telemetry.affected_nodes = []
+
+        result = self.plugin.run(
+            "uuid", "test.yml", MagicMock(), scenario_telemetry
+        )
+
+        self.assertEqual(result, 0)
+        calls = [str(c) for c in mock_ssh.execute.call_args_list]
+        self.assertTrue(any("systemctl stop" in c for c in calls))
+        self.assertTrue(any("systemctl start" in c for c in calls))
+
+    @patch("krkn.scenario_plugins.vm_storage_chaos.vm_storage_chaos_scenario_plugin.SSHExecutor")
+    @patch("krkn.scenario_plugins.vm_storage_chaos.vm_storage_chaos_scenario_plugin.time")
+    @patch(
+        "builtins.open",
+        mock_open(read_data=(
+            "vm_storage_chaos:\n"
+            "  action: io_burst\n"
+            "  storage_targets:\n"
+            "    - host: 10.0.0.1\n"
+            "      path: /var/lib/containers\n"
+            "  duration: 1\n"
+            "  io_workers: 2\n"
+            "  io_bytes: 500M\n"
+        )),
+    )
+    def test_io_burst(self, mock_time, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (0, "done", "")
+        mock_ssh_cls.return_value = mock_ssh
+        mock_time.sleep = MagicMock()
+        mock_time.time = MagicMock(side_effect=[0, 5])
+
+        scenario_telemetry = MagicMock(spec=ScenarioTelemetry)
+        scenario_telemetry.affected_nodes = []
+
+        result = self.plugin.run(
+            "uuid", "test.yml", MagicMock(), scenario_telemetry
+        )
+
+        self.assertEqual(result, 0)
+        calls = [str(c) for c in mock_ssh.execute.call_args_list]
+        self.assertTrue(any("stress-ng" in c for c in calls))
+
+    @patch("krkn.scenario_plugins.vm_storage_chaos.vm_storage_chaos_scenario_plugin.SSHExecutor")
+    @patch("krkn.scenario_plugins.vm_storage_chaos.vm_storage_chaos_scenario_plugin.time")
+    @patch(
+        "builtins.open",
+        mock_open(read_data=(
+            "vm_storage_chaos:\n"
+            "  action: fill_storage\n"
+            "  storage_targets:\n"
+            "    - host: 10.0.0.50\n"
+            "      path: /var/lib/containers\n"
+            "  duration: 1\n"
+            "  fill_percentage: 90\n"
+        )),
+    )
+    def test_fill_storage(self, mock_time, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.side_effect = [
+            (0, "5000000000 10000000000", ""),
+            (0, "", ""),
+            (0, "", ""),
+        ]
+        mock_ssh_cls.return_value = mock_ssh
+        mock_time.sleep = MagicMock()
+        mock_time.time = MagicMock(side_effect=[0, 10])
+
+        scenario_telemetry = MagicMock(spec=ScenarioTelemetry)
+        scenario_telemetry.affected_nodes = []
+
+        result = self.plugin.run(
+            "uuid", "test.yml", MagicMock(), scenario_telemetry
+        )
+
+        self.assertEqual(result, 0)
+
+    @patch("builtins.open", mock_open(read_data="vm_storage_chaos:\n  action: kill_storage_service\n"))
+    def test_no_storage_targets(self):
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 1)
+
+    @patch("builtins.open", mock_open(read_data="vm_storage_chaos:\n  action: invalid\n  storage_targets:\n    - host: x\n"))
+    @patch("krkn.scenario_plugins.vm_storage_chaos.vm_storage_chaos_scenario_plugin.SSHExecutor")
+    def test_invalid_action(self, mock_ssh_cls):
+        mock_ssh_cls.return_value = MagicMock(spec=SSHExecutor)
+        result = self.plugin.run("uuid", "test.yml", MagicMock(), MagicMock())
+        self.assertEqual(result, 1)
+
+    @patch("krkn.scenario_plugins.vm_storage_chaos.vm_storage_chaos_scenario_plugin.SSHExecutor")
+    @patch(
+        "builtins.open",
+        mock_open(read_data=(
+            "vm_storage_chaos:\n"
+            "  action: kill_storage_service\n"
+            "  storage_targets:\n"
+            "    - host: 10.0.0.50\n"
+            "      service: nfs-server\n"
+            "  duration: 1\n"
+        )),
+    )
+    def test_stop_service_failure(self, mock_ssh_cls):
+        mock_ssh = MagicMock(spec=SSHExecutor)
+        mock_ssh.execute.return_value = (1, "", "service not found")
+        mock_ssh_cls.return_value = mock_ssh
+
+        scenario_telemetry = MagicMock(spec=ScenarioTelemetry)
+        scenario_telemetry.affected_nodes = []
+
+        result = self.plugin.run(
+            "uuid", "test.yml", MagicMock(), scenario_telemetry
+        )
+
+        self.assertEqual(result, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description

Add `execution_mode: standalone` config option that allows krkn to inject chaos on any Linux host via SSH without requiring a Kubernetes cluster. Targets the 300K+ VMware customers migrating to RHEL+KVM who need resilience testing without Kubernetes.

## What's new

**Standalone mode foundation:**
- `run_kraken.py`: guards skip K8s initialization when `execution_mode: standalone`
- `ssh_node_scenarios.py`: SSHExecutor class + SSH node provider (`cloud_type: ssh`)
- `targets:` field for static host lists (replaces K8s node discovery)
- `supports_standalone()` method on AbstractScenarioPlugin for dynamic capability check

**Extended existing plugins with SSH delivery:**
- `hog_scenarios`: CPU/memory/IO stress via SSH + stress-ng (reuses HogConfig from krkn-lib)
- `network_chaos_scenarios`: tc/iptables via SSH (reuses get_egress_cmd)
- `time_scenarios`: timedatectl via SSH

**New standalone-only plugins:**
- `standalone_disk_fill_scenarios`: targeted disk fill with auto-cleanup
- `standalone_file_scenarios`: chmod/rename/append/delete with auto-revert

**OpenShift Virtualization chaos (based on real JIRA bugs):**
- `vm_migration_chaos_scenarios`: migration disruption (CNV-89391, CNV-81533)
- `vm_storage_chaos_scenarios`: NFS failover, IO burst (CNV-83991, CNV-79002)
- VMware migration validation pack (5-step scenario bundle)

**Security:**
- shlex.quote() on all user-supplied values in shell commands
- Input validation (regex) on egress params, fill_size, interface names
- paramiko.WarningPolicy() for SSH host key handling

## Backward compatibility

- Default `execution_mode: kubernetes` preserves existing behavior
- All 1263 existing tests pass unchanged
- K8s scenarios rejected with clear error in standalone mode

## Related PRs
- krkn-lib: SSHExecutor + HogConfig standalone fields
- krkn-hub: baremetal container images
- website: standalone mode documentation
- scenarios-hub: standalone scenario examples

## Test plan
- [x] 1263 unit tests pass
- [x] 24 E2E edge case tests against live target (podman Fedora CoreOS)
- [x] Live tested: disk fill, network chaos, time skew, file chaos
- [x] K8s backward compatibility verified on OpenShift 5.0
- [x] 4 code review rounds, 36 findings fixed