### PR TITLE
fix/service hijacking

### DIFF
--- a/.github/workflows/tests_v2.yml
+++ b/.github/workflows/tests_v2.yml
@@ -27,6 +27,8 @@ jobs:
           kind load docker-image nginx:alpine
           docker pull quay.io/krkn-chaos/krkn:tools
           kind load docker-image quay.io/krkn-chaos/krkn:tools
+          docker pull quay.io/krkn-chaos/krkn-service-hijacking:v0.1.3
+          kind load docker-image quay.io/krkn-chaos/krkn-service-hijacking:v0.1.3
 
       - name: Install Python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4

--- a/.github/workflows/tests_v2.yml
+++ b/.github/workflows/tests_v2.yml
@@ -33,6 +33,8 @@ jobs:
           kind load docker-image nginx:alpine
           docker pull quay.io/krkn-chaos/krkn:tools
           kind load docker-image quay.io/krkn-chaos/krkn:tools
+          docker pull quay.io/krkn-chaos/krkn-service-hijacking:v0.1.3
+          kind load docker-image quay.io/krkn-chaos/krkn-service-hijacking:v0.1.3
 
       - name: Install Python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4

--- a/CI/tests_v2/lib/utils.py
+++ b/CI/tests_v2/lib/utils.py
@@ -28,6 +28,7 @@ SCENARIO_EXECUTION_MARKERS = {
     "node_network_chaos": r"creating workload to inject network chaos in node|removing tc rules",
     "container_scenarios": r"Killing container .+ in pod",
     "namespace_deletion": r"Delete objects in selected namespace|Deleted all objects in namespace",
+    "service_hijacking": r"patching service:|service:.+successfully patched|selectors successfully restored",
 }
 
 # nodeid -> {"scenario", "pattern", "verified"}; consumed by conftest to build the

--- a/CI/tests_v2/pytest.ini
+++ b/CI/tests_v2/pytest.ini
@@ -17,6 +17,7 @@ markers =
     node_scenarios: marks a test as a node chaos scenario test (node reboot/stop-start)
     node_network_chaos: marks a test as a node network chaos scenario test
     namespace_deletion: marks a test as a namespace deletion (service_disruption) scenario test
+    service_hijacking: marks a test as a service_hijacking scenario test
     no_workload: skip workload deployment for this test (e.g. negative tests)
     order: set test order (pytest-order)
 junit_family = xunit2

--- a/CI/tests_v2/scenarios/service_hijacking/resource.yaml
+++ b/CI/tests_v2/scenarios/service_hijacking/resource.yaml
@@ -1,30 +1,60 @@
-# Nginx Pod + Service targeted by service hijacking scenario tests.
-# Namespace is patched at deploy time by the test framework.
-# Uses ClusterIP (no NodePort needed; v2 tests assert control-plane state, not HTTP traffic).
-apiVersion: v1
-kind: Pod
+# Nginx target workload plus three Services used by the service_hijacking tests.
+# Namespace is patched at deploy time by the test framework (see BaseScenarioTest).
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  name: nginx
-  labels:
-    app.kubernetes.io/name: proxy
+  name: nginx-hijack-target
 spec:
-  containers:
-  - name: nginx
-    image: nginx:stable
-    ports:
-      - containerPort: 80
-        name: http-web-svc
-
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-hijack-target
+      scenario: hijack
+  template:
+    metadata:
+      labels:
+        app: nginx-hijack-target
+        scenario: hijack
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - name: http-web-svc
+          containerPort: 80
 ---
+# Named-port Service (service_target_port: "http-web-svc" in scenario_base.yaml).
 apiVersion: v1
 kind: Service
 metadata:
   name: nginx-service
 spec:
   selector:
-    app.kubernetes.io/name: proxy
+    app: nginx-hijack-target
   ports:
-  - name: name-of-service-port
-    protocol: TCP
+  - name: http-web-svc
     port: 80
     targetPort: http-web-svc
+---
+# Same backend, exposed with a numeric targetPort for the numeric-port-targeting test.
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service-numeric
+spec:
+  selector:
+    app: nginx-hijack-target
+  ports:
+  - port: 80
+    targetPort: 80
+---
+# ExternalName services structurally reject a `spec.selector` patch (the Kubernetes API
+# rejects selector/ports/clusterIP on type=ExternalName), giving a deterministic way to
+# simulate "service patch failure" without relying on RBAC or races.
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service-unpatchable
+spec:
+  type: ExternalName
+  externalName: example.com

--- a/CI/tests_v2/scenarios/service_hijacking/resource.yaml
+++ b/CI/tests_v2/scenarios/service_hijacking/resource.yaml
@@ -1,0 +1,30 @@
+# Nginx Pod + Service targeted by service hijacking scenario tests.
+# Namespace is patched at deploy time by the test framework.
+# Uses ClusterIP (no NodePort needed; v2 tests assert control-plane state, not HTTP traffic).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: proxy
+spec:
+  containers:
+  - name: nginx
+    image: nginx:stable
+    ports:
+      - containerPort: 80
+        name: http-web-svc
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  selector:
+    app.kubernetes.io/name: proxy
+  ports:
+  - name: name-of-service-port
+    protocol: TCP
+    port: 80
+    targetPort: http-web-svc

--- a/CI/tests_v2/scenarios/service_hijacking/scenario_base.yaml
+++ b/CI/tests_v2/scenarios/service_hijacking/scenario_base.yaml
@@ -1,0 +1,19 @@
+# Base service_hijacking scenario. Tests load this and patch service_namespace.
+# Flat dict consumed directly by ServiceHijackingScenarioPlugin.run().
+service_target_port: 80
+service_name: nginx-service
+service_namespace: default
+image: quay.io/krkn-chaos/krkn-service-hijacking:v0.1.3
+chaos_duration: 15
+privileged: True
+plan:
+  - resource: "/health"
+    steps:
+      GET:
+        - duration: 15
+          status: 500
+          mime_type: "application/json"
+          payload: |
+            {
+              "status": "internal server error"
+            }

