### PR TITLE
fix(network_filter_ng): ensure rollback for node and pod network filters

### DIFF
--- a/krkn/scenario_plugins/network_chaos_ng/modules/node_network_filter.py
+++ b/krkn/scenario_plugins/network_chaos_ng/modules/node_network_filter.py
@@ -42,10 +42,33 @@ class NodeNetworkFilterModule(AbstractNetworkChaosModule):
     config: NetworkFilterConfig
     kubecli: KrknTelemetryOpenshift
 
+    def _rollback(
+        self,
+        pod_name: str,
+        input_rules: list = None,
+        output_rules: list = None,
+        rules_applied: bool = False,
+    ):
+        if rules_applied:
+            clean_network_rules(
+                self.kubecli.get_lib_kubernetes(),
+                input_rules,
+                output_rules,
+                pod_name,
+                self.config.namespace,
+            )
+        self.kubecli.get_lib_kubernetes().delete_pod(
+            pod_name, self.config.namespace
+        )
+
     def run(self, target: str, error_queue: queue.Queue = None):
         parallel = False
         if error_queue:
             parallel = True
+        pod_name = None
+        input_rules = None
+        output_rules = None
+        rules_applied = False
         try:
             log_info(
                 f"creating workload to filter node {target} network"
@@ -91,6 +114,7 @@ class NodeNetworkFilterModule(AbstractNetworkChaosModule):
                 parallel,
                 target,
             )
+            rules_applied = True
 
             log_info(
                 f"waiting {self.config.test_duration} seconds before removing the iptables rules",
@@ -102,6 +126,12 @@ class NodeNetworkFilterModule(AbstractNetworkChaosModule):
 
             log_info("removing iptables rules", parallel, target)
 
+            # iptables cleanup is destructive and not idempotent: disarm the
+            # rollback guard *before* cleaning so that if cleanup or pod deletion
+            # fails, the exception handler cannot run a second, destructive
+            # cleanup pass. Cleanup stays inside `try`, so its failures flow
+            # through the existing error_queue / raise handling.
+            rules_applied = False
             clean_network_rules(
                 self.kubecli.get_lib_kubernetes(),
                 input_rules,
@@ -115,6 +145,15 @@ class NodeNetworkFilterModule(AbstractNetworkChaosModule):
             )
 
         except Exception as e:
+            if pod_name:
+                try:
+                    self._rollback(
+                        pod_name, input_rules, output_rules, rules_applied
+                    )
+                except Exception:
+                    # best-effort cleanup: never mask or drop the original
+                    # scenario error (preserves the error_queue / raise contract)
+                    pass
             if error_queue is None:
                 raise e
             else:

--- a/krkn/scenario_plugins/network_chaos_ng/modules/pod_network_filter.py
+++ b/krkn/scenario_plugins/network_chaos_ng/modules/pod_network_filter.py
@@ -43,10 +43,36 @@ from krkn.scenario_plugins.network_chaos_ng.modules.utils_network_filter import 
 class PodNetworkFilterModule(AbstractNetworkChaosModule):
     config: NetworkFilterConfig
 
+    def _rollback(
+        self,
+        pod_name: str,
+        input_rules: list = None,
+        output_rules: list = None,
+        pids: list = None,
+        rules_applied: bool = False,
+    ):
+        if rules_applied:
+            clean_network_rules_namespaced(
+                self.kubecli.get_lib_kubernetes(),
+                input_rules,
+                output_rules,
+                pod_name,
+                self.config.namespace,
+                pids,
+            )
+        self.kubecli.get_lib_kubernetes().delete_pod(
+            pod_name, self.config.namespace
+        )
+
     def run(self, target: str, error_queue: queue.Queue = None):
         parallel = False
         if error_queue:
             parallel = True
+        pod_name = None
+        input_rules = None
+        output_rules = None
+        pids = None
+        rules_applied = False
         try:
             pod_name = f"pod-filter-{get_random_string(5)}"
             container_name = f"fedora-container-{get_random_string(5)}"
@@ -86,6 +112,16 @@ class PodNetworkFilterModule(AbstractNetworkChaosModule):
                         parallel,
                         pod_name,
                     )
