### PR TITLE
fix: deterministic pod kills with exclude_label in pod disruption scenario

### DIFF
--- a/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
+++ b/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
@@ -227,6 +227,7 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
                 _exclude_pods = self.get_pods("",config.exclude_label,config.namespace_pattern, kubecli, field_selector="status.phase=Running", node_label_selector=config.node_label_selector, node_names=config.node_names)
                 for pod in _exclude_pods:
                     exclude_pods.add(pod[0])
+                    logging.info(f"Excluding pod {pod[0]} from chaos")
 
             expected_pod_count = len(pods)
             pods = [pod for pod in pods if pod[0] not in exclude_pods]

--- a/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
+++ b/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
@@ -228,9 +228,9 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
                 for pod in _exclude_pods:
                     exclude_pods.add(pod[0])
 
+            expected_pod_count = len(pods)
             pods = [pod for pod in pods if pod[0] not in exclude_pods]
 
-            pods_count = len(pods)
             if len(pods) < config.kill:
                 logging.error("Not enough pods match the criteria, expected {} but found only {} pods".format(
                         config.kill, len(pods)))
@@ -243,7 +243,7 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
                 logging.info(f'Deleting pod {pod[0]}')
                 kubecli.delete_pod(pod[0], pod[1])
             
-            return_val = self.wait_for_pods(config.label_selector,config.name_pattern,config.namespace_pattern, pods_count, config.duration, config.timeout, kubecli, config.node_label_selector, config.node_names)
+            return_val = self.wait_for_pods(config.label_selector,config.name_pattern,config.namespace_pattern, expected_pod_count, config.duration, config.timeout, kubecli, config.node_label_selector, config.node_names)
         except Exception as e:
             raise(e)
 

--- a/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
+++ b/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
@@ -228,6 +228,7 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
                 for pod in _exclude_pods:
                     exclude_pods.add(pod[0])
 
+            pods = [pod for pod in pods if pod[0] not in exclude_pods]
 
             pods_count = len(pods)
             if len(pods) < config.kill:
@@ -239,11 +240,8 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
             for i in range(config.kill):
                 pod = pods[i]
                 logging.info(pod)
-                if pod[0] in exclude_pods:
-                    logging.info(f"Excluding {pod[0]} from chaos")
-                else:
-                    logging.info(f'Deleting pod {pod[0]}')
-                    kubecli.delete_pod(pod[0], pod[1])
+                logging.info(f'Deleting pod {pod[0]}')
+                kubecli.delete_pod(pod[0], pod[1])
             
             return_val = self.wait_for_pods(config.label_selector,config.name_pattern,config.namespace_pattern, pods_count, config.duration, config.timeout, kubecli, config.node_label_selector, config.node_names)
         except Exception as e:

--- a/tests/test_pod_disruption_scenario_plugin.py
+++ b/tests/test_pod_disruption_scenario_plugin.py
@@ -83,6 +83,8 @@ class TestPodDisruptionScenarioPlugin(unittest.TestCase):
 
         self.assertEqual(result, 0)
         self.assertEqual(mock_kubecli.delete_pod.call_count, config.kill)
+        self.plugin.wait_for_pods.assert_called_once()
+        self.assertEqual(self.plugin.wait_for_pods.call_args[0][3], 5)
 
         for call in mock_kubecli.delete_pod.call_args_list:
             deleted_pod_name = call[0][0]

--- a/tests/test_pod_disruption_scenario_plugin.py
+++ b/tests/test_pod_disruption_scenario_plugin.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 
+from krkn.scenario_plugins.pod_disruption.models.models import InputParams
 from krkn.scenario_plugins.pod_disruption.pod_disruption_scenario_plugin import PodDisruptionScenarioPlugin
 
 
@@ -38,6 +39,97 @@ class TestPodDisruptionScenarioPlugin(unittest.TestCase):
 
         self.assertEqual(result, ["pod_disruption_scenarios"])
         self.assertEqual(len(result), 1)
