### PR TITLE
fix(network_chaos_ng): ensure rollback for node and pod network chaos

### DIFF
--- a/krkn/scenario_plugins/network_chaos_ng/modules/node_network_chaos.py
+++ b/krkn/scenario_plugins/network_chaos_ng/modules/node_network_chaos.py
@@ -45,10 +45,36 @@ class NodeNetworkChaosModule(AbstractNetworkChaosModule):
         super().__init__(config, kubecli)
         self.config = config
 
+    def _rollback(
+        self,
+        network_chaos_pod_name: str,
+        interfaces: list,
+        rules_applied: bool = False,
+        parallel: bool = False,
+    ):
+        if rules_applied:
+            common_delete_limit_rules(
+                self.config.egress,
+                self.config.ingress,
+                interfaces,
+                network_chaos_pod_name,
+                self.config.namespace,
+                self.kubecli.get_lib_kubernetes(),
+                None,
+                parallel,
+                network_chaos_pod_name,
+            )
+        self.kubecli.get_lib_kubernetes().delete_pod(
+            network_chaos_pod_name, self.config.namespace
+        )
+
     def run(self, target: str, error_queue: queue.Queue = None):
         parallel = False
         if error_queue:
             parallel = True
+        network_chaos_pod_name = None
+        interfaces = []
+        rules_applied = False
         try:
             network_chaos_pod_name = f"node-network-chaos-{get_random_string(5)}"
             container_name = f"fedora-container-{get_random_string(5)}"
@@ -79,6 +105,9 @@ class NodeNetworkChaosModule(AbstractNetworkChaosModule):
                         "no network interface found in pod, impossible to execute the network chaos scenario",
                         parallel,
                         network_chaos_pod_name,
+                    )
+                    self._rollback(
+                        network_chaos_pod_name, interfaces, rules_applied, parallel
                     )
                     return
                 log_info(
@@ -135,28 +164,19 @@ class NodeNetworkChaosModule(AbstractNetworkChaosModule):
                     self.config.namespace,
                     None,
                 )
+                rules_applied = True
 
                 time.sleep(self.config.test_duration)
 
                 log_info("removing tc rules", parallel, network_chaos_pod_name)
 
-                common_delete_limit_rules(
-                    self.config.egress,
-                    self.config.ingress,
-                    interfaces,
-                    network_chaos_pod_name,
-                    self.config.namespace,
-                    self.kubecli.get_lib_kubernetes(),
-                    None,
-                    parallel,
-                    network_chaos_pod_name,
-                )
-
-            self.kubecli.get_lib_kubernetes().delete_pod(
-                network_chaos_pod_name, self.config.namespace
-            )
+            self._rollback(network_chaos_pod_name, interfaces, rules_applied, parallel)
 
         except Exception as e:
+            if network_chaos_pod_name:
+                self._rollback(
+                    network_chaos_pod_name, interfaces, rules_applied, parallel
+                )
             if error_queue is None:
                 raise e
             else:

--- a/krkn/scenario_plugins/network_chaos_ng/modules/pod_network_chaos.py
+++ b/krkn/scenario_plugins/network_chaos_ng/modules/pod_network_chaos.py
@@ -43,10 +43,38 @@ class PodNetworkChaosModule(AbstractNetworkChaosModule):
         super().__init__(config, kubecli)
         self.config = config
 
+    def _rollback(
+        self,
+        network_chaos_pod_name: str,
+        interfaces: list,
+        pids: list = None,
+        rules_applied: bool = False,
+        parallel: bool = False,
+    ):
+        if rules_applied:
+            common_delete_limit_rules(
+                self.config.egress,
+                self.config.ingress,
+                interfaces,
+                network_chaos_pod_name,
+                self.config.namespace,
+                self.kubecli.get_lib_kubernetes(),
+                pids,
+                parallel,
+                network_chaos_pod_name,
+            )
+        self.kubecli.get_lib_kubernetes().delete_pod(
+            network_chaos_pod_name, self.config.namespace
+        )
+
     def run(self, target: str, error_queue: queue.Queue = None):
         parallel = False
         if error_queue:
             parallel = True
+        network_chaos_pod_name = None
+        interfaces = []
+        pids = None
+        rules_applied = False
         try:
             network_chaos_pod_name = f"pod-network-chaos-{get_random_string(5)}"
             container_name = f"fedora-container-{get_random_string(5)}"