+                    # No rules applied yet (rules_applied is False), so this only
+                    # deletes the previously-leaked chaos pod. Best-effort: a
+                    # cleanup failure must not turn this graceful skip into a
+                    # reported scenario failure (parity with main).
+                    try:
+                        self._rollback(
+                            pod_name, input_rules, output_rules, pids, rules_applied
+                        )
+                    except Exception:
+                        pass
                     return
                 log_info(
                     f"detected network interfaces: {','.join(interfaces)}",
@@ -137,6 +173,7 @@ class PodNetworkFilterModule(AbstractNetworkChaosModule):
                 parallel,
                 target,
             )
+            rules_applied = True
 
             log_info(
                 f"waiting {self.config.test_duration} seconds before removing the iptables rules",
@@ -148,6 +185,12 @@ class PodNetworkFilterModule(AbstractNetworkChaosModule):
 
             log_info("removing iptables rules", parallel, pod_name)
 
+            # iptables cleanup is destructive and not idempotent: disarm the
+            # rollback guard *before* cleaning so that if cleanup or pod deletion
+            # fails, the exception handler cannot run a second, destructive
+            # cleanup pass. Cleanup stays inside `try`, so its failures flow
+            # through the existing error_queue / raise handling.
+            rules_applied = False
             clean_network_rules_namespaced(
                 self.kubecli.get_lib_kubernetes(),
                 input_rules,
@@ -162,6 +205,15 @@ class PodNetworkFilterModule(AbstractNetworkChaosModule):
             )
 
         except Exception as e:
+            if pod_name:
+                try:
+                    self._rollback(
+                        pod_name, input_rules, output_rules, pids, rules_applied
+                    )
+                except Exception:
+                    # best-effort cleanup: never mask or drop the original
+                    # scenario error (preserves the error_queue / raise contract)
+                    pass
             if error_queue is None:
                 raise e
             else:

--- a/tests/test_node_network_filter.py
+++ b/tests/test_node_network_filter.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for NodeNetworkFilterModule rollback / exception safety.
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_node_network_filter.py -v
+
+Assisted By: Claude Code
+"""
+
+import unittest
+import queue
+from unittest.mock import MagicMock, patch
+
+from krkn.scenario_plugins.network_chaos_ng.modules.node_network_filter import (
+    NodeNetworkFilterModule,
+)
+from krkn.scenario_plugins.network_chaos_ng.models import NetworkFilterConfig
+
+MODULE = "krkn.scenario_plugins.network_chaos_ng.modules.node_network_filter"
+
+
+class TestNodeNetworkFilterModuleRollback(unittest.TestCase):
+    """
+    Rollback / exception-safety tests for NodeNetworkFilterModule.
+
+    Unlike the tc-based chaos modules, iptables cleanup is destructive:
+    clean_network_rules() blindly deletes the rule at INPUT/OUTPUT position 1
+    once per rule. Cleanup must therefore run ONLY when rules were actually
+    applied. These tests lock that contract, in particular the case where an
+    exception occurs after the rule lists are generated but before they are
+    applied.
+    """
+
+    def setUp(self):
+        self.mock_kubecli = MagicMock()
+        self.mock_kubernetes = MagicMock()
+        self.mock_kubecli.get_lib_kubernetes.return_value = self.mock_kubernetes
+
+        self.config = NetworkFilterConfig(
+            id="node_network_filter",
+            image="test-image",
+            wait_duration=1,
+            test_duration=30,
+            label_selector="",
+            service_account="",
+            taints=[],
+            namespace="default",
+            instance_count=1,
+            target="worker-1",
+            execution="serial",
+            interfaces=["eth0"],
+            ingress=True,
+            egress=True,
+            ports=[80],
+            protocols=["tcp"],
+        )
+
+        self.module = NodeNetworkFilterModule(self.config, self.mock_kubecli)
+
+    # ----- _rollback() unit behaviour -----------------------------------
+
+    def test_rollback_cleans_rules_when_applied(self):
+        """rules_applied=True -> iptables cleanup runs, then pod is deleted."""
+        with patch(f"{MODULE}.clean_network_rules") as mock_clean:
+            self.module._rollback(
+                "chaos-pod", ["in-rule"], ["out-rule"], rules_applied=True
+            )
+        mock_clean.assert_called_once()
+        args = mock_clean.call_args[0]
+        self.assertEqual(args[1], ["in-rule"])  # input_rules
+        self.assertEqual(args[2], ["out-rule"])  # output_rules
+        self.mock_kubernetes.delete_pod.assert_called_once_with("chaos-pod", "default")
+
+    def test_rollback_skips_cleanup_when_not_applied(self):
+        """rules_applied=False -> NO iptables cleanup, only pod deletion."""
+        with patch(f"{MODULE}.clean_network_rules") as mock_clean:
+            self.module._rollback(
+                "chaos-pod", ["in-rule"], ["out-rule"], rules_applied=False
+            )
+        mock_clean.assert_not_called()
+        self.mock_kubernetes.delete_pod.assert_called_once_with("chaos-pod", "default")
+
+    # ----- run() happy path ---------------------------------------------
+
+    @patch(f"{MODULE}.clean_network_rules")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_rules")
+    @patch(f"{MODULE}.deploy_network_chaos_ng_pod")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_success_cleans_and_deletes_pod(
+        self, mock_log, mock_sleep, mock_deploy, mock_generate, mock_apply, mock_clean
+    ):
+        """Successful run applies rules, then cleans them and deletes the pod."""
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+
+        self.module.run("worker-1")
+
+        mock_apply.assert_called_once()
+        mock_sleep.assert_called_once_with(30)
+        mock_clean.assert_called_once()
+        # cleanup targets exactly the generated rules
+        clean_args = mock_clean.call_args[0]
+        self.assertEqual(clean_args[1], ["in-rule"])
+        self.assertEqual(clean_args[2], ["out-rule"])
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    # ----- run() exception paths ----------------------------------------
+
+    @patch(f"{MODULE}.clean_network_rules")
+    @patch(f"{MODULE}.generate_rules")
+    @patch(f"{MODULE}.deploy_network_chaos_ng_pod")
+    @patch(f"{MODULE}.log_info")
+    def test_run_exception_before_generate_deletes_pod_no_cleanup(
+        self, mock_log, mock_deploy, mock_generate, mock_clean
+    ):
+        """Failure before any rules are generated: pod deleted, no iptables cleanup."""
+        mock_deploy.side_effect = RuntimeError("deploy failed")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("worker-1")
+
+        mock_generate.assert_not_called()
+        mock_clean.assert_not_called()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(f"{MODULE}.clean_network_rules")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_rules")
+    @patch(f"{MODULE}.deploy_network_chaos_ng_pod")
+    @patch(f"{MODULE}.log_info")
+    def test_run_exception_after_generate_before_apply_does_not_clean(
+        self, mock_log, mock_deploy, mock_generate, mock_apply, mock_clean
+    ):
+        """
+        PRIMARY REGRESSION GUARD.
+
+        Rules are generated but apply fails. Because rules were never applied,
+        _rollback must NOT call clean_network_rules — otherwise it would delete
+        unrelated pre-existing iptables rules from the node. The pod is still
+        deleted.
+        """
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_apply.side_effect = RuntimeError("apply failed")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("worker-1")
+
+        mock_clean.assert_not_called()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(f"{MODULE}.clean_network_rules")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_rules")
+    @patch(f"{MODULE}.deploy_network_chaos_ng_pod")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_exception_after_apply_cleans_and_deletes(
+        self, mock_log, mock_sleep, mock_deploy, mock_generate, mock_apply, mock_clean
+    ):
+        """Interrupted after rules were applied: iptables cleanup and pod deletion both run."""
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_sleep.side_effect = RuntimeError("interrupted")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("worker-1")
+
+        mock_clean.assert_called_once()
+        clean_args = mock_clean.call_args[0]
+        self.assertEqual(clean_args[1], ["in-rule"])
+        self.assertEqual(clean_args[2], ["out-rule"])
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    # ----- run() parallel / error_queue path ----------------------------
+
+    @patch(f"{MODULE}.clean_network_rules")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_rules")
+    @patch(f"{MODULE}.deploy_network_chaos_ng_pod")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_error_queue_after_apply_cleans_and_reports(
+        self, mock_log, mock_sleep, mock_deploy, mock_generate, mock_apply, mock_clean
+    ):
+        """Parallel mode: post-apply failure still rolls back and reports via the queue."""
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_sleep.side_effect = RuntimeError("interrupted")
+
+        error_queue = queue.Queue()
+        self.module.run("worker-1", error_queue)
+
+        self.assertFalse(error_queue.empty())
+        self.assertEqual(error_queue.get(), "interrupted")
+        mock_clean.assert_called_once()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(f"{MODULE}.clean_network_rules")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_rules")
+    @patch(f"{MODULE}.deploy_network_chaos_ng_pod")
+    @patch(f"{MODULE}.log_info")
+    def test_run_error_queue_before_apply_reports_without_cleanup(
+        self, mock_log, mock_deploy, mock_generate, mock_apply, mock_clean
+    ):
+        """Parallel mode: pre-apply failure reports via the queue and does not clean firewall rules."""
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_apply.side_effect = Exception("apply failed")
+
+        error_queue = queue.Queue()
+        self.module.run("worker-1", error_queue)
+
+        self.assertFalse(error_queue.empty())
+        self.assertEqual(error_queue.get(), "apply failed")
+        mock_clean.assert_not_called()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(f"{MODULE}.clean_network_rules")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_rules")
+    @patch(f"{MODULE}.deploy_network_chaos_ng_pod")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_cleanup_runs_once_when_pod_deletion_fails(
+        self, mock_log, mock_sleep, mock_deploy, mock_generate, mock_apply, mock_clean
+    ):
+        """
+        If pod deletion fails after a successful cleanup, cleanup must NOT run a
+        second time. clean_network_rules deletes INPUT/OUTPUT position 1 per
+        rule, so a second pass would delete unrelated firewall rules. Rollback
+        runs in `finally`, guaranteeing exactly one cleanup pass.
+        """
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        self.mock_kubernetes.delete_pod.side_effect = Exception("api error")
+
+        with self.assertRaises(Exception):
+            self.module.run("worker-1")
+
+        mock_clean.assert_called_once()
+
+    @patch(f"{MODULE}.clean_network_rules")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_rules")
+    @patch(f"{MODULE}.deploy_network_chaos_ng_pod")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_parallel_cleanup_failure_reaches_error_queue(
+        self, mock_log, mock_sleep, mock_deploy, mock_generate, mock_apply, mock_clean
+    ):
+        """
+        Regression: in parallel mode a cleanup-time failure must be reported via
+        error_queue (matching main), not escape as a raised exception.
+        """
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        self.mock_kubernetes.delete_pod.side_effect = Exception("api 500 during delete")
+
+        error_queue = queue.Queue()
+        # Must not raise.
+        self.module.run("worker-1", error_queue)
+
+        self.assertFalse(error_queue.empty())
+        self.assertEqual(error_queue.get(), "api 500 during delete")
+        mock_clean.assert_called_once()
+
+    @patch(f"{MODULE}.clean_network_rules")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_rules")
+    @patch(f"{MODULE}.deploy_network_chaos_ng_pod")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_original_error_preserved_when_cleanup_also_fails(
+        self, mock_log, mock_sleep, mock_deploy, mock_generate, mock_apply, mock_clean
+    ):
+        """
+        Regression: if rollback cleanup ALSO fails, the original scenario error
+        must still be reported (not the cleanup error, and not lost).
+        """
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_sleep.side_effect = RuntimeError("scenario boom")
+        mock_clean.side_effect = Exception("cleanup failed")
+
+        error_queue = queue.Queue()
+        self.module.run("worker-1", error_queue)
+
+        self.assertEqual(error_queue.get(), "scenario boom")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_node_network_filter.py
+++ b/tests/test_node_network_filter.py
@@ -229,7 +229,8 @@ class TestNodeNetworkFilterModuleRollback(unittest.TestCase):
         If pod deletion fails after a successful cleanup, cleanup must NOT run a
         second time. clean_network_rules deletes INPUT/OUTPUT position 1 per
         rule, so a second pass would delete unrelated firewall rules. Rollback
-        runs in `finally`, guaranteeing exactly one cleanup pass.
+        runs in the `except` block; setting `rules_applied = False` before
+        clean_network_rules disarms it, guaranteeing exactly one cleanup pass.
         """
         mock_generate.return_value = (["in-rule"], ["out-rule"])
         self.mock_kubernetes.delete_pod.side_effect = Exception("api error")

--- a/tests/test_pod_network_filter.py
+++ b/tests/test_pod_network_filter.py
@@ -309,7 +309,9 @@ class TestPodNetworkFilterModuleRollback(unittest.TestCase):
         """
         If pod deletion fails after a successful cleanup, namespaced cleanup must
         NOT run a second time (it would delete unrelated rules inside the pod
-        netns). Rollback runs in `finally`, guaranteeing exactly one cleanup pass.
+        netns). Rollback runs in the `except` block; setting `rules_applied =
+        False` before clean_network_rules_namespaced disarms it, guaranteeing
+        exactly one cleanup pass.
         """
         mock_setup.return_value = (["container-123"], ["eth0"])
         mock_generate.return_value = (["in-rule"], ["out-rule"])

--- a/tests/test_pod_network_filter.py
+++ b/tests/test_pod_network_filter.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for PodNetworkFilterModule rollback / exception safety.
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_pod_network_filter.py -v
+
+Assisted By: Claude Code
+"""
+
+import unittest
+import queue
+from unittest.mock import MagicMock, patch
+
+from krkn.scenario_plugins.network_chaos_ng.modules.pod_network_filter import (
+    PodNetworkFilterModule,
+)
+from krkn.scenario_plugins.network_chaos_ng.models import NetworkFilterConfig
+
+MODULE = "krkn.scenario_plugins.network_chaos_ng.modules.pod_network_filter"
+
+
+class TestPodNetworkFilterModuleRollback(unittest.TestCase):
+    """
+    Rollback / exception-safety tests for PodNetworkFilterModule.
+
+    Same destructive-cleanup contract as the node filter, but cleanup is
+    namespaced (nsenter into the target pod netns via pids) and there is an
+    additional no-interface early-return path that previously leaked the pod.
+    """
+
+    def setUp(self):
+        self.mock_kubecli = MagicMock()
+        self.mock_kubernetes = MagicMock()
+        self.mock_kubecli.get_lib_kubernetes.return_value = self.mock_kubernetes
+
+        self.config = NetworkFilterConfig(
+            id="pod_network_filter",
+            image="test-image",
+            wait_duration=1,
+            test_duration=30,
+            label_selector="",
+            service_account="",
+            taints=[],
+            namespace="default",
+            instance_count=1,
+            target="test-pod",
+            execution="serial",
+            interfaces=["eth0"],
+            ingress=True,
+            egress=True,
+            ports=[80],
+            protocols=["tcp"],
+        )
+
+        self.module = PodNetworkFilterModule(self.config, self.mock_kubecli)
+
+        # Default happy-path resolution for the k8s client calls made by run().
+        mock_pod_info = MagicMock()
+        mock_pod_info.nodeName = "worker-1"
+        self.mock_kubernetes.get_pod_info.return_value = mock_pod_info
+        self.mock_kubernetes.get_container_ids.return_value = ["container-123"]
+        self.mock_kubernetes.get_pod_pids.return_value = ["1234"]
+
+    # ----- _rollback() unit behaviour -----------------------------------
+
+    def test_rollback_cleans_rules_when_applied(self):
+        """rules_applied=True -> namespaced iptables cleanup runs (with pids), then pod deleted."""
+        with patch(f"{MODULE}.clean_network_rules_namespaced") as mock_clean:
+            self.module._rollback(
+                "chaos-pod",
+                ["in-rule"],
+                ["out-rule"],
+                pids=["1234"],
+                rules_applied=True,
+            )
+        mock_clean.assert_called_once()
+        args = mock_clean.call_args[0]
+        self.assertEqual(args[1], ["in-rule"])  # input_rules
+        self.assertEqual(args[2], ["out-rule"])  # output_rules
+        self.assertEqual(args[5], ["1234"])  # pids
+        self.mock_kubernetes.delete_pod.assert_called_once_with("chaos-pod", "default")
+
+    def test_rollback_skips_cleanup_when_not_applied(self):
+        """rules_applied=False -> NO iptables cleanup, only pod deletion."""
+        with patch(f"{MODULE}.clean_network_rules_namespaced") as mock_clean:
+            self.module._rollback(
+                "chaos-pod",
+                ["in-rule"],
+                ["out-rule"],
+                pids=["1234"],
+                rules_applied=False,
+            )
+        mock_clean.assert_not_called()
+        self.mock_kubernetes.delete_pod.assert_called_once_with("chaos-pod", "default")
+
+    # ----- run() happy path ---------------------------------------------
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_namespaced_rules")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_success_cleans_and_deletes_pod(
+        self, mock_log, mock_sleep, mock_setup, mock_generate, mock_apply, mock_clean
+    ):
+        """Successful run applies rules, then cleans them (with pids) and deletes the pod."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+
+        self.module.run("test-pod")
+
+        mock_apply.assert_called_once()
+        mock_sleep.assert_called_once_with(30)
+        mock_clean.assert_called_once()
+        clean_args = mock_clean.call_args[0]
+        self.assertEqual(clean_args[1], ["in-rule"])
+        self.assertEqual(clean_args[2], ["out-rule"])
+        self.assertEqual(clean_args[5], ["1234"])  # pids threaded to cleanup
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    # ----- run() early return (no interface) ----------------------------
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.log_error")
+    @patch(f"{MODULE}.log_info")
+    def test_run_no_interface_early_return_deletes_pod(
+        self, mock_log, mock_log_error, mock_setup, mock_clean
+    ):
+        """No interface detected: pod is now cleaned up on the early return (was leaked)."""
+        self.config.interfaces = []
+        mock_setup.return_value = (["container-123"], [])
+
+        self.module.run("test-pod")
+
+        mock_log_error.assert_called()
+        mock_clean.assert_not_called()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.log_error")
+    @patch(f"{MODULE}.log_info")
+    def test_run_no_interface_skip_stays_graceful_when_pod_deletion_fails_serial(
+        self, mock_log, mock_log_error, mock_setup, mock_clean
+    ):
+        """
+        Serial parity with main: the no-interface skip must return normally even
+        if pod deletion fails. A cleanup failure must not become a scenario error.
+        """
+        self.config.interfaces = []
+        mock_setup.return_value = (["container-123"], [])
+        self.mock_kubernetes.delete_pod.side_effect = Exception("delete failed on skip path")
+
+        # Must not raise.
+        result = self.module.run("test-pod")
+
+        self.assertIsNone(result)
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+        mock_clean.assert_not_called()
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.log_error")
+    @patch(f"{MODULE}.log_info")
+    def test_run_no_interface_skip_stays_graceful_when_pod_deletion_fails_parallel(
+        self, mock_log, mock_log_error, mock_setup, mock_clean
+    ):
+        """
+        Parallel parity with main: the no-interface skip must leave error_queue
+        empty even if pod deletion fails during cleanup.
+        """
+        self.config.interfaces = []
+        mock_setup.return_value = (["container-123"], [])
+        self.mock_kubernetes.delete_pod.side_effect = Exception("delete failed on skip path")
+
+        error_queue = queue.Queue()
+        self.module.run("test-pod", error_queue)
+
+        self.assertTrue(error_queue.empty())
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+        mock_clean.assert_not_called()
+
+    # ----- run() exception paths ----------------------------------------
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.generate_namespaced_rules")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.log_info")
+    def test_run_exception_before_generate_deletes_pod_no_cleanup(
+        self, mock_log, mock_setup, mock_generate, mock_clean
+    ):
+        """Failure before rules are generated (no pids): pod deleted, no iptables cleanup."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        self.mock_kubernetes.get_pod_pids.return_value = []  # raises before generate
+
+        with self.assertRaises(Exception):
+            self.module.run("test-pod")
+
+        mock_generate.assert_not_called()
+        mock_clean.assert_not_called()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_namespaced_rules")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.log_info")
+    def test_run_exception_after_generate_before_apply_does_not_clean(
+        self, mock_log, mock_setup, mock_generate, mock_apply, mock_clean
+    ):
+        """
+        PRIMARY REGRESSION GUARD.
+
+        Namespaced rules are generated but apply fails. Because rules were never
+        applied, _rollback must NOT call clean_network_rules_namespaced —
+        otherwise it would delete unrelated iptables rules inside the target
+        pod's network namespace. The pod is still deleted.
+        """
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_apply.side_effect = RuntimeError("apply failed")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("test-pod")
+
+        mock_clean.assert_not_called()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_namespaced_rules")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_exception_after_apply_cleans_and_deletes(
+        self, mock_log, mock_sleep, mock_setup, mock_generate, mock_apply, mock_clean
+    ):
+        """Interrupted after rules were applied: namespaced cleanup and pod deletion both run."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_sleep.side_effect = RuntimeError("interrupted")
+
+        with self.assertRaises(RuntimeError):
+            self.module.run("test-pod")
+
+        mock_clean.assert_called_once()
+        clean_args = mock_clean.call_args[0]
+        self.assertEqual(clean_args[5], ["1234"])  # pids
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    # ----- run() parallel / error_queue path ----------------------------
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_namespaced_rules")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_error_queue_after_apply_cleans_and_reports(
+        self, mock_log, mock_sleep, mock_setup, mock_generate, mock_apply, mock_clean
+    ):
+        """Parallel mode: post-apply failure still rolls back and reports via the queue."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_sleep.side_effect = RuntimeError("interrupted")
+
+        error_queue = queue.Queue()
+        self.module.run("test-pod", error_queue)
+
+        self.assertFalse(error_queue.empty())
+        self.assertEqual(error_queue.get(), "interrupted")
+        mock_clean.assert_called_once()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_namespaced_rules")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.log_info")
+    def test_run_error_queue_before_apply_reports_without_cleanup(
+        self, mock_log, mock_setup, mock_generate, mock_apply, mock_clean
+    ):
+        """Parallel mode: pre-apply failure reports via the queue and does not clean firewall rules."""
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_apply.side_effect = Exception("apply failed")
+
+        error_queue = queue.Queue()
+        self.module.run("test-pod", error_queue)
+
+        self.assertFalse(error_queue.empty())
+        self.assertEqual(error_queue.get(), "apply failed")
+        mock_clean.assert_not_called()
+        self.assertEqual(self.mock_kubernetes.delete_pod.call_count, 1)
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_namespaced_rules")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_cleanup_runs_once_when_pod_deletion_fails(
+        self, mock_log, mock_sleep, mock_setup, mock_generate, mock_apply, mock_clean
+    ):
+        """
+        If pod deletion fails after a successful cleanup, namespaced cleanup must
+        NOT run a second time (it would delete unrelated rules inside the pod
+        netns). Rollback runs in `finally`, guaranteeing exactly one cleanup pass.
+        """
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        self.mock_kubernetes.delete_pod.side_effect = Exception("api error")
+
+        with self.assertRaises(Exception):
+            self.module.run("test-pod")
+
+        mock_clean.assert_called_once()
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_namespaced_rules")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_parallel_cleanup_failure_reaches_error_queue(
+        self, mock_log, mock_sleep, mock_setup, mock_generate, mock_apply, mock_clean
+    ):
+        """
+        Regression: in parallel mode a cleanup-time failure must be reported via
+        error_queue (matching main), not escape as a raised exception.
+        """
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        self.mock_kubernetes.delete_pod.side_effect = Exception("api 500 during delete")
+
+        error_queue = queue.Queue()
+        # Must not raise.
+        self.module.run("test-pod", error_queue)
+
+        self.assertFalse(error_queue.empty())
+        self.assertEqual(error_queue.get(), "api 500 during delete")
+        mock_clean.assert_called_once()
+
+    @patch(f"{MODULE}.clean_network_rules_namespaced")
+    @patch(f"{MODULE}.apply_network_rules")
+    @patch(f"{MODULE}.generate_namespaced_rules")
+    @patch(f"{MODULE}.setup_network_chaos_ng_scenario")
+    @patch(f"{MODULE}.time.sleep")
+    @patch(f"{MODULE}.log_info")
+    def test_run_original_error_preserved_when_cleanup_also_fails(
+        self, mock_log, mock_sleep, mock_setup, mock_generate, mock_apply, mock_clean
+    ):
+        """
+        Regression: if rollback cleanup ALSO fails, the original scenario error
+        must still be reported (not the cleanup error, and not lost).
+        """
+        mock_setup.return_value = (["container-123"], ["eth0"])
+        mock_generate.return_value = (["in-rule"], ["out-rule"])
+        mock_sleep.side_effect = RuntimeError("scenario boom")
+        mock_clean.side_effect = Exception("cleanup failed")
+
+        error_queue = queue.Queue()
+        self.module.run("test-pod", error_queue)
+
+        self.assertEqual(error_queue.get(), "scenario boom")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds exception-safe rollback to the `network_filter_ng` node and pod filter modules.

It follows the same goal as #1461 by ensuring temporary resources are cleaned up on exception and early-return paths, preventing leaked chaos pods while preserving the existing behaviour of successful executions.

## Changes

### NodeNetworkFilterModule

- Add a private `_rollback()` helper
- Clean up applied iptables rules before deleting the temporary chaos pod
- Invoke rollback on exception paths
- Track successful rule application with a `rules_applied` flag

### PodNetworkFilterModule

- Add a private `_rollback()` helper
- Clean up namespaced iptables rules before deleting the temporary chaos pod
- Clean up the temporary chaos pod on the no-interface early-return path
- Invoke rollback on exception paths
- Track successful rule application with a `rules_applied` flag

## Why `rules_applied` is necessary

Unlike the `tc` cleanup used by the network chaos modules, the filter modules remove iptables rules using positional deletion (`iptables -D ...`).

The rule lists are generated before `apply_network_rules()` executes. If cleanup were triggered simply because rules had been generated, an exception before rule application could remove unrelated pre-existing firewall rules.

To avoid that, rollback is gated by a dedicated `rules_applied` flag that is set only after `apply_network_rules()` completes successfully.

## Behaviour

The successful execution path is unchanged.

This PR only changes previously-unhandled cleanup paths:

- exception before normal cleanup
- exception after rules have been applied
- pod no-interface early return

These paths now perform best-effort cleanup of temporary resources while preserving the existing error-handling behaviour.

## Tests

This PR introduces comprehensive unit tests for both filter modules, including coverage for:

- successful execution
- rollback before rule application
- rollback after rule application
- rollback helper behaviour
- exactly-once cleanup
- serial and parallel (`error_queue`) execution
- pod no-interface early return
- cleanup failure handling
- original error preservation

All existing network-related regression tests continue to pass.