### PR TITLE
fix: evaluate all series in slo_passed for instant vectors

### DIFF
--- a/krkn/prometheus/collector.py
+++ b/krkn/prometheus/collector.py
@@ -44,7 +44,8 @@ def slo_passed(prometheus_result: List[Any]) -> Optional[bool]:
         elif "value" in series:
             has_samples = True
             try:
-                return float(series["value"][1]) == 0
+                if float(series["value"][1]) != 0:
+                    return False
             except (TypeError, ValueError):
                 return False
 

--- a/tests/test_prometheus_collector.py
+++ b/tests/test_prometheus_collector.py
@@ -153,6 +153,19 @@ class TestSLOPassed(unittest.TestCase):
         result = slo_passed(prometheus_result)
         self.assertFalse(result)
 
+    def test_result_with_multiple_instant_series_later_has_nonzero(self):
+        """Test that a later non-zero value in instant vector series returns False."""
+        prometheus_result = [
+            {
+                "value": [1234567890, "0"]
+            },
+            {
+                "value": [1234567891, "2.0"]  # Non-zero in a subsequent series
+            }
+        ]
+        result = slo_passed(prometheus_result)
+        self.assertFalse(result)
+
     def test_result_with_float_zero(self):
         """Test that float zero is handled correctly."""
         prometheus_result = [


### PR DESCRIPTION
## Description
Fixes #1311

When evaluating Prometheus instant vector queries, the `slo_passed` function would silently return after evaluating the first series. If the first series passed (`value` equals 0), it incorrectly assumed the entire SLO passed, ignoring all other series that could potentially be failing.

This updates the logic to continue checking subsequent series if the current one is successful, and only returns `False` if a failure is detected, accurately mirroring the logic already used for range queries (`values`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