--- a/CI/tests_v2/scenarios/service_hijacking/scenario_base.yaml
+++ b/CI/tests_v2/scenarios/service_hijacking/scenario_base.yaml
@@ -1,19 +1,50 @@
-# Base service_hijacking scenario. Tests load this and patch service_namespace.
-# Flat dict consumed directly by ServiceHijackingScenarioPlugin.run().
-service_target_port: 80
+# Base service_hijacking scenario. Tests load this and patch service_namespace
+# (and optionally service_name, service_target_port, chaos_duration, plan -- these
+# are top-level keys, so overrides via load_and_patch_scenario(**overrides) apply directly).
+service_target_port: http-web-svc
 service_name: nginx-service
 service_namespace: default
 image: quay.io/krkn-chaos/krkn-service-hijacking:v0.1.3
-chaos_duration: 15
+chaos_duration: 12
 privileged: True
 plan:
-  - resource: "/health"
+  - resource: "/list/index.php"
     steps:
       GET:
-        - duration: 15
+        - duration: 6
           status: 500
           mime_type: "application/json"
           payload: |
             {
-              "status": "internal server error"
+              "status":"internal server error"
             }
+        - duration: 6
+          status: 201
+          mime_type: "application/json"
+          payload: |
+            {
+              "status":"resource created"
+            }
+      POST:
+        - duration: 6
+          status: 401
+          mime_type: "application/json"
+          payload: |
+            {
+              "status": "unauthorized"
+            }
+        - duration: 6
+          status: 404
+          mime_type: "text/plain"
+          payload: "not found"
+  - resource: "/patch"
+    steps:
+      PATCH:
+        - duration: 6
+          status: 201
+          mime_type: "text/plain"
+          payload: "resource patched"
+        - duration: 6
+          status: 400
+          mime_type: "text/plain"
+          payload: "bad request"

--- a/CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py
+++ b/CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py
@@ -1,347 +1,348 @@
 """
-Functional test for service hijacking scenario.
-Migrated from CI/tests/test_service_hijacking.sh with control-plane assertions.
-
-Each test runs in its own ephemeral namespace with an nginx Pod + Service deployed
-automatically.  Assertions are at the control-plane level (service selector patched /
-restored, hijacker pod deployed / cleaned up), NOT at the HTTP-response level.
+Functional test for the service hijacking scenario (patch a Service's selector to redirect
+traffic to a configurable webservice pod for a duration, then restore).
+Equivalent to CI/tests/test_service_hijacking.sh with proper assertions.
 """
 
-import copy
+import contextlib
 import logging
+import socket
+import subprocess
 import time
 
 import pytest
+import requests
+from kubernetes import client
 
-from lib.base import BaseScenarioTest
+from lib.base import BaseScenarioTest, KRAKEN_PROC_WAIT_TIMEOUT
 from lib.utils import (
     assert_kraken_failure,
     assert_kraken_success,
     assert_scenario_executed,
     list_pods_by_prefix,
-    load_scenario_base,
     wait_for_no_pods_by_prefix,
 )
 
 logger = logging.getLogger(__name__)
 
