### PR TITLE
fix: ingress network chaos ip commands broken by bash -c argument splitting

### DIFF
--- a/krkn/scenario_plugins/native/network/ingress_shaping.py
+++ b/krkn/scenario_plugins/native/network/ingress_shaping.py
@@ -185,7 +185,7 @@ def get_default_interface(node: str, pod_template, kubecli: KrknKubernetes, imag
     kubecli.create_pod(pod_body, "default", 300)
     pod_name = f"fedtools-{pod_name_regex}"
     try:
-        cmd = ["ip", "r"]
+        cmd = ["ip r"]
         output = kubecli.exec_cmd_in_pod(cmd, pod_name, "default")
 
         if not output:
@@ -238,7 +238,7 @@ def verify_interface(
     pod_name = f"fedtools-{pod_name_regex}"
     try:
         if input_interface_list == []:
-            cmd = ["ip", "r"]
+            cmd = ["ip r"]
             output = kubecli.exec_cmd_in_pod(cmd, pod_name, "default")
 
             if not output:
@@ -254,7 +254,7 @@ def verify_interface(
             input_interface_list = [default_route.split()[4]]
 
         else:
-            cmd = ["ip", "-br", "addr", "show"]
+            cmd = ["ip -br addr show"]
             output = kubecli.exec_cmd_in_pod(cmd, pod_name, "default")
 
             if not output:


### PR DESCRIPTION
## Summary

Fixes the root cause of `ip -br addr show` returning help/usage text in the ingress network chaos scenario on ROSA/OVNKubernetes.

### Root cause

`exec_cmd_in_pod` wraps commands with `bash -c` when no `base_command` is specified. Passing `["ip", "-br", "addr", "show"]` produces `["bash", "-c", "ip", "-br", "addr", "show"]` — due to `bash -c` semantics, only the first argument after `-c` (`"ip"`) is treated as the command string; the rest become unused positional parameters. This caused bare `ip` to run with no arguments, printing help/usage text instead of interface data.

The egress scenario was unaffected because it uses `base_command="chroot"` which bypasses `bash -c` wrapping.

## Changes

Passes all 3 `ip` commands in `ingress_shaping.py` as single strings so `bash -c` treats each as one complete command:

- `get_default_interface`: `["ip", "r"]` → `["ip r"]`
- `verify_interface` (empty list path): `["ip", "r"]` → `["ip r"]`
- `verify_interface` (interface check): `["ip", "-br", "addr", "show"]` → `["ip -br addr show"]`

## Test plan

- [x] Reproduced issue on ROSA 4.19.36 / OVNKubernetes / m5.xlarge with `ens5` interface — confirmed `ip` help text in error on `main` branch (exit code 1)
- [x] Confirmed PR #1388 alone still fails — help text detected, but fallback `ip addr show` has the same `bash -c` bug (exit code 1)
- [x] Verified this fix resolves the issue — scenario runs to completion with `output_id: "success"` (exit code 0)

Closes #1380
Supersedes #1388

🤖 Generated with [Claude Code](https://claude.com/claude-code)