@@ -85,6 +113,13 @@ class PodNetworkChaosModule(AbstractNetworkChaosModule):
                         "no network interface found in pod, impossible to execute the network chaos scenario",
                         parallel,
                         network_chaos_pod_name,
+                    )
+                    self._rollback(
+                        network_chaos_pod_name,
+                        interfaces,
+                        pids,
+                        rules_applied,
+                        parallel,
                     )
                     return
                 log_info(
@@ -138,28 +173,21 @@ class PodNetworkChaosModule(AbstractNetworkChaosModule):
                 self.config.namespace,
                 pids,
             )
+            rules_applied = True
 
             time.sleep(self.config.test_duration)
 
             log_info("removing tc rules", parallel, network_chaos_pod_name)
 
-            common_delete_limit_rules(
-                self.config.egress,
-                self.config.ingress,
-                interfaces,
-                network_chaos_pod_name,
-                self.config.namespace,
-                self.kubecli.get_lib_kubernetes(),
-                pids,
-                parallel,
-                network_chaos_pod_name,
-            )
-
-            self.kubecli.get_lib_kubernetes().delete_pod(
-                network_chaos_pod_name, self.config.namespace
+            self._rollback(
+                network_chaos_pod_name, interfaces, pids, rules_applied, parallel
             )
 
         except Exception as e:
+            if network_chaos_pod_name:
+                self._rollback(
+                    network_chaos_pod_name, interfaces, pids, rules_applied, parallel
+                )
             if error_queue is None:
                 raise e
             else:

--- a/tests/test_node_network_chaos.py
+++ b/tests/test_node_network_chaos.py
@@ -210,6 +210,13 @@ class TestNodeNetworkChaosModule(unittest.TestCase):
         mock_log_error.assert_called()
         self.assertIn("no network interface", str(mock_log_error.call_args))
 
+        # The chaos pod is now cleaned up on the no-interface early return
+        # (previously it was leaked).
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.common_delete_limit_rules"
+    )
     @patch(
         "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.node_qdisc_is_simple"
     )
