### PR TITLE
fix(rollback): continue after individual rollback failures

### DIFF
--- a/krkn/rollback/handler.py
+++ b/krkn/rollback/handler.py
@@ -36,6 +36,15 @@ if TYPE_CHECKING:
     from krkn.rollback.serialization import Serializer
 
 
+class RollbackExecutionError(RuntimeError):
+    """Raised after all rollback files run when one or more failed."""
+
+    def __init__(self, failures: list[tuple[str, Exception]]) -> None:
+        self.failures = failures
+        details = "; ".join(f"{path}: {error}" for path, error in failures)
+        super().__init__(f"{len(failures)} rollback file(s) failed: {details}")
+
+
 def set_rollback_context_decorator(func):
     """
     Decorator to automatically set and clear rollback context.
@@ -160,6 +169,7 @@ def execute_rollback_version_files(
 
     # Execute all version files in the directory
     logger.info(f"Executing rollback version files for run_uuid={run_uuid or '*'}, scenario_type={scenario_type or '*'}")
+    failures: list[tuple[str, Exception]] = []
     for version_file in version_files:
         try:
             logger.info(f"Executing rollback version file: {version_file}")
@@ -178,21 +188,22 @@ def execute_rollback_version_files(
                 )
             rollback_callable(rollback_content, telemetry_arg)
             logger.info('Rollback completed.')
-            success = True
         except Exception as e:
-            success = False
             logger.error(f"Failed to execute rollback version file {version_file}: {e}")
-            raise
+            failures.append((version_file, e))
+            continue
 
         # Rename the version file with .executed suffix if successful
-        if success:
-            try:
-                executed_file = f"{version_file}.executed"
-                os.rename(version_file, executed_file)
-                logger.info(f"Renamed {version_file} to {executed_file} successfully.")
-            except Exception as e:
-                logger.error(f"Failed to rename rollback version file {version_file}: {e}")
-                raise
+        try:
+            executed_file = f"{version_file}.executed"
+            os.rename(version_file, executed_file)
+            logger.info(f"Renamed {version_file} to {executed_file} successfully.")
+        except Exception as e:
+            logger.error(f"Failed to rename rollback version file {version_file}: {e}")
+            failures.append((version_file, e))
+
+    if failures:
+        raise RollbackExecutionError(failures)
 
 def cleanup_rollback_version_files(run_uuid: str, scenario_type: str):
     """

--- a/tests/test_rollback_handler.py
+++ b/tests/test_rollback_handler.py
@@ -1,0 +1,50 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from krkn.rollback.config import RollbackConfig
+from krkn.rollback.handler import RollbackExecutionError, execute_rollback_version_files
+
+
+def test_executes_remaining_files_and_raises_aggregate_error():
+    version_files = ["first.py", "second.py", "third.py"]
+    calls = []
+
+    def parse_version_file(path):
+        def rollback(content, telemetry):
+            calls.append(path)
+            if path != "second.py":
+                raise RuntimeError(f"failed {path}")
+
+        return rollback, Mock(skip_kubernetes=False)
+
+    with (
+        patch.object(RollbackConfig, "search_rollback_version_files", return_value=version_files),
+        patch("krkn.rollback.handler._parse_rollback_module", side_effect=parse_version_file),
+        patch("krkn.rollback.handler.os.rename") as rename,
+    ):
+        with pytest.raises(RollbackExecutionError) as error:
+            execute_rollback_version_files(Mock(), ignore_auto_rollback_config=True)
+
+    assert calls == version_files
+    assert [path for path, _ in error.value.failures] == ["first.py", "third.py"]
+    assert "failed first.py" in str(error.value)
+    assert "failed third.py" in str(error.value)
+    rename.assert_called_once_with("second.py", "second.py.executed")
+
+
+def test_collects_rename_failure_and_continues():
+    version_files = ["first.py", "second.py"]
+    rollback = Mock()
+    content = Mock(skip_kubernetes=True)
+
+    with (
+        patch.object(RollbackConfig, "search_rollback_version_files", return_value=version_files),
+        patch("krkn.rollback.handler._parse_rollback_module", return_value=(rollback, content)),
+        patch("krkn.rollback.handler.os.rename", side_effect=[OSError("rename failed"), None]),
+    ):
+        with pytest.raises(RollbackExecutionError) as error:
+            execute_rollback_version_files(Mock(), ignore_auto_rollback_config=True)
+
+    assert rollback.call_count == 2
+    assert [path for path, _ in error.value.failures] == ["first.py"]


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

Run every queued rollback version file even when an individual execution or rename fails. Failures are collected with their file paths and raised as one `RollbackExecutionError` only after best-effort recovery has attempted the full queue.

## Related Tickets & Documents

- Related Issue #: #1467
- Closes #: #1467

# Documentation

- [ ] **Is documentation needed for this update?**

No public configuration or API behavior changes.

# Checklist before requesting a review

- [ ] The proposed approach has received maintainer acknowledgment on the issue.
- [ ] I have run krkn against a Kubernetes/OpenShift cluster.
- [x] Focused unit tests cover execution failures, rename failures, continuation order, successful renames, and aggregate contents.

## Tests performed

```text
.venv/Scripts/python.exe -m pytest tests/test_rollback_handler.py -q
..                                                                       [100%]
2 passed in 0.24s
```

## AI disclosure

OpenAI Codex materially assisted with the implementation and tests. This is disclosed in the commit with `Assisted-by: OpenAI Codex <noreply@openai.com>` as required by `AI_CONTRIBUTION_POLICY.md`.