### PR TITLE
feat(ci): add sigstore/cosign cryptographic signing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
   release:
     permissions:
       contents: write
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -44,6 +45,7 @@ jobs:
           OUTPUT=${TEMPLATE//\{VERSION\}/$VERSION}
           OUTPUT=${OUTPUT//\{CHANGES\}/$NOTES}
           echo "$OUTPUT" > release-notes.md
+          
       - name: create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -61,3 +63,13 @@ jobs:
           syft . --scope all-layers --output cyclonedx-json > sbom.json
           echo "SBOM generated successfully!"
           gh release upload ${{ github.ref_name }} sbom.json
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
+
+      - name: Sign the SBOM
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cosign sign-blob --yes --bundle sbom.json.bundle sbom.json
+          gh release upload ${{ github.ref_name }} sbom.json.bundle


### PR DESCRIPTION
## Description
Fixes #1333

This PR implements cryptographic signing for Krkn releases to satisfy CNCF CLOMonitor and OpenSSF Scorecard requirements. 

It updates `.github/workflows/release.yml` to:
1. Include the `id-token: write` permission, which is required for Sigstore OIDC authentication.
2. Install `cosign` using the official `sigstore/cosign-installer` action.
3. Perform keyless signing (`cosign sign-blob`) on the generated SBOM and attach the resulting `.bundle` to the GitHub Release.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