-# Prefix used by the service-hijacking plugin when deploying the hijacker pod.
-HIJACKER_POD_PREFIX = "krkn-service-hijacking"
+# krkn_lib.deploy_service_hijacking names the hijacker pod "service-hijacking-pod-<random5>".
+HIJACKER_POD_PREFIX = "service-hijacking-pod-"
+SELECTOR_WAIT_TIMEOUT = 30
+HTTP_RETRY_TIMEOUT = 10
 
 
-def _read_service_selector(k8s_core, name: str, namespace: str) -> dict:
-    """Return the current selector dict of a Service, or {} if not found."""
+def _free_port() -> int:
+    """Ask the OS for an unused local TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@contextlib.contextmanager
+def _service_port_forward(repo_root, namespace: str, service_name: str, service_port: int = 80):
+    """Port-forward a Service to a free local port; yields the local base URL."""
+    port = _free_port()
+    proc = subprocess.Popen(
+        ["kubectl", "port-forward", "-n", namespace, f"service/{service_name}", f"{port}:{service_port}"],
+        cwd=repo_root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
     try:
-        svc = k8s_core.read_namespaced_service(name=name, namespace=namespace)
-        return dict(svc.spec.selector or {})
-    except Exception:
-        return {}
+        time.sleep(2)  # let the forward come up before the first request
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
 
 
-def _wait_for_service_selector_change(
-    k8s_core, name: str, namespace: str, original_selector: dict, timeout: float = 60
-) -> dict:
-    """Poll until the service selector differs from *original_selector*.
-    Returns the new selector, or raises TimeoutError."""
-    deadline = time.monotonic() + timeout
+def _request_with_retry(method: str, url: str, timeout_total: float = HTTP_RETRY_TIMEOUT, **kwargs):
+    """Retry until the port-forward accepts connections, then return the response."""
+    deadline = time.monotonic() + timeout_total
+    last_exc = None
     while time.monotonic() < deadline:
-        current = _read_service_selector(k8s_core, name, namespace)
-        if current and current != original_selector:
+        try:
+            return requests.request(method, url, timeout=3, **kwargs)
+        except (requests.ConnectionError, requests.Timeout) as e:
+            last_exc = e
+            time.sleep(0.5)
+    raise AssertionError(f"HTTP {method} {url} did not connect within {timeout_total}s: {last_exc}")
+
+
+def _get_selector(k8s_core, namespace: str, service_name: str) -> dict:
+    svc = k8s_core.read_namespaced_service(name=service_name, namespace=namespace)
+    return dict(svc.spec.selector or {})
+
+
+def _wait_for_selector_change(k8s_core, namespace: str, service_name: str, original: dict,
+                               timeout: int = SELECTOR_WAIT_TIMEOUT) -> dict:
+    """Poll until the Service selector differs from `original`. Return the new selector."""
+    deadline = time.monotonic() + timeout
+    current = original
+    while time.monotonic() < deadline:
+        current = _get_selector(k8s_core, namespace, service_name)
+        if current != original:
             return current
         time.sleep(1)
     raise TimeoutError(
-        f"Service {namespace}/{name} selector did not change from "
-        f"{original_selector!r} within {timeout}s"
+        f"Service {namespace}/{service_name} selector did not change from {original} within {timeout}s"
+    )
+
+
+def _wait_for_selector_restored(k8s_core, namespace: str, service_name: str, original: dict,
+                                 timeout: int = SELECTOR_WAIT_TIMEOUT) -> None:
+    """Poll until the Service selector matches `original` again."""
+    deadline = time.monotonic() + timeout
+    current = None
+    while time.monotonic() < deadline:
+        current = _get_selector(k8s_core, namespace, service_name)
+        if current == original:
+            return
+        time.sleep(1)
+    raise TimeoutError(
+        f"Service {namespace}/{service_name} selector did not restore to {original} within {timeout}s "
+        f"(last={current})"
     )
 
 
 @pytest.mark.functional
 @pytest.mark.service_hijacking
 class TestServiceHijacking(BaseScenarioTest):
-    """Service hijacking scenario: patch service selector, redirect traffic, restore."""
+    """Service hijacking scenario: patch a Service selector to a hijacker webservice, then restore."""
 
     WORKLOAD_MANIFEST = "CI/tests_v2/scenarios/service_hijacking/resource.yaml"
     WORKLOAD_IS_PATH = True
-    # The resource.yaml deploys a bare Pod (not a Deployment), so we match its label.
-    LABEL_SELECTOR = "app.kubernetes.io/name=proxy"
+    LABEL_SELECTOR = "scenario=hijack"
     SCENARIO_NAME = "service_hijacking"
     SCENARIO_TYPE = "service_hijacking_scenarios"
-    # Flat YAML: namespace lives at top-level "service_namespace", handled by override below.
-    NAMESPACE_KEY_PATH = []
+    NAMESPACE_KEY_PATH = ["service_namespace"]
     NAMESPACE_IS_REGEX = False
+    OVERRIDES_KEY_PATH = []  # scenario fields are top-level; overrides patch them directly
 
-    # ── Override base helpers for the flat YAML structure ──────────────────
-
-    def load_and_patch_scenario(self, repo_root, namespace, **overrides):
-        """Load scenario_base.yaml and patch ``service_namespace`` (flat dict, not nested)."""
-        scenario = copy.deepcopy(load_scenario_base(repo_root, self.SCENARIO_NAME))
-        scenario["service_namespace"] = namespace
-        for key, value in overrides.items():
-            scenario[key] = value
-        return scenario
-
-    # ── Happy-path tests ──────────────────────────────────────────────────
+    SERVICE_NAME = "nginx-service"
+    SERVICE_NAME_NUMERIC = "nginx-service-numeric"
+    SERVICE_NAME_UNPATCHABLE = "nginx-service-unpatchable"
 
     @pytest.mark.order(1)
-    def test_service_hijack_single_step(self):
-        """TC-1: Service hijack with single GET step.
-
-        Verify: Krkn exits 0, service selector is patched to point to
-        hijacker pod, original selector is restored after chaos, hijacker
-        pod is cleaned up.
-        """
+    def test_hijack_plan_steps_and_restore(self):
+        """Rows 1-3, 6, 7: selector is patched, GET/POST on /list/index.php and PATCH on /patch
+        return each step's configured status/payload/MIME, then the original selector is
+        restored and the hijacker pod is undeployed."""
         ns = self.ns
-        original_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
-        assert original_selector, f"nginx-service not found in namespace={ns}"
+        original_selector = _get_selector(self.k8s_core, ns, self.SERVICE_NAME)
 
-        result = self.run_scenario(self.tmp_path, ns)
+        scenario = self.load_and_patch_scenario(self.repo_root, ns, chaos_duration=12)
+        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_plan")
+        config_path = self.build_config(
+            self.SCENARIO_TYPE, str(scenario_path), filename="hijack_plan_config.yaml"
+        )
+        proc = self.run_kraken_background(config_path)
+        try:
+            hijacked_selector = _wait_for_selector_change(self.k8s_core, ns, self.SERVICE_NAME, original_selector)
+            assert hijacked_selector, f"Expected a new selector after hijack (namespace={ns})"
+
+            with _service_port_forward(self.repo_root, ns, self.SERVICE_NAME) as base_url:
+                # Step 1 window (~0-6s).
+                resp = _request_with_retry("GET", f"{base_url}/list/index.php")
+                assert resp.status_code == 500, f"Step 1 GET status (namespace={ns}): {resp.status_code}"
+                assert resp.json() == {"status": "internal server error"}, f"Step 1 GET payload (namespace={ns})"
+                assert resp.headers.get("content-type", "").startswith("application/json"), (
+                    f"Step 1 GET MIME (namespace={ns}): {resp.headers.get('content-type')}"
+                )
+
+                resp = _request_with_retry("POST", f"{base_url}/list/index.php")
+                assert resp.status_code == 401, f"Step 1 POST status (namespace={ns}): {resp.status_code}"
+                assert resp.json() == {"status": "unauthorized"}, f"Step 1 POST payload (namespace={ns})"
+
+                resp = _request_with_retry("PATCH", f"{base_url}/patch")
+                assert resp.status_code == 201, f"Step 1 PATCH status (namespace={ns}): {resp.status_code}"
+                assert resp.text.strip() == "resource patched", f"Step 1 PATCH payload (namespace={ns})"
+
+                # Cross into step 2's window.
+                time.sleep(7)
+
+                resp = _request_with_retry("GET", f"{base_url}/list/index.php")
+                assert resp.status_code == 201, f"Step 2 GET status (namespace={ns}): {resp.status_code}"
+                assert resp.json() == {"status": "resource created"}, f"Step 2 GET payload (namespace={ns})"
+
+                resp = _request_with_retry("POST", f"{base_url}/list/index.php")
+                assert resp.status_code == 404, f"Step 2 POST status (namespace={ns}): {resp.status_code}"
+                assert resp.text.strip() == "not found", f"Step 2 POST payload (namespace={ns})"
+
+                resp = _request_with_retry("PATCH", f"{base_url}/patch")
+                assert resp.status_code == 400, f"Step 2 PATCH status (namespace={ns}): {resp.status_code}"
+                assert resp.text.strip() == "bad request", f"Step 2 PATCH payload (namespace={ns})"
+
+            proc.wait(timeout=KRAKEN_PROC_WAIT_TIMEOUT)
+            stdout = proc.stdout.read() if proc.stdout else ""
+            stderr = proc.stderr.read() if proc.stderr else ""
+        except Exception:
+            if proc.poll() is None:
+                proc.terminate()
+            raise
+        result = subprocess.CompletedProcess(proc.args, proc.returncode, stdout, stderr)
         assert_kraken_success(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
-        assert_scenario_executed(
-            result, self.SCENARIO_NAME, context=f"namespace={ns}", tmp_path=self.tmp_path
-        )
+        assert_scenario_executed(result, self.SCENARIO_NAME, context=f"namespace={ns}", tmp_path=self.tmp_path)
 
-        # After scenario completes: selector should be restored.
-        restored_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
-        assert restored_selector == original_selector, (
-            f"Service selector not restored: expected {original_selector}, "
-            f"got {restored_selector} (namespace={ns})"
-        )
+        # Row 6: original selector restored.
+        _wait_for_selector_restored(self.k8s_core, ns, self.SERVICE_NAME, original_selector)
+        # Row 7: hijacker pod undeployed.
+        wait_for_no_pods_by_prefix(self.k8s_core, ns, HIJACKER_POD_PREFIX, timeout=30)
 
-        # Hijacker pod should be gone.
-        hijacker_pods = list_pods_by_prefix(self.k8s_core, ns, HIJACKER_POD_PREFIX)
-        assert len(hijacker_pods) == 0, (
-            f"Hijacker pod(s) still present after scenario: "
-            f"{[p.metadata.name for p in hijacker_pods]} (namespace={ns})"
-        )
-
-    def test_multi_step_plan(self):
-        """TC-2: Multi-step plan (time-based transitions).
-
-        Verify: plan with 2 GET steps completes, Krkn exits 0.
-        """
-        ns = self.ns
-        multi_step_plan = [
+    def _single_step_scenario(self, ns: str, service_name: str, service_target_port, chaos_duration: int = 6):
+        """Build a minimal one-resource/one-step plan for the port-targeting tests."""
+        scenario = self.load_and_patch_scenario(self.repo_root, ns, chaos_duration=chaos_duration)
+        scenario["service_name"] = service_name
+        scenario["service_target_port"] = service_target_port
+        scenario["plan"] = [
             {
-                "resource": "/health",
+                "resource": "/list/index.php",
                 "steps": {
                     "GET": [
-                        {"duration": 8, "status": 500, "mime_type": "application/json",
-                         "payload": '{"status":"internal server error"}'},
-                        {"duration": 8, "status": 201, "mime_type": "application/json",
-                         "payload": '{"status":"resource created"}'},
+                        {
+                            "duration": chaos_duration,
+                            "status": 200,
+                            "mime_type": "text/plain",
+                            "payload": "ok",
+                        }
                     ]
                 },
             }
         ]
-        result = self.run_scenario(
-            self.tmp_path, ns,
-            overrides={"plan": multi_step_plan, "chaos_duration": 16},
-            config_filename="multi_step_config.yaml",
-        )
-        assert_kraken_success(result, context=f"multi-step namespace={ns}", tmp_path=self.tmp_path)
-
-    def test_multiple_http_methods(self):
-        """TC-3: Multiple HTTP methods (GET + POST).
-
-        Verify: plan with both GET and POST methods defined completes, Krkn exits 0.
-        """
-        ns = self.ns
-        multi_method_plan = [
-            {
-                "resource": "/api",
-                "steps": {
-                    "GET": [
-                        {"duration": 15, "status": 200, "mime_type": "application/json",
-                         "payload": '{"method":"get"}'},
-                    ],
-                    "POST": [
-                        {"duration": 15, "status": 201, "mime_type": "application/json",
-                         "payload": '{"method":"post"}'},
-                    ],
-                },
-            }
-        ]
-        result = self.run_scenario(
-            self.tmp_path, ns,
-            overrides={"plan": multi_method_plan},
-            config_filename="multi_method_config.yaml",
-        )
-        assert_kraken_success(
-            result, context=f"multi-method namespace={ns}", tmp_path=self.tmp_path
-        )
+        return scenario
 
     def test_named_port_targeting(self):
-        """TC-4: Named port targeting.
-
-        Verify: service_target_port as a string (named port) works correctly.
-        """
+        """Row 4: service_target_port as a named port ("http-web-svc") routes traffic correctly."""
         ns = self.ns
-        result = self.run_scenario(
-            self.tmp_path, ns,
-            overrides={"service_target_port": "http-web-svc"},
-            config_filename="named_port_config.yaml",
+        scenario = self._single_step_scenario(ns, self.SERVICE_NAME, "http-web-svc")
+        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_named_port")
+        config_path = self.build_config(
+            self.SCENARIO_TYPE, str(scenario_path), filename="hijack_named_port_config.yaml"
         )
-        assert_kraken_success(
-            result, context=f"named-port namespace={ns}", tmp_path=self.tmp_path
-        )
+        original_selector = _get_selector(self.k8s_core, ns, self.SERVICE_NAME)
+        proc = self.run_kraken_background(config_path)
+        try:
+            _wait_for_selector_change(self.k8s_core, ns, self.SERVICE_NAME, original_selector)
+            with _service_port_forward(self.repo_root, ns, self.SERVICE_NAME) as base_url:
+                resp = _request_with_retry("GET", f"{base_url}/list/index.php")
+                assert resp.status_code == 200 and resp.text.strip() == "ok", (
+                    f"Named-port hijack response (namespace={ns}): {resp.status_code} {resp.text!r}"
+                )
+        finally:
+            proc.wait(timeout=KRAKEN_PROC_WAIT_TIMEOUT)
+        assert proc.returncode == 0, f"Kraken exited {proc.returncode} (namespace={ns})"
 
     def test_numeric_port_targeting(self):
-        """TC-5: Numeric port targeting.
-
-        Verify: service_target_port as an integer works correctly.
-        """
+        """Row 5: service_target_port as an integer (80) routes traffic correctly."""
         ns = self.ns
-        result = self.run_scenario(
-            self.tmp_path, ns,
-            overrides={"service_target_port": 80},
-            config_filename="numeric_port_config.yaml",
+        scenario = self._single_step_scenario(ns, self.SERVICE_NAME_NUMERIC, 80)
+        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_numeric_port")
+        config_path = self.build_config(
+            self.SCENARIO_TYPE, str(scenario_path), filename="hijack_numeric_port_config.yaml"
         )
-        assert_kraken_success(
-            result, context=f"numeric-port namespace={ns}", tmp_path=self.tmp_path
-        )
+        original_selector = _get_selector(self.k8s_core, ns, self.SERVICE_NAME_NUMERIC)
+        proc = self.run_kraken_background(config_path)
+        try:
+            _wait_for_selector_change(self.k8s_core, ns, self.SERVICE_NAME_NUMERIC, original_selector)
+            with _service_port_forward(self.repo_root, ns, self.SERVICE_NAME_NUMERIC) as base_url:
+                resp = _request_with_retry("GET", f"{base_url}/list/index.php")
+                assert resp.status_code == 200 and resp.text.strip() == "ok", (
+                    f"Numeric-port hijack response (namespace={ns}): {resp.status_code} {resp.text!r}"
+                )
+        finally:
+            proc.wait(timeout=KRAKEN_PROC_WAIT_TIMEOUT)
+        assert proc.returncode == 0, f"Kraken exited {proc.returncode} (namespace={ns})"
 
-    def test_service_restoration(self):
-        """TC-6: Service restoration after chaos_duration.
-
-        Verify: original service selectors match after scenario completes.
-        """
+    def test_rollback_on_interruption(self):
+        """Row 11: interrupting a running scenario leaves rollback state on disk; `execute-rollback`
+        restores the original selector and removes the hijacker pod."""
         ns = self.ns
-        original_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
-        assert original_selector, f"nginx-service not found in namespace={ns}"
-
-        result = self.run_scenario(self.tmp_path, ns, config_filename="restore_config.yaml")
-        assert_kraken_success(result, context=f"restore namespace={ns}", tmp_path=self.tmp_path)
-
-        restored_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
-        assert restored_selector == original_selector, (
-            f"Service selector mismatch after restoration: "
-            f"expected {original_selector}, got {restored_selector} (namespace={ns})"
+        original_selector = _get_selector(self.k8s_core, ns, self.SERVICE_NAME)
+        scenario = self.load_and_patch_scenario(self.repo_root, ns, chaos_duration=60)
+        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_rollback")
+        config_path = self.build_config(
+            self.SCENARIO_TYPE, str(scenario_path), filename="hijack_rollback_config.yaml"
         )
+        proc = self.run_kraken_background(config_path)
 
-    def test_hijacker_pod_cleanup(self):
-        """TC-7: Hijacker pod cleanup.
+        # Drain stdout/stderr in background threads to prevent OS pipe buffer
+        # deadlock (~64 KiB limit) during the long selector-change wait.
+        import threading
+        def _drain(stream):
+            try:
+                for _ in stream:
+                    pass
+            except Exception:
+                pass
+        threading.Thread(target=_drain, args=(proc.stdout,), daemon=True).start()
+        threading.Thread(target=_drain, args=(proc.stderr,), daemon=True).start()
 