@@ -221,7 +228,12 @@ class TestNodeNetworkChaosModule(unittest.TestCase):
     )
     @patch("krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.log_info")
     def test_run_complex_qdisc_without_force(
-        self, mock_log_info, mock_log_warning, mock_setup, mock_qdisc_is_simple
+        self,
+        mock_log_info,
+        mock_log_warning,
+        mock_setup,
+        mock_qdisc_is_simple,
+        mock_delete_rules,
     ):
         """
         Test run skips chaos when complex qdisc exists and force=False
@@ -240,6 +252,10 @@ class TestNodeNetworkChaosModule(unittest.TestCase):
         # Verify warning was logged
         mock_log_warning.assert_called()
         self.assertIn("already has tc rules", str(mock_log_warning.call_args))
+
+        # No tc rules were applied on this branch, so rollback must NOT attempt
+        # tc cleanup (regression lock: behaviour is byte-for-byte unchanged here).
+        mock_delete_rules.assert_not_called()
 
         # Verify cleanup pod was still deleted
         self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
@@ -486,6 +502,146 @@ class TestNodeNetworkChaosModule(unittest.TestCase):
 
         # Verify qdisc was checked for all 3 interfaces
         self.assertEqual(mock_qdisc_is_simple.call_count, 3)
+
+
+class TestNodeNetworkChaosModuleRollback(unittest.TestCase):
+    """
+    Rollback / exception-safety tests for NodeNetworkChaosModule.
+
+    Modeled on TestVmiNetworkChaosModuleRollback. Verifies that the chaos pod
+    and any applied tc rules are cleaned up on the exception path and on the
+    no-interface early return, and that tc cleanup is gated on rules actually
+    having been applied (not merely on interfaces being known).
+    """
+
+    def setUp(self):
+        self.mock_kubecli = MagicMock()
+        self.mock_kubernetes = MagicMock()
+        self.mock_kubecli.get_lib_kubernetes.return_value = self.mock_kubernetes
+
+        self.config = NetworkChaosConfig(
+            id="test-node-network-chaos",
+            image="test-image",
+            wait_duration=1,
+            test_duration=30,
+            label_selector="",
+            service_account="",
+            taints=[],
+            namespace="default",
+            instance_count=1,
+            target="worker-1",
+            execution="parallel",
+            interfaces=["eth0"],
+            ingress=True,
+            egress=True,
+            latency="100ms",
+            loss="10",
+            bandwidth="100mbit",
+            force=False,
+        )
+
+        self.module = NodeNetworkChaosModule(self.config, self.mock_kubecli)
+
+    def test_rollback_calls_delete_limit_rules_when_rules_applied(self):
+        """When rules were applied, _rollback removes tc rules then deletes the pod."""
+        with patch(
+            "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.common_delete_limit_rules"
+        ) as mock_del:
+            self.module._rollback("chaos-pod", ["eth0"], rules_applied=True)
+        mock_del.assert_called_once()
+        del_args = mock_del.call_args[0]
+        self.assertEqual(del_args[2], ["eth0"])  # interfaces
+        self.assertIsNone(del_args[6])  # pids: None for node (hostNetwork=True)
+        self.mock_kubernetes.delete_pod.assert_called_once_with("chaos-pod", "default")
+
+    def test_rollback_skips_delete_limit_rules_when_not_applied(self):
+        """When no rules were applied, _rollback deletes only the pod."""
+        with patch(
+            "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.common_delete_limit_rules"
+        ) as mock_del:
+            self.module._rollback("chaos-pod", ["eth0"], rules_applied=False)
+        mock_del.assert_not_called()
+        self.mock_kubernetes.delete_pod.assert_called_once_with("chaos-pod", "default")
+
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.common_delete_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.node_qdisc_is_simple"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.setup_network_chaos_ng_scenario"
+    )
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.log_info")
+    def test_run_rollback_deletes_pod_on_exception_before_tc(
+        self, mock_log_info, mock_setup, mock_qdisc, mock_del
+    ):
+        """Exception before tc is applied: pod deleted, no tc cleanup attempted."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_qdisc.side_effect = RuntimeError("qdisc check failed")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("worker-1")
+
+        mock_del.assert_not_called()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.common_delete_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.common_set_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.node_qdisc_is_simple"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.setup_network_chaos_ng_scenario"
+    )
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.time.sleep")
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.log_info")
+    def test_run_rollback_calls_delete_limit_rules_on_exception_after_tc(
+        self, mock_log_info, mock_sleep, mock_setup, mock_qdisc, mock_set, mock_del
+    ):
+        """Interrupted after tc is applied: tc cleanup and pod deletion both run."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_qdisc.return_value = True
+        mock_sleep.side_effect = RuntimeError("interrupted")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("worker-1")
+
+        mock_del.assert_called_once()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.common_delete_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.common_set_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.node_qdisc_is_simple"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.setup_network_chaos_ng_scenario"
+    )
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.time.sleep")
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.node_network_chaos.log_info")
+    def test_run_rollback_passes_correct_interfaces_on_exception(
+        self, mock_log_info, mock_sleep, mock_setup, mock_qdisc, mock_set, mock_del
+    ):
+        """Rollback on the exception path targets the correct interfaces, pids=None."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_qdisc.return_value = True
+        mock_sleep.side_effect = RuntimeError("interrupted")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("worker-1")
+
+        del_args = mock_del.call_args[0]
+        self.assertEqual(del_args[2], ["eth0"])  # interfaces
+        self.assertIsNone(del_args[6])  # pids: None for node
 
 
 if __name__ == "__main__":

--- a/tests/test_pod_network_chaos.py
+++ b/tests/test_pod_network_chaos.py
@@ -238,6 +238,10 @@ class TestPodNetworkChaosModule(unittest.TestCase):
         mock_log_error.assert_called()
         self.assertIn("no network interface", str(mock_log_error.call_args))
 
+        # The chaos pod is now cleaned up on the no-interface early return
+        # (previously it was leaked).
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
     @patch(
         "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.setup_network_chaos_ng_scenario"
     )
@@ -258,6 +262,9 @@ class TestPodNetworkChaosModule(unittest.TestCase):
             self.module.run("test-pod")
 
         self.assertIn("impossible to resolve container id", str(context.exception))
