### PR TITLE
Retry other PVC-mounted pods when selected pod is unusable

### DIFF
--- a/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
+++ b/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
@@ -110,6 +110,7 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                     pods_to_try = [pod_name]
 
                 shell = None
+                configured_pvc_name = (pvc_name or "").strip()
                 for candidate_pod_name in pods_to_try:
                     logging.info("Attempting to use pod '%s'",candidate_pod_name)
                     # Get volume name
@@ -125,14 +126,20 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
 
                     found_valid_pvc = False
                     for volume in pod.volumes:
-                        if volume.pvcName is not None:
-                            volume_name = volume.name
-                            pvc_name = volume.pvcName
-                            pvc = lib_telemetry.get_lib_kubernetes().get_pvc_info(
-                                pvc_name, namespace
-                            )
-                            found_valid_pvc = True
-                            break
+                        
+                        if volume.pvcName is None:
+                            continue
+                        # If a PVC was configured, only match that PVC
+                        if configured_pvc_name and volume.pvcName != configured_pvc_name:
+                            continue
+                        
+                        volume_name = volume.name
+                        pvc_name = volume.pvcName
+                        pvc = lib_telemetry.get_lib_kubernetes().get_pvc_info(
+                            pvc_name, namespace
+                        )
+                        found_valid_pvc = True
+                        break
                     if not found_valid_pvc:
                         logging.warning(
                             "PvcScenarioPlugin Pod '%s' in namespace '%s' does not use a pvc"

--- a/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
+++ b/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
@@ -74,7 +74,7 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                         "PvcScenarioPlugin You must specify the namespace where the PVC is"
                     )
                     return 1
-                if pvc_name is None and pod_name is None:
+                if not pvc_name and not pod_name:
                     logging.error(
                         "PvcScenarioPlugin You must specify the pvc_name or the pod_name"
                     )
@@ -95,7 +95,7 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                     pvc = lib_telemetry.get_lib_kubernetes().get_pvc_info(
                         pvc_name, namespace
                     )