-        Verify: no krkn-service-hijacking pods remain in namespace after scenario.
-        """
-        ns = self.ns
-        result = self.run_scenario(self.tmp_path, ns, config_filename="cleanup_config.yaml")
-        assert_kraken_success(result, context=f"cleanup namespace={ns}", tmp_path=self.tmp_path)
+        try:
+            _wait_for_selector_change(self.k8s_core, ns, self.SERVICE_NAME, original_selector)
+            hijacker_pods = list_pods_by_prefix(self.k8s_core, ns, HIJACKER_POD_PREFIX)
+            assert hijacker_pods, f"Expected a hijacker pod before interruption (namespace={ns})"
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=KRAKEN_PROC_WAIT_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=KRAKEN_PROC_WAIT_TIMEOUT)
 
-        # Allow a brief settling window, then assert no hijacker pods.
+        rollback_result = self.run_kraken(config_path, extra_args=["execute-rollback"])
+        assert rollback_result.returncode == 0, (
+            f"execute-rollback failed (namespace={ns}): {rollback_result.stderr}"
+        )
+        _wait_for_selector_restored(self.k8s_core, ns, self.SERVICE_NAME, original_selector)
         wait_for_no_pods_by_prefix(self.k8s_core, ns, HIJACKER_POD_PREFIX, timeout=30)
-
-    # ── Negative / failure-mode tests ─────────────────────────────────────
 
     @pytest.mark.no_workload
     def test_nonexistent_service_fails(self):
-        """TC-8: Non-existent service.
-
-        Verify: Krkn exits 1 with error when targeting a service that doesn't exist.
-        """
+        """Row 8: targeting a Service that doesn't exist causes Kraken to exit non-zero."""
         ns = self.ns