+
+        # The chaos pod is now cleaned up before the exception propagates.
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
 
     @patch(
         "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.setup_network_chaos_ng_scenario"
@@ -282,6 +289,9 @@ class TestPodNetworkChaosModule(unittest.TestCase):
             self.module.run("test-pod")
 
         self.assertIn("impossible to resolve pid", str(context.exception))
+
+        # The chaos pod is now cleaned up before the exception propagates.
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
 
     @patch("krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.time.sleep")
     @patch(
@@ -445,6 +455,144 @@ class TestPodNetworkChaosModule(unittest.TestCase):
         delete_call_args = mock_delete_rules.call_args
         self.assertEqual(delete_call_args[0][0], True)  # egress
         self.assertEqual(delete_call_args[0][1], False)  # ingress
+
+
+class TestPodNetworkChaosModuleRollback(unittest.TestCase):
+    """
+    Rollback / exception-safety tests for PodNetworkChaosModule.
+
+    Modeled on TestVmiNetworkChaosModuleRollback. Verifies that the chaos pod
+    and any applied tc rules (in the target pod netns via nsenter/pids) are
+    cleaned up on the exception path and on the no-interface early return, and
+    that tc cleanup is gated on rules actually having been applied.
+    """
+
+    def setUp(self):
+        self.mock_kubecli = MagicMock()
+        self.mock_kubernetes = MagicMock()
+        self.mock_kubecli.get_lib_kubernetes.return_value = self.mock_kubernetes
+
+        self.config = NetworkChaosConfig(
+            id="test-pod-network-chaos",
+            image="test-image",
+            wait_duration=1,
+            test_duration=30,
+            label_selector="",
+            service_account="",
+            taints=[],
+            namespace="default",
+            instance_count=1,
+            target="test-pod",
+            execution="parallel",
+            interfaces=["eth0"],
+            ingress=True,
+            egress=True,
+            latency="100ms",
+            loss="10",
+            bandwidth="100mbit",
+        )
+
+        self.module = PodNetworkChaosModule(self.config, self.mock_kubecli)
+
+        self.mock_pod_info = MagicMock()
+        self.mock_pod_info.nodeName = "worker-1"
+        self.mock_kubernetes.get_pod_info.return_value = self.mock_pod_info
+
+    def test_rollback_calls_delete_limit_rules_when_rules_applied(self):
+        """When rules were applied, _rollback removes tc rules (with pids) then deletes the pod."""
+        with patch(
+            "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.common_delete_limit_rules"
+        ) as mock_del:
+            self.module._rollback(
+                "chaos-pod", ["eth0"], pids=["1234"], rules_applied=True
+            )
+        mock_del.assert_called_once()
+        del_args = mock_del.call_args[0]
+        self.assertEqual(del_args[2], ["eth0"])  # interfaces
+        self.assertEqual(del_args[6], ["1234"])  # pids
+        self.mock_kubernetes.delete_pod.assert_called_once_with("chaos-pod", "default")
+
+    def test_rollback_skips_delete_limit_rules_when_not_applied(self):
+        """When no rules were applied, _rollback deletes only the pod."""
+        with patch(
+            "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.common_delete_limit_rules"
+        ) as mock_del:
+            self.module._rollback(
+                "chaos-pod", ["eth0"], pids=["1234"], rules_applied=False
+            )
+        mock_del.assert_not_called()
+        self.mock_kubernetes.delete_pod.assert_called_once_with("chaos-pod", "default")
+
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.common_delete_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.setup_network_chaos_ng_scenario"
+    )
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.log_info")
+    def test_run_rollback_deletes_pod_on_exception_before_tc(
+        self, mock_log_info, mock_setup, mock_del
+    ):
+        """Exception before tc is applied (no pids): pod deleted, no tc cleanup."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        self.mock_kubernetes.get_pod_pids.return_value = []  # raises before tc
+
+        with self.assertRaises(Exception):
+            self.module.run("test-pod")
+
+        mock_del.assert_not_called()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.common_delete_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.common_set_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.setup_network_chaos_ng_scenario"
+    )
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.time.sleep")
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.log_info")
+    def test_run_rollback_calls_delete_limit_rules_on_exception_after_tc(
+        self, mock_log_info, mock_sleep, mock_setup, mock_set, mock_del
+    ):
+        """Interrupted after tc is applied: tc cleanup and pod deletion both run."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        self.mock_kubernetes.get_pod_pids.return_value = ["1234"]
+        mock_sleep.side_effect = RuntimeError("interrupted")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("test-pod")
+
+        mock_del.assert_called_once()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.common_delete_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.common_set_limit_rules"
+    )
+    @patch(
+        "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.setup_network_chaos_ng_scenario"
+    )
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.time.sleep")
+    @patch("krkn.scenario_plugins.network_chaos_ng.modules.pod_network_chaos.log_info")
+    def test_run_rollback_passes_correct_pids_on_exception(
+        self, mock_log_info, mock_sleep, mock_setup, mock_set, mock_del
+    ):
+        """Rollback on the exception path targets the correct interfaces and pids."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        self.mock_kubernetes.get_pod_pids.return_value = ["1234", "5678"]
+        mock_sleep.side_effect = RuntimeError("interrupted")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("test-pod")
+
+        del_args = mock_del.call_args[0]
+        self.assertEqual(del_args[2], ["eth0"])  # interfaces
+        self.assertEqual(del_args[6], ["1234", "5678"])  # pids
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR backports the exception-safe rollback pattern already used by the VMI Network Chaos modules to the Node and Pod Network Chaos (`tc/netem`) implementations.

Previously, if an exception occurred after the privileged chaos pod had been created but before normal cleanup completed, the rollback path could be skipped, leaving behind:

- Active `tc`/`netem` rules
- Ingress `ifb` devices (when ingress shaping was enabled)
- The privileged Network Chaos pod

The VMI Network Chaos modules already solve this through a dedicated `_rollback()` helper. This change applies the same exception-safety pattern to the remaining `tc`-based modules while preserving their existing successful execution behavior.

---

## What changed

### `NodeNetworkChaosModule`

- Added a private `_rollback()` helper.
- Centralized cleanup into a single rollback path.
- Introduced explicit rollback state using `rules_applied`.
- Executes rollback on:
  - Successful completion
  - Early-return paths
  - Exception paths

### `PodNetworkChaosModule`

Applied the same rollback pattern while preserving the existing namespace/PID-based cleanup logic.

Rollback now correctly performs:

- `tc` cleanup (when rules were applied)
- Privileged chaos pod deletion

for both successful and exceptional execution.

---

## Design decisions

### State-driven cleanup

Rollback is intentionally gated by a dedicated `rules_applied` flag rather than by interface discovery.

Interfaces are resolved before any traffic-shaping rules are installed. Using interface presence as the cleanup condition would alter the existing `force=False` path by attempting `tc` cleanup when nothing had actually been configured.

Tracking whether shaping rules were successfully applied preserves existing behavior while ensuring cleanup only occurs when required.

### Exception guard

The exception path uses:

```python
if network_chaos_pod_name:
```

instead of maintaining a separate deployment flag.

`setup_network_chaos_ng_scenario()` creates the privileged chaos pod before performing interface and container discovery, both of which may still raise exceptions.

Using the pod name as the lifecycle indicator guarantees rollback is attempted whenever pod creation may already have occurred, matching the existing VMI implementation.

### Cleanup ordering

Rollback intentionally performs cleanup in the following order:

1. Remove `tc` rules (when installed)
2. Delete the privileged chaos pod

This ordering matches the VMI implementation and ensures the pod remains available while executing the cleanup commands.

---

## Tests

Added dedicated rollback test suites for both modules, modeled after the existing VMI rollback tests.

### New coverage

- Rollback after successful `tc` setup
- Rollback before `tc` setup
- Rollback after interrupted execution
- Cleanup on early-return paths
- Correct interface propagation
- Correct PID propagation
- Cleanup gated by `rules_applied`
- Preservation of the existing `force=False` behavior

Existing tests were also updated to assert cleanup on previously leaky execution paths.

### Validation

Executed successfully:

- ✅ `test_node_network_chaos.py`
- ✅ `test_pod_network_chaos.py`
- ✅ `test_vmi_network_chaos.py` (regression verification)
- ✅ Adjacent Network Chaos NG test suites

All targeted tests passed.

---

## Scope

This PR intentionally only covers the `tc/netem` Network Chaos modules:

- ✅ `NodeNetworkChaosModule`
- ✅ `PodNetworkChaosModule`

The Network Filter (`iptables`) modules are intentionally left for a follow-up change because their cleanup semantics differ and require additional state tracking around rule ownership.

---

## Why this change

This is a reliability improvement that aligns all `tc`-based Network Chaos implementations with the exception-safe cleanup model already established by the VMI modules.

Rather than introducing a new abstraction, this PR backports an existing maintainer-established pattern, minimizing architectural change while improving failure-path correctness.

As a result:

- Successful execution behavior is preserved.
- Early-return paths now consistently clean up privileged chaos pods.
- Exception paths now consistently clean up both applied traffic-shaping rules and the privileged chaos pod.
- The implementation remains consistent with the existing VMI Network Chaos design.