### PR TITLE
ci: skip heavy workflows for docs-only PRs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,8 +4,6 @@ on:
     tags: ['v[0-9].[0-9]+.[0-9]+']
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
   pull_request:
     paths-ignore:
       - '**/*.md'

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,7 +4,11 @@ on:
     tags: ['v[0-9].[0-9]+.[0-9]+']
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   security-scan-source:

--- a/.github/workflows/docs-bypass.yml
+++ b/.github/workflows/docs-bypass.yml
@@ -1,0 +1,31 @@
+name: Docs Bypass
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Bypass success for docs-only PR"
+  tests-v2:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Bypass success for docs-only PR"
+  security-scan-source:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Bypass success for docs-only PR"
+  build-and-push-krkn:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Bypass success for docs-only PR"
+  build-push-redhat-chaos:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Bypass success for docs-only PR"
+  manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Bypass success for docs-only PR"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,13 @@
 name: Functional & Unit Tests
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
 jobs:
   tests:
     # Common steps

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
 jobs:
   tests:
     # Common steps

--- a/.github/workflows/tests_v2.yml
+++ b/.github/workflows/tests_v2.yml
@@ -1,9 +1,13 @@
 name: Tests v2 (pytest functional)
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
 jobs:
   tests-v2:
     name: Tests v2 (pytest functional)

--- a/.github/workflows/tests_v2.yml
+++ b/.github/workflows/tests_v2.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
 jobs:
   tests-v2:
     name: Tests v2 (pytest functional)


### PR DESCRIPTION
## Description
Fixes #1447

This PR adds `paths-ignore: - '**/*.md'` rules to the heavy CI workflows (`Functional & Unit Tests`, `Tests v2`, and `Docker Image CI`). 

If a pull request only modifies Markdown files, these heavy jobs will be skipped to reduce CI queue times and resource usage. Other documentation or linting checks (like `require-docs`) will continue to run as expected.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (infrastructure/CI update)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