-        result = self.run_scenario(
-            self.tmp_path, ns,
-            overrides={"service_name": "nonexistent-svc"},
-            config_filename="nonexistent_svc_config.yaml",
+        scenario = self.load_and_patch_scenario(self.repo_root, ns, chaos_duration=3)
+        scenario["service_name"] = "nonexistent-svc"
+        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_missing_svc")
+        config_path = self.build_config(
+            self.SCENARIO_TYPE, str(scenario_path), filename="hijack_missing_svc_config.yaml"
         )
-        assert_kraken_failure(
-            result, context=f"nonexistent-svc namespace={ns}", tmp_path=self.tmp_path
+        result = self.run_kraken(config_path)
+        assert_kraken_failure(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
+        combined = f"{result.stdout or ''}\n{result.stderr or ''}"
+        assert "not found in namespace" in combined, (
+            f"Expected 'not found in namespace' in Krkn output (namespace={ns})"
         )
 
     @pytest.mark.no_workload
     def test_nonexistent_namespace_fails(self):
-        """TC-9: Non-existent namespace.
-
-        Verify: Krkn exits 1 when namespace doesn't exist.
-        """
-        ns = self.ns
-        result = self.run_scenario(
-            self.tmp_path, ns,
-            overrides={"service_namespace": "fake-ns"},
-            config_filename="nonexistent_ns_config.yaml",
+        """Row 9: targeting a namespace that doesn't exist causes Kraken to exit non-zero."""
+        scenario = self.load_and_patch_scenario(self.repo_root, "nonexistent-namespace-xyz-12345", chaos_duration=3)
+        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_bad_ns")
+        config_path = self.build_config(
+            self.SCENARIO_TYPE, str(scenario_path), filename="hijack_bad_ns_config.yaml"
         )
-        assert_kraken_failure(
-            result, context=f"fake-ns namespace={ns}", tmp_path=self.tmp_path
-        )
+        result = self.run_kraken(config_path)
+        assert_kraken_failure(result, context=f"test namespace={self.ns}", tmp_path=self.tmp_path)
 
     @pytest.mark.no_workload
     def test_service_patch_failure(self):
-        """TC-10: Service patch failure.
-
-        Verify: Krkn exits 1 when the target service exists but selector
-        replacement fails. Simulated by targeting a service whose name matches
-        but that lives in a namespace where no service is deployed (the test
-        namespace has no workload because of no_workload marker, so
-        nginx-service does not exist there).
-        """
+        """Row 10: an ExternalName Service structurally rejects a selector patch (the API server
+        forbids spec.selector when type=ExternalName), simulating a service that can't be patched."""
         ns = self.ns
-        # The test namespace is empty (no_workload), so nginx-service does not exist.
-        # This exercises the "service not found" code path in the plugin.
-        result = self.run_scenario(
-            self.tmp_path, ns,
-            config_filename="patch_failure_config.yaml",
+        body = client.V1Service(
+            metadata=client.V1ObjectMeta(name=self.SERVICE_NAME_UNPATCHABLE),
+            spec=client.V1ServiceSpec(type="ExternalName", external_name="example.com"),
         )
-        assert_kraken_failure(
-            result, context=f"patch-failure namespace={ns}", tmp_path=self.tmp_path
-        )
+        self.k8s_core.create_namespaced_service(namespace=ns, body=body)
 
-    # ── Rollback verification ─────────────────────────────────────────────
-
-    def test_rollback_on_interruption(self):
-        """TC-11: Rollback on interruption.
-
-        Verify: if the scenario is interrupted (SIGTERM), the rollback
-        handler restores original selectors and deletes the hijacker pod.
-        """
-        import signal
-
-        ns = self.ns
-        original_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
-        assert original_selector, f"nginx-service not found in namespace={ns}"
-
-        # Use a long chaos_duration so we have time to interrupt.
-        scenario = self.load_and_patch_scenario(
-            self.repo_root, ns, chaos_duration=120
-        )
-        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_rollback")
+        scenario = self.load_and_patch_scenario(self.repo_root, ns, chaos_duration=3)
+        scenario["service_name"] = self.SERVICE_NAME_UNPATCHABLE
+        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_unpatchable")
         config_path = self.build_config(
-            self.SCENARIO_TYPE, str(scenario_path),
-            filename="rollback_config.yaml",
+            self.SCENARIO_TYPE, str(scenario_path), filename="hijack_unpatchable_config.yaml"
         )
-        proc = self.run_kraken_background(config_path)
-        try:
-            # Wait for the hijack to take effect (selector changes).
-            _wait_for_service_selector_change(
-                self.k8s_core, "nginx-service", ns, original_selector, timeout=90
-            )
-            logger.info("Hijack detected in namespace=%s, sending SIGTERM", ns)
-            # Interrupt Krkn; rollback handler should fire.
-            proc.send_signal(signal.SIGTERM)
-            proc.wait(timeout=60)
-        except Exception:
-            # Kill the process if anything goes wrong.
-            proc.kill()
-            proc.wait(timeout=10)
-            raise
-        finally:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait(timeout=10)
-
-        # Give rollback handler time to restore.
-        time.sleep(5)
-
-        # Verify service selector was restored by the rollback handler.
-        restored_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
-        assert restored_selector == original_selector, (
-            f"Rollback failed: service selector not restored after interruption. "
-            f"Expected {original_selector}, got {restored_selector} (namespace={ns})"
-        )
-
-        # Verify hijacker pod was cleaned up by rollback handler.
-        hijacker_pods = list_pods_by_prefix(self.k8s_core, ns, HIJACKER_POD_PREFIX)
-        assert len(hijacker_pods) == 0, (
-            f"Rollback failed: hijacker pod(s) still present after interruption: "
-            f"{[p.metadata.name for p in hijacker_pods]} (namespace={ns})"
-        )
-
+        result = self.run_kraken(config_path)
+        assert_kraken_failure(result, context=f"namespace={ns}", tmp_path=self.tmp_path)

--- a/CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py
+++ b/CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py
@@ -1,0 +1,347 @@
+"""
+Functional test for service hijacking scenario.
+Migrated from CI/tests/test_service_hijacking.sh with control-plane assertions.
+
+Each test runs in its own ephemeral namespace with an nginx Pod + Service deployed
+automatically.  Assertions are at the control-plane level (service selector patched /
+restored, hijacker pod deployed / cleaned up), NOT at the HTTP-response level.
+"""
+
+import copy
+import logging
+import time
+
+import pytest
+
+from lib.base import BaseScenarioTest
+from lib.utils import (
+    assert_kraken_failure,
+    assert_kraken_success,
+    assert_scenario_executed,
+    list_pods_by_prefix,
+    load_scenario_base,
+    wait_for_no_pods_by_prefix,
+)
+
+logger = logging.getLogger(__name__)
+
+# Prefix used by the service-hijacking plugin when deploying the hijacker pod.
+HIJACKER_POD_PREFIX = "krkn-service-hijacking"
+
+
+def _read_service_selector(k8s_core, name: str, namespace: str) -> dict:
+    """Return the current selector dict of a Service, or {} if not found."""
+    try:
+        svc = k8s_core.read_namespaced_service(name=name, namespace=namespace)
+        return dict(svc.spec.selector or {})
+    except Exception:
+        return {}
+
+
+def _wait_for_service_selector_change(
+    k8s_core, name: str, namespace: str, original_selector: dict, timeout: float = 60
+) -> dict:
+    """Poll until the service selector differs from *original_selector*.
+    Returns the new selector, or raises TimeoutError."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        current = _read_service_selector(k8s_core, name, namespace)
+        if current and current != original_selector:
+            return current
+        time.sleep(1)
+    raise TimeoutError(
+        f"Service {namespace}/{name} selector did not change from "
+        f"{original_selector!r} within {timeout}s"
+    )
+
+
+@pytest.mark.functional
+@pytest.mark.service_hijacking
+class TestServiceHijacking(BaseScenarioTest):
+    """Service hijacking scenario: patch service selector, redirect traffic, restore."""
+
+    WORKLOAD_MANIFEST = "CI/tests_v2/scenarios/service_hijacking/resource.yaml"
+    WORKLOAD_IS_PATH = True
+    # The resource.yaml deploys a bare Pod (not a Deployment), so we match its label.
+    LABEL_SELECTOR = "app.kubernetes.io/name=proxy"
+    SCENARIO_NAME = "service_hijacking"
+    SCENARIO_TYPE = "service_hijacking_scenarios"
+    # Flat YAML: namespace lives at top-level "service_namespace", handled by override below.
+    NAMESPACE_KEY_PATH = []
+    NAMESPACE_IS_REGEX = False
+
+    # ── Override base helpers for the flat YAML structure ──────────────────
+
+    def load_and_patch_scenario(self, repo_root, namespace, **overrides):
+        """Load scenario_base.yaml and patch ``service_namespace`` (flat dict, not nested)."""
+        scenario = copy.deepcopy(load_scenario_base(repo_root, self.SCENARIO_NAME))
+        scenario["service_namespace"] = namespace
+        for key, value in overrides.items():
+            scenario[key] = value
+        return scenario
+
+    # ── Happy-path tests ──────────────────────────────────────────────────
+
+    @pytest.mark.order(1)
+    def test_service_hijack_single_step(self):
+        """TC-1: Service hijack with single GET step.
+
+        Verify: Krkn exits 0, service selector is patched to point to
+        hijacker pod, original selector is restored after chaos, hijacker
+        pod is cleaned up.
+        """
+        ns = self.ns
+        original_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
+        assert original_selector, f"nginx-service not found in namespace={ns}"
+
+        result = self.run_scenario(self.tmp_path, ns)
+        assert_kraken_success(result, context=f"namespace={ns}", tmp_path=self.tmp_path)
+        assert_scenario_executed(
+            result, self.SCENARIO_NAME, context=f"namespace={ns}", tmp_path=self.tmp_path
+        )
+
+        # After scenario completes: selector should be restored.
+        restored_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
+        assert restored_selector == original_selector, (
+            f"Service selector not restored: expected {original_selector}, "
+            f"got {restored_selector} (namespace={ns})"
+        )
+
+        # Hijacker pod should be gone.
+        hijacker_pods = list_pods_by_prefix(self.k8s_core, ns, HIJACKER_POD_PREFIX)
+        assert len(hijacker_pods) == 0, (
+            f"Hijacker pod(s) still present after scenario: "
+            f"{[p.metadata.name for p in hijacker_pods]} (namespace={ns})"
+        )
+
+    def test_multi_step_plan(self):
+        """TC-2: Multi-step plan (time-based transitions).
+
+        Verify: plan with 2 GET steps completes, Krkn exits 0.
+        """
+        ns = self.ns
+        multi_step_plan = [
+            {
+                "resource": "/health",
+                "steps": {
+                    "GET": [
+                        {"duration": 8, "status": 500, "mime_type": "application/json",
+                         "payload": '{"status":"internal server error"}'},
+                        {"duration": 8, "status": 201, "mime_type": "application/json",
+                         "payload": '{"status":"resource created"}'},
+                    ]
+                },
+            }
+        ]
+        result = self.run_scenario(
+            self.tmp_path, ns,
+            overrides={"plan": multi_step_plan, "chaos_duration": 16},
+            config_filename="multi_step_config.yaml",
+        )
+        assert_kraken_success(result, context=f"multi-step namespace={ns}", tmp_path=self.tmp_path)
+
+    def test_multiple_http_methods(self):
+        """TC-3: Multiple HTTP methods (GET + POST).
+
+        Verify: plan with both GET and POST methods defined completes, Krkn exits 0.
+        """
+        ns = self.ns
+        multi_method_plan = [
+            {
+                "resource": "/api",
+                "steps": {
+                    "GET": [
+                        {"duration": 15, "status": 200, "mime_type": "application/json",
+                         "payload": '{"method":"get"}'},
+                    ],
+                    "POST": [
+                        {"duration": 15, "status": 201, "mime_type": "application/json",
+                         "payload": '{"method":"post"}'},
+                    ],
+                },
+            }
+        ]
+        result = self.run_scenario(
+            self.tmp_path, ns,
+            overrides={"plan": multi_method_plan},
+            config_filename="multi_method_config.yaml",
+        )
+        assert_kraken_success(
+            result, context=f"multi-method namespace={ns}", tmp_path=self.tmp_path
+        )
+
+    def test_named_port_targeting(self):
+        """TC-4: Named port targeting.
+
+        Verify: service_target_port as a string (named port) works correctly.
+        """
+        ns = self.ns
+        result = self.run_scenario(
+            self.tmp_path, ns,
+            overrides={"service_target_port": "http-web-svc"},
+            config_filename="named_port_config.yaml",
+        )
+        assert_kraken_success(
+            result, context=f"named-port namespace={ns}", tmp_path=self.tmp_path
+        )
+
+    def test_numeric_port_targeting(self):
+        """TC-5: Numeric port targeting.
+
+        Verify: service_target_port as an integer works correctly.
+        """
+        ns = self.ns
+        result = self.run_scenario(
+            self.tmp_path, ns,
+            overrides={"service_target_port": 80},
+            config_filename="numeric_port_config.yaml",
+        )
+        assert_kraken_success(
+            result, context=f"numeric-port namespace={ns}", tmp_path=self.tmp_path
+        )
+
+    def test_service_restoration(self):
+        """TC-6: Service restoration after chaos_duration.
+
+        Verify: original service selectors match after scenario completes.
+        """
+        ns = self.ns
+        original_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
+        assert original_selector, f"nginx-service not found in namespace={ns}"
+
+        result = self.run_scenario(self.tmp_path, ns, config_filename="restore_config.yaml")
+        assert_kraken_success(result, context=f"restore namespace={ns}", tmp_path=self.tmp_path)
+
+        restored_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
+        assert restored_selector == original_selector, (
+            f"Service selector mismatch after restoration: "
+            f"expected {original_selector}, got {restored_selector} (namespace={ns})"
+        )
+
+    def test_hijacker_pod_cleanup(self):
+        """TC-7: Hijacker pod cleanup.
+
+        Verify: no krkn-service-hijacking pods remain in namespace after scenario.
+        """
+        ns = self.ns
+        result = self.run_scenario(self.tmp_path, ns, config_filename="cleanup_config.yaml")
+        assert_kraken_success(result, context=f"cleanup namespace={ns}", tmp_path=self.tmp_path)
+
+        # Allow a brief settling window, then assert no hijacker pods.
+        wait_for_no_pods_by_prefix(self.k8s_core, ns, HIJACKER_POD_PREFIX, timeout=30)
+
+    # ── Negative / failure-mode tests ─────────────────────────────────────
+
+    @pytest.mark.no_workload
+    def test_nonexistent_service_fails(self):
+        """TC-8: Non-existent service.
+
+        Verify: Krkn exits 1 with error when targeting a service that doesn't exist.
+        """
+        ns = self.ns
+        result = self.run_scenario(
+            self.tmp_path, ns,
+            overrides={"service_name": "nonexistent-svc"},
+            config_filename="nonexistent_svc_config.yaml",
+        )
+        assert_kraken_failure(
+            result, context=f"nonexistent-svc namespace={ns}", tmp_path=self.tmp_path
+        )
+
+    @pytest.mark.no_workload
+    def test_nonexistent_namespace_fails(self):
+        """TC-9: Non-existent namespace.
+
+        Verify: Krkn exits 1 when namespace doesn't exist.
+        """
+        ns = self.ns
+        result = self.run_scenario(
+            self.tmp_path, ns,
+            overrides={"service_namespace": "fake-ns"},
+            config_filename="nonexistent_ns_config.yaml",
+        )
+        assert_kraken_failure(
+            result, context=f"fake-ns namespace={ns}", tmp_path=self.tmp_path
+        )
+
+    @pytest.mark.no_workload
+    def test_service_patch_failure(self):
+        """TC-10: Service patch failure.
+
+        Verify: Krkn exits 1 when the target service exists but selector
+        replacement fails. Simulated by targeting a service whose name matches
+        but that lives in a namespace where no service is deployed (the test
+        namespace has no workload because of no_workload marker, so
+        nginx-service does not exist there).
+        """
+        ns = self.ns
+        # The test namespace is empty (no_workload), so nginx-service does not exist.
+        # This exercises the "service not found" code path in the plugin.
+        result = self.run_scenario(
+            self.tmp_path, ns,
+            config_filename="patch_failure_config.yaml",
+        )
+        assert_kraken_failure(
+            result, context=f"patch-failure namespace={ns}", tmp_path=self.tmp_path
+        )
+
+    # ── Rollback verification ─────────────────────────────────────────────
+
+    def test_rollback_on_interruption(self):
+        """TC-11: Rollback on interruption.
+
+        Verify: if the scenario is interrupted (SIGTERM), the rollback
+        handler restores original selectors and deletes the hijacker pod.
+        """
+        import signal
+
+        ns = self.ns
+        original_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
+        assert original_selector, f"nginx-service not found in namespace={ns}"
+
+        # Use a long chaos_duration so we have time to interrupt.
+        scenario = self.load_and_patch_scenario(
+            self.repo_root, ns, chaos_duration=120
+        )
+        scenario_path = self.write_scenario(self.tmp_path, scenario, suffix="_rollback")
+        config_path = self.build_config(
+            self.SCENARIO_TYPE, str(scenario_path),
+            filename="rollback_config.yaml",
+        )
+        proc = self.run_kraken_background(config_path)
+        try:
+            # Wait for the hijack to take effect (selector changes).
+            _wait_for_service_selector_change(
+                self.k8s_core, "nginx-service", ns, original_selector, timeout=90
+            )
+            logger.info("Hijack detected in namespace=%s, sending SIGTERM", ns)
+            # Interrupt Krkn; rollback handler should fire.
+            proc.send_signal(signal.SIGTERM)
+            proc.wait(timeout=60)
+        except Exception:
+            # Kill the process if anything goes wrong.
+            proc.kill()
+            proc.wait(timeout=10)
+            raise
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10)
+
+        # Give rollback handler time to restore.
+        time.sleep(5)
+
+        # Verify service selector was restored by the rollback handler.
+        restored_selector = _read_service_selector(self.k8s_core, "nginx-service", ns)
+        assert restored_selector == original_selector, (
+            f"Rollback failed: service selector not restored after interruption. "
+            f"Expected {original_selector}, got {restored_selector} (namespace={ns})"
+        )
+
+        # Verify hijacker pod was cleaned up by rollback handler.
+        hijacker_pods = list_pods_by_prefix(self.k8s_core, ns, HIJACKER_POD_PREFIX)
+        assert len(hijacker_pods) == 0, (
+            f"Rollback failed: hijacker pod(s) still present after interruption: "
+            f"{[p.metadata.name for p in hijacker_pods]} (namespace={ns})"
+        )
+


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Migrates the `service_hijacking` scenario to the v2 pytest functional test framework (`CI/tests_v2`).

This adds 7 test cases covering:
-  Happy-path service hijacking
- Named port targeting
- Numeric port targeting
- Rollback behavior on interruption
- Negative/failure scenarios
- Service patch failure handling

Additionally, this updates the CI workflow to pre-load the service-hijacking container image into KinD.

## Related Tickets & Documents

Related Issue #: 

Closes #1436 

## Documentation

- [ ] Documentation is needed for this update

## Checklist before requesting a review

- [x] I have performed a self-review of my code by running krkn and the specific scenario.
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage.

## Tests performed

Ran the full v2 test suite on a local KinD cluster (1 control-plane + 2 workers):

```bash
source venv/bin/activate && python -m pytest CI/tests_v2/ -v --timeout=300 --log-cli-level=INFO
```

### Service hijacking test results

```
CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py::TestServiceHijacking::test_hijack_plan_steps_and_restore PASSED
CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py::TestServiceHijacking::test_named_port_targeting PASSED
CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py::TestServiceHijacking::test_numeric_port_targeting PASSED
CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py::TestServiceHijacking::test_rollback_on_interruption PASSED
CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py::TestServiceHijacking::test_nonexistent_service_fails PASSED
CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py::TestServiceHijacking::test_nonexistent_namespace_fails PASSED
CI/tests_v2/scenarios/service_hijacking/test_service_hijacking.py::TestServiceHijacking::test_service_patch_failure PASSED
```

Full test suite summary:

```
============= 59 passed, 1 skipped, 1 error in 1651.40s (0:27:31) =============
```

All 7 `service_hijacking` tests passed.

The 1 error is a pre-existing `application_outage` pod readiness timeout and is unrelated to this PR.

The 1 skipped test (`test_instance_count_with_label_selector`) requires 2+ worker nodes and is unrelated to this change.