### PR TITLE
feat: expose command triggers in global krknctl inputs

### DIFF
--- a/containers/krknctl-input.json
+++ b/containers/krknctl-input.json
@@ -642,5 +642,69 @@
     "required": "false",
     "mount_path": "/home/krkn/resiliency-file.yaml",
     "group": "resiliency"
+  },
+  {
+    "name": "trigger-command",
+    "short_description": "Trigger command",
+    "description": "Shell command to evaluate before chaos starts. Chaos begins only after this command exits with the expected code. Leave empty to disable triggers.",
+    "variable": "TRIGGER_COMMAND",
+    "type": "string",
+    "default": "",
+    "required": "false",
+    "group": "triggers"
+  },
+  {
+    "name": "trigger-expected-rc",
+    "short_description": "Trigger expected exit code",
+    "description": "Expected shell command exit code for the trigger to be considered satisfied",
+    "variable": "TRIGGER_EXPECTED_RC",
+    "type": "number",
+    "default": "0",
+    "required": "false",
+    "group": "triggers"
+  },
+  {
+    "name": "triggers-mode",
+    "short_description": "Triggers mode",
+    "description": "How multiple trigger conditions are combined",
+    "variable": "TRIGGERS_MODE",
+    "type": "enum",
+    "allowed_values": "all_of,any_of",
+    "separator": ",",
+    "default": "all_of",
+    "required": "false",
+    "group": "triggers"
+  },
+  {
+    "name": "triggers-timeout",
+    "short_description": "Triggers timeout",
+    "description": "Maximum time in seconds to wait for trigger conditions before applying on-timeout behavior",
+    "variable": "TRIGGERS_TIMEOUT",
+    "type": "number",
+    "default": "300",
+    "required": "false",
+    "group": "triggers"
+  },
+  {
+    "name": "triggers-interval",
+    "short_description": "Triggers polling interval",
+    "description": "Polling interval in seconds while waiting for trigger conditions",
+    "variable": "TRIGGERS_INTERVAL",
+    "type": "number",
+    "default": "5",
+    "required": "false",
+    "group": "triggers"
+  },
+  {
+    "name": "triggers-on-timeout",
+    "short_description": "Triggers on timeout",
+    "description": "Behavior when trigger conditions are not met before timeout",
+    "variable": "TRIGGERS_ON_TIMEOUT",
+    "type": "enum",
+    "allowed_values": "skip,fail,run_anyway",
+    "separator": ",",
+    "default": "skip",
+    "required": "false",
+    "group": "triggers"
   }
 ]


### PR DESCRIPTION
## Summary
- Add global `triggers` group fields to `containers/krknctl-input.json` for krknctl (`TRIGGER_COMMAND`, `TRIGGER_EXPECTED_RC`, `TRIGGERS_MODE`, `TRIGGERS_TIMEOUT`, `TRIGGERS_INTERVAL`, `TRIGGERS_ON_TIMEOUT`).
- Enables krknctl users to configure Phase 1 command triggers without editing config YAML directly.

Related to #1483

Companion hub PR: https://github.com/krkn-chaos/krkn-hub/pull/356

## Test plan
- [x] Local registry image with updated global label shows `--trigger-command` / related flags in `krknctl run pod-scenarios --help`
- [x] `krknctl run` passes `TRIGGER_*` env vars into the container
- [x] Trigger wait → scale condition → chaos inject succeeds with hub wiring


Made with [Cursor](https://cursor.com)