+
+    def test_killing_pods_with_exclude_label(self):
+        config_data = {
+            "name_pattern": ".*",
+            "namespace_pattern": "test-namespace",
+            "label_selector": "app=test",
+            "exclude_label": "chaos=exclude",
+            "kill": 2,
+            "duration": 0,
+            "timeout": 0,
+            "krkn_pod_recovery_time": 0,
+            "node_label_selector": None,
+            "node_names": None
+        }
+        config = InputParams(config_data)
+
+        # 5 normal pods, 2 of which will be excluded
+        mock_pods = [
+            ("pod-1", "test-namespace"),
+            ("pod-2", "test-namespace"),
+            ("pod-3", "test-namespace"),
+            ("pod-4", "test-namespace"),
+            ("pod-exclude-1", "test-namespace"),
+        ]
+        mock_exclude_pods = [
+            ("pod-4", "test-namespace"),
+            ("pod-exclude-1", "test-namespace"),
+        ]
+
+        def get_pods_side_effect(name_pattern, label_selector, namespace, kubecli, *args, **kwargs):
+            if label_selector == "app=test":
+                return list(mock_pods)
+            if label_selector == "chaos=exclude":
+                return list(mock_exclude_pods)
+            return []
+
+        self.plugin.get_pods = MagicMock(side_effect=get_pods_side_effect)
+        self.plugin.wait_for_pods = MagicMock(return_value=0)
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+
+        result = self.plugin.killing_pods(config, mock_kubecli)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(mock_kubecli.delete_pod.call_count, config.kill)
+
+        for call in mock_kubecli.delete_pod.call_args_list:
+            deleted_pod_name = call[0][0]
+            self.assertNotIn(deleted_pod_name, ["pod-4", "pod-exclude-1"])
+
+    def test_killing_pods_not_enough_pods(self):
+        config_data = {
+            "name_pattern": ".*",
+            "namespace_pattern": "test-namespace",
+            "label_selector": "app=test",
+            "exclude_label": "chaos=exclude",
+            "kill": 4, 
+            "duration": 0,
+            "timeout": 0,
+            "krkn_pod_recovery_time": 0,
+            "node_label_selector": None,
+            "node_names": None
+        }
+        config = InputParams(config_data)
+
+        # 5 pods total, but 2 excluded = 3 available (less than kill=4 requested)
+        mock_pods = [
+            ("pod-1", "test-namespace"),
+            ("pod-2", "test-namespace"),
+            ("pod-3", "test-namespace"),
+            ("pod-4-exclude", "test-namespace"),
+            ("pod-5-exclude", "test-namespace"),
+        ]
+        mock_exclude_pods = [
+            ("pod-4-exclude", "test-namespace"),
+            ("pod-5-exclude", "test-namespace"),
+        ]
+
+        def get_pods_side_effect(name_pattern, label_selector, namespace, kubecli, *args, **kwargs):
+            if label_selector == "app=test":
+                return list(mock_pods)
+            if label_selector == "chaos=exclude":
+                return list(mock_exclude_pods)
+            return []
+
+        self.plugin.get_pods = MagicMock(side_effect=get_pods_side_effect)
+        mock_kubecli = MagicMock(spec=KrknKubernetes)
+
+        result = self.plugin.killing_pods(config, mock_kubecli)
+
+        self.assertEqual(result, 1)
+        self.assertEqual(mock_kubecli.delete_pod.call_count, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  
Fixes a non-deterministic logic bug in the `PodDisruptionScenarioPlugin`. Previously, if an `exclude_label` was provided, the plugin identified the excluded pods but failed to remove them from the target `pods` array. This caused the random target selector to occasionally land on excluded pods, log a skip, and fail to fulfill the requested `config.kill` count, silently resulting in fewer dead pods than the scenario demanded. 
This PR applies a strict list-comprehension filter to strip `exclude_pods` right after identifying them, natively guaranteeing that `len(pods) < config.kill` works accurately and that the disruption loop targets the exact number of valid pods.

## Related Tickets & Documents

- Related Issue #: Fixes #1477
- Closes #: Fixes #1477

# Documentation  
- [ ] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)  
- N/A

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:

```
```bash
python -m coverage run -a -m unittest tests/test_pod_disruption_scenario_plugin.py -v
...

test_get_scenario_types (tests.test_pod_disruption_scenario_plugin.TestPodDisruptionScenarioPlugin.test_get_scenario_types)
Test get_scenario_types returns correct scenario type ... ok
test_killing_pods_not_enough_pods (tests.test_pod_disruption_scenario_plugin.TestPodDisruptionScenarioPlugin.test_killing_pods_not_enough_pods) ... ERROR:root:Not enough pods match the criteria, expected 4 but found only 3 pods
ok
test_killing_pods_with_exclude_label (tests.test_pod_disruption_scenario_plugin.TestPodDisruptionScenarioPlugin.test_killing_pods_with_exclude_label) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.015s

OK 


```