-                    if not pvc.podNames:
+                    if pvc is None or not pvc.podNames:
                         logging.error(
                             "PvcScenarioPlugin Pod associated with %s PVC, on namespace %s, "
                             "not found" % (str(pvc_name), str(namespace))
@@ -152,18 +152,24 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                     container_name = None
                     mount_path = None
                     # Get container name and mount path
-                    for container in pod.containers:
-                        for vol in container.volumeMounts:
-                            if vol.name == volume_name:
-                                mount_path = vol.mountPath
-                                container_name = container.name
-                                break
-                    if container_name is None:
-                        logging.warning(
-                            "Could not find volume mount path in pod '%s', trying next pod"
-                            % candidate_pod_name
-                        )
+                    match = next(
+                        (
+                            (container, vol)
+                            for container in pod.containers
+                            for vol in container.volumeMounts
+                            if vol.name == volume_name
+                        ),
+                        None,
+                    )
+                    if match is None:
+                        logging.error("Volume '%s' is not mounted in any container of pod '%s'"
+                                      % (volume_name, candidate_pod_name)
+                                     )
                         continue
+                                        
+                    container, volume_mount = match
+                    container_name = container.name
+                    mount_path = volume_mount.mountPath
                     logging.info("Container path: %s" % container_name)
                     logging.info("Mount path: %s" % mount_path)
 

--- a/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
+++ b/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
@@ -95,69 +95,94 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                     pvc = lib_telemetry.get_lib_kubernetes().get_pvc_info(
                         pvc_name, namespace
                     )
-                    try:
-                        # random generator not used for
-                        # security/cryptographic purposes.
-                        pod_name = random.choice(pvc.podNames)  # nosec
-                        logging.info("Pod name: %s" % pod_name)
-                    except Exception:
+                    if not pvc.podNames:
                         logging.error(
                             "PvcScenarioPlugin Pod associated with %s PVC, on namespace %s, "
                             "not found" % (str(pvc_name), str(namespace))
                         )
                         return 1
 
-                # Get volume name
-                pod = lib_telemetry.get_lib_kubernetes().get_pod_info(
-                    name=pod_name, namespace=namespace
-                )
+                    # Create a shuffled copy to maintain the random attempt distribution
+                    pods_to_try = list(pvc.podNames)
+                    random.shuffle(pods_to_try)
+                else:
+                    # Fallback if only pod_name was provided in the configuration
+                    pods_to_try = [pod_name]
 
-                if pod is None:
-                    logging.error(
-                        "PvcScenarioPlugin Exiting as pod '%s' doesn't exist "
-                        "in namespace '%s'" % (str(pod_name), str(namespace))
+                shell = None
+                for candidate_pod_name in pods_to_try:
+                    logging.info("Attempting to use pod '%s'",candidate_pod_name)
+                    # Get volume name
+                    pod = lib_telemetry.get_lib_kubernetes().get_pod_info(
+                        name=candidate_pod_name, namespace=namespace
                     )
-                    return 1
 
-                for volume in pod.volumes:
-                    if volume.pvcName is not None:
-                        volume_name = volume.name
-                        pvc_name = volume.pvcName
-                        pvc = lib_telemetry.get_lib_kubernetes().get_pvc_info(
-                            pvc_name, namespace
+                    if pod is None:
+                        logging.warning(
+                            "Pod '%s' not found, trying next pod" % candidate_pod_name
                         )
-                        break
-                if "pvc" not in locals():
-                    logging.error(
-                        "PvcScenarioPlugin Pod '%s' in namespace '%s' does not use a pvc"
-                        % (str(pod_name), str(namespace))
-                    )
-                    return 1
-                logging.info("Volume name: %s" % volume_name)
-                logging.info("PVC name: %s" % pvc_name)
+                        continue
 
-                # Get container name and mount path
-                for container in pod.containers:
-                    for vol in container.volumeMounts:
-                        if vol.name == volume_name:
-                            mount_path = vol.mountPath
-                            container_name = container.name
+                    found_valid_pvc = False
+                    for volume in pod.volumes:
+                        if volume.pvcName is not None:
+                            volume_name = volume.name
+                            pvc_name = volume.pvcName
+                            pvc = lib_telemetry.get_lib_kubernetes().get_pvc_info(
+                                pvc_name, namespace
+                            )
+                            found_valid_pvc = True
                             break
-                logging.info("Container path: %s" % container_name)
-                logging.info("Mount path: %s" % mount_path)
+                    if not found_valid_pvc:
+                        logging.warning(
+                            "PvcScenarioPlugin Pod '%s' in namespace '%s' does not use a pvc"
+                            % (str(candidate_pod_name), str(namespace))
+                        )
+                        continue
+                    logging.info("Volume name: %s" % volume_name)
+                    logging.info("PVC name: %s" % pvc_name)
 
-                # Validate that the container has a usable shell before proceeding
-                shell = lib_telemetry.get_lib_kubernetes().get_pod_shell(
-                    pod_name, namespace, container_name
-                )
-                if shell is None:
-                    logging.error(
+                    container_name = None
+                    mount_path = None
+                    # Get container name and mount path
+                    for container in pod.containers:
+                        for vol in container.volumeMounts:
+                            if vol.name == volume_name:
+                                mount_path = vol.mountPath
+                                container_name = container.name
+                                break
+                    if container_name is None:
+                        logging.warning(
+                            "Could not find volume mount path in pod '%s', trying next pod"
+                            % candidate_pod_name
+                        )
+                        continue
+                    logging.info("Container path: %s" % container_name)
+                    logging.info("Mount path: %s" % mount_path)
+
+                    # Validate that the container has a usable shell before proceeding
+                    shell = lib_telemetry.get_lib_kubernetes().get_pod_shell(
+                        candidate_pod_name, namespace, container_name
+                    )
+                    if shell is not None:
+                        pod_name = candidate_pod_name  # Found a working pod!
+                        break
+                    else:
+                        logging.warning(
                         "PvcScenarioPlugin container '%s' in pod '%s' has no "
                         "usable shell (/bin/bash or /bin/sh); cannot execute "
-                        "commands inside the container" % (str(container_name), str(pod_name))
+                        "commands inside the container"
+                        % (str(container_name), str(candidate_pod_name))
+                    )
+                if shell is None:
+                    logging.error(
+                        "PvcScenarioPlugin reached the end of target options and found no "
+                        "usable shell (/bin/bash or /bin/sh) across any of the pods associated "
+                        "with PVC '%s'; cannot execute scenario." % str(pvc_name)
                     )
                     return 1
-
+                logging.info("Using pod '%s' to execute the PVC scenario " % (pod_name))
+                
                 # Get PVC capacity and used bytes
                 command = "df %s -B 1024 | sed 1d" % (str(mount_path))
                 command_output = (
@@ -256,7 +281,7 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                 logging.info("\n" + str(response))
                 if str(file_name).lower() in str(response).lower():
                     logging.info("%s file successfully created" % (str(full_path)))
-                    
+
                     # Set rollback callable to ensure temp file cleanup on failure or interruption
                     rollback_data = {
                         "pod_name": pod_name,
@@ -266,7 +291,9 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                         "full_path": full_path,
                     }
                     json_str = json.dumps(rollback_data)
-                    encoded_data = base64.b64encode(json_str.encode('utf-8')).decode('utf-8')
+                    encoded_data = base64.b64encode(json_str.encode("utf-8")).decode(
+                        "utf-8"
+                    )
                     self.rollback_handler.set_rollback_callable(
                         self.rollback_temp_file,
                         RollbackContent(
@@ -368,20 +395,23 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
         """
         try:
             namespace = rollback_content.namespace
-            import base64 # noqa
-            import json # noqa
-            decoded_data = base64.b64decode(rollback_content.resource_identifier.encode('utf-8')).decode('utf-8')
+            import base64  # noqa
+            import json  # noqa
+
+            decoded_data = base64.b64decode(
+                rollback_content.resource_identifier.encode("utf-8")
+            ).decode("utf-8")
             rollback_data = json.loads(decoded_data)
             pod_name = rollback_data["pod_name"]
             container_name = rollback_data["container_name"]
             full_path = rollback_data["full_path"]
             file_name = rollback_data["file_name"]
             mount_path = rollback_data["mount_path"]
-            
+
             logging.info(
                 f"Rolling back PVC scenario: removing temp file {full_path} from pod {pod_name} in namespace {namespace}"
             )
-            
+
             # Remove the temp file
             command = "rm -f %s" % (str(full_path))
             logging.info("Remove temp file from the PVC command:\n %s" % command)
@@ -396,14 +426,14 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                 [command], pod_name, namespace, container_name
             )
             logging.info("\n" + str(response))
-            
+
             if not (str(file_name).lower() in str(response).lower()):
                 logging.info("Temp file successfully removed during rollback")
             else:
                 logging.warning(
                     f"Temp file {file_name} may still exist after rollback attempt"
                 )
-            
+
             logging.info("PVC scenario rollback completed successfully.")
         except Exception as e:
             logging.error(f"Failed to rollback PVC scenario temp file: {e}")

--- a/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
+++ b/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
@@ -175,10 +175,10 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                         % (str(container_name), str(candidate_pod_name))
                     )
                 if shell is None:
+                    target_identifier = f"PVC '{pvc_name}'" if pvc_name else f"pod '{pod_name}'"
                     logging.error(
-                        "PvcScenarioPlugin reached the end of target options and found no "
-                        "usable shell (/bin/bash or /bin/sh) across any of the pods associated "
-                        "with PVC '%s'; cannot execute scenario." % str(pvc_name)
+                        "PvcScenarioPlugin reached the end of target options and failed to execute the scenario; "
+                        "none of the pods associated with %s are ready or usable." % target_identifier
                     )
                     return 1
                 logging.info("Using pod '%s' to execute the PVC scenario " % (pod_name))

--- a/tests/test_pvc_scenario_plugin.py
+++ b/tests/test_pvc_scenario_plugin.py
@@ -716,14 +716,90 @@ class TestPvcScenarioPluginRun(unittest.TestCase):
 
             # Should return 1 because random.choice on empty list raises IndexError
             self.assertEqual(result, 1)
-
-    def test_run_no_shell_in_container(self):
-        """Test run returns 1 when container has no usable shell (/bin/bash or /bin/sh)"""
+            
+    @patch("krkn.scenario_plugins.pvc.pvc_scenario_plugin.time.sleep")
+    def test_run_retries_pods_and_succeeds(self, mock_sleep):
+        """Test that the engine loops through multiple pods if the first one lacks a shell"""
         with tempfile.TemporaryDirectory() as temp_dir:
             scenario_config = {
                 "pvc_scenario": {
                     "namespace": "test-ns",
-                    "pod_name": "prometheus-k8s-0",
+                    "pvc_name": "test-pvc",
+                    "fill_percentage": 80,
+                    "duration": 1,
+                }
+            }
+            scenario_path = self.create_scenario_file(scenario_config, temp_dir)
+
+            mock_telemetry = MagicMock(spec=KrknTelemetryOpenshift)
+            mock_kubecli = MagicMock()
+            mock_telemetry.get_lib_kubernetes.return_value = mock_kubecli
+
+            # Mock a PVC cluster layout providing 2 pods
+            mock_pvc = MagicMock()
+            mock_pvc.podNames = ["broken-pod", "working-pod"]
+            mock_kubecli.get_pvc_info.return_value = mock_pvc
+
+            # Pod Mock Definitions
+            def get_pod_info_side_effect(name, namespace):
+                pod = MagicMock()
+                mock_volume = MagicMock()
+                mock_volume.pvcName = "test-pvc"
+                mock_volume.name = "test-volume"
+                pod.volumes = [mock_volume]
+
+                mock_container = MagicMock()
+                mock_container.name = "test-container"
+                mock_vol_mount = MagicMock()
+                mock_vol_mount.name = "test-volume"
+                mock_vol_mount.mountPath = "/mnt/data"
+                mock_container.volumeMounts = [mock_vol_mount]
+                pod.containers = [mock_container]
+                return pod
+
+            mock_kubecli.get_pod_info.side_effect = get_pod_info_side_effect
+
+            # Simulate "broken-pod" has no shell, but "working-pod" successfully returns "bash"
+            def get_pod_shell_side_effect(pod_name, ns, container):
+                if pod_name == "broken-pod":
+                    return None
+                return "bash"
+
+            mock_kubecli.get_pod_shell.side_effect = get_pod_shell_side_effect
+
+            # Exec configurations for the successful execution track
+            mock_kubecli.exec_cmd_in_pod.side_effect = [
+                "/dev/sda1 100000 10000 90000 10% /mnt/data",  # df check
+                "/usr/bin/fallocate",                          # command -v check
+                "/usr/bin/dd",
+                "",                                            # execution
+                "-rw-r--r-- 1 root root 70M Jan 1 00:00 kraken.tmp",
+                "",
+                "total 0",
+            ]
+
+            # Patch random.shuffle to keep order predictable for testing execution paths
+            with patch("random.shuffle", lambda x: None):
+                result = self.plugin.run(
+                    run_uuid="test-uuid",
+                    scenario=scenario_path,
+                    lib_telemetry=mock_telemetry,
+                    scenario_telemetry=MagicMock(),
+                )
+
+            # Assure the engine bypasses the error state and completes successfully (0)
+            self.assertEqual(result, 0)
+            # Verify it evaluated the active shell profile on the working candidate explicitly
+            mock_kubecli.get_pod_info.assert_any_call(name="broken-pod", namespace="test-ns")
+            mock_kubecli.get_pod_info.assert_any_call(name="working-pod", namespace="test-ns")
+
+    def test_run_fails_when_all_pods_lack_shell(self):
+        """Test that the plugin fails safely out if all cluster pods lack a shell"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            scenario_config = {
+                "pvc_scenario": {
+                    "namespace": "test-ns",
+                    "pvc_name": "test-pvc",
                     "fill_percentage": 80,
                 }
             }
@@ -733,39 +809,103 @@ class TestPvcScenarioPluginRun(unittest.TestCase):
             mock_kubecli = MagicMock()
             mock_telemetry.get_lib_kubernetes.return_value = mock_kubecli
 
+            mock_pvc = MagicMock()
+            mock_pvc.podNames = ["pod-a", "pod-b"]
+            mock_kubecli.get_pvc_info.return_value = mock_pvc
+
+            # Provide common valid structural shapes for pods
             mock_pod = MagicMock()
             mock_volume = MagicMock()
-            mock_volume.pvcName = "prometheus-k8s-db-prometheus-k8s-0"
-            mock_volume.name = "prometheus-db"
+            mock_volume.pvcName = "test-pvc"
+            mock_volume.name = "test-volume"
             mock_pod.volumes = [mock_volume]
-
             mock_container = MagicMock()
-            mock_container.name = "prometheus"
+            mock_container.name = "test-container"
             mock_vol_mount = MagicMock()
-            mock_vol_mount.name = "prometheus-db"
-            mock_vol_mount.mountPath = "/prometheus"
+            mock_vol_mount.name = "test-volume"
+            mock_vol_mount.mountPath = "/mnt/data"
             mock_container.volumeMounts = [mock_vol_mount]
             mock_pod.containers = [mock_container]
 
             mock_kubecli.get_pod_info.return_value = mock_pod
-            mock_kubecli.get_pvc_info.return_value = MagicMock()
-            mock_kubecli.get_pod_shell.return_value = None  # no shell available
-
-            mock_scenario_telemetry = MagicMock()
+            # Both pods return None for active shell capabilities
+            mock_kubecli.get_pod_shell.return_value = None
 
             result = self.plugin.run(
                 run_uuid="test-uuid",
                 scenario=scenario_path,
                 lib_telemetry=mock_telemetry,
-                scenario_telemetry=mock_scenario_telemetry,
+                scenario_telemetry=MagicMock(),
             )
 
             self.assertEqual(result, 1)
-            mock_kubecli.get_pod_shell.assert_called_once_with(
-                "prometheus-k8s-0", "test-ns", "prometheus"
-            )
-            # No exec_cmd_in_pod calls should happen after shell check fails
-            mock_kubecli.exec_cmd_in_pod.assert_not_called()
+            self.assertEqual(mock_kubecli.get_pod_shell.call_count, 2)
+
+    def test_run_skips_pod_without_pvc_and_continues(self):
+        """Test that the loop ignores intermediate candidate pods missing a valid PVC mapping"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            scenario_config = {
+                "pvc_scenario": {
+                    "namespace": "test-ns",
+                    "pvc_name": "test-pvc",
+                    "fill_percentage": 80,
+                    "duration": 1,
+                }
+            }
+            scenario_path = self.create_scenario_file(scenario_config, temp_dir)
+
+            mock_telemetry = MagicMock(spec=KrknTelemetryOpenshift)
+            mock_kubecli = MagicMock()
+            mock_telemetry.get_lib_kubernetes.return_value = mock_kubecli
+
+            mock_pvc = MagicMock()
+            mock_pvc.podNames = ["no-pvc-pod", "good-pod"]
+            mock_kubecli.get_pvc_info.return_value = mock_pvc
+
+            def get_pod_info_side_effect(name, namespace):
+                pod = MagicMock()
+                mock_volume = MagicMock()
+                mock_container = MagicMock()
+                mock_container.name = "test-container"
+                mock_vol_mount = MagicMock()
+                mock_vol_mount.name = "test-volume"
+                mock_vol_mount.mountPath = "/mnt/data"
+                mock_container.volumeMounts = [mock_vol_mount]
+                pod.containers = [mock_container]
+
+                if name == "no-pvc-pod":
+                    mock_volume.pvcName = None  # Broken volume mapping configuration
+                else:
+                    mock_volume.pvcName = "test-pvc"
+                
+                mock_volume.name = "test-volume"
+                pod.volumes = [mock_volume]
+                return pod
+
+            mock_kubecli.get_pod_info.side_effect = get_pod_info_side_effect
+            mock_kubecli.get_pod_shell.return_value = "bash"
+
+            mock_kubecli.exec_cmd_in_pod.side_effect = [
+                "/dev/sda1 100000 10000 90000 10% /mnt/data",
+                "/usr/bin/fallocate",
+                "/usr/bin/dd",
+                "",
+                "-rw-r--r-- 1 root root 70M Jan 1 00:00 kraken.tmp",
+                "",
+                "total 0",
+            ]
+
+            with patch("random.shuffle", lambda x: None), patch("krkn.scenario_plugins.pvc.pvc_scenario_plugin.time.sleep"):
+                result = self.plugin.run(
+                    run_uuid="test-uuid",
+                    scenario=scenario_path,
+                    lib_telemetry=mock_telemetry,
+                    scenario_telemetry=MagicMock(),
+                )
+
+            self.assertEqual(result, 0)
+            mock_kubecli.get_pod_info.assert_any_call(name="no-pvc-pod", namespace="test-ns")
+            mock_kubecli.get_pod_info.assert_any_call(name="good-pod", namespace="test-ns")
 
     def test_run_shell_check_before_exec(self):
         """Test that get_pod_shell is called before any exec_cmd_in_pod when shell exists"""

--- a/tests/test_pvc_scenario_plugin.py
+++ b/tests/test_pvc_scenario_plugin.py
@@ -906,6 +906,54 @@ class TestPvcScenarioPluginRun(unittest.TestCase):
             self.assertEqual(result, 0)
             mock_kubecli.get_pod_info.assert_any_call(name="no-pvc-pod", namespace="test-ns")
             mock_kubecli.get_pod_info.assert_any_call(name="good-pod", namespace="test-ns")
+            
+    def test_run_pod_name_only_fails_when_unusable(self):
+        """Test that passing only a pod_name fails cleanly if that specific pod is unusable"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            scenario_config = {
+                "pvc_scenario": {
+                    "namespace": "test-ns",
+                    "pod_name": "standalone-target-pod",
+                    "fill_percentage": 80,
+                }
+            }
+            scenario_path = self.create_scenario_file(scenario_config, temp_dir)
+
+            mock_telemetry = MagicMock(spec=KrknTelemetryOpenshift)
+            mock_kubecli = MagicMock()
+            mock_telemetry.get_lib_kubernetes.return_value = mock_kubecli
+
+            # Mock structural shapes for the targeted pod
+            mock_pod = MagicMock()
+            mock_volume = MagicMock()
+            mock_volume.pvcName = "standalone-pvc"
+            mock_volume.name = "test-volume"
+            mock_pod.volumes = [mock_volume]
+            
+            mock_container = MagicMock()
+            mock_container.name = "test-container"
+            mock_vol_mount = MagicMock()
+            mock_vol_mount.name = "test-volume"
+            mock_vol_mount.mountPath = "/mnt/data"
+            mock_container.volumeMounts = [mock_vol_mount]
+            mock_pod.containers = [mock_container]
+
+            mock_kubecli.get_pod_info.return_value = mock_pod
+            # Force the single targeted pod to fail the shell check
+            mock_kubecli.get_pod_shell.return_value = None
+
+            result = self.plugin.run(
+                run_uuid="test-uuid",
+                scenario=scenario_path,
+                lib_telemetry=mock_telemetry,
+                scenario_telemetry=MagicMock(),
+            )
+
+            # Verifies that it exits with a 1 since the only pod provided was unusable
+            self.assertEqual(result, 1)
+            mock_kubecli.get_pod_shell.assert_called_once_with(
+                "standalone-target-pod", "test-ns", "test-container"
+            )
 
     def test_run_shell_check_before_exec(self):
         """Test that get_pod_shell is called before any exec_cmd_in_pod when shell exists"""


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization

# Description

This PR improves the reliability of the PVC scenario plugin. Instead of picking a single random pod and failing immediately if it's unusable, the plugin now loops through the `pods_to_try` list until it finds a healthy pod with a working shell to execute the scenario

## Proposed Changes

- **Looping Through Pods:** Refactored the pod selection into a `for candidate_pod_name in pods_to_try:` loop. 
- **Handling Shell Failures:** If `get_pod_shell()` returns `None`, the code logs a warning and runs `continue` to try the next available pod instead of returning `1` right away.
- **Fixed PVC Flag Tracking:** Replaced  `if "pvc" not in locals():` check with a clean boolean flag named `found_valid_pvc`. This properly tracks the volume state for the current pod iteration and prevents stale loop data from causing runtime crashes.

### Test Functions Added
* Extended `TestPvcScenarioPluginRun` by introducing structural test coverage targeting loop mechanics:
  - `test_run_retries_pods_and_succeeds`: Checks that if one or more candidate pods are unusable, the code skips them and successfully uses the first available usable pod.
  - `test_run_fails_when_all_pods_lack_shell`: Makes sure the plugin returns an error code if none of the available pods have a working shell.
  - `test_run_skips_pod_without_pvc_and_continues`: Guarantees the loop safely skips over any candidate pod that is missing a valid PVC mapping without breaking.
  - `test_run_pod_name_only_fails_when_unusable`: Ensures that when only a `pod_name` is provided, the plugin returns an error code if that single targeted pod is unusable.

## Screenshots

### PVC Scenario Logs

<img width="914" height="654" alt="Screenshot 2026-07-20 at 10 36 01 PM" src="https://github.com/user-attachments/assets/0cdf1624-cbe2-4299-addd-b8c042efa015" />

### Unit Test Results
<img width="913" height="546" alt="Screenshot 2026-07-20 at 10 36 55 PM" src="https://github.com/user-attachments/assets/fb0eb2bc-9e97-437b-9676-b4d8a7feaeed" />

## Related Issues
- Related Issue #1489 
- Closes #1489   

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage