### PR TITLE
fix: sort rollback version files in descending timestamp order (LIFO)

### DIFF
--- a/krkn/rollback/config.py
+++ b/krkn/rollback/config.py
@@ -227,6 +227,10 @@ class RollbackConfig(metaclass=SingletonMeta):
             else:
                 logger.warning(f"Directory {dir} does not match expected pattern of <timestamp>-<run_uuid>")
 
+        rollback_context_directories.sort(
+            key=lambda d: int(d.split("-", 1)[0]), reverse=True
+        )
+
         if not rollback_context_directories:
             logger.warning(f"No rollback context directories found for run UUID {run_uuid}")
             return []
@@ -249,6 +253,10 @@ class RollbackConfig(metaclass=SingletonMeta):
                     logger.warning(
                         f"File {file} does not match expected pattern of <{scenario_type or '*'}>_<timestamp>_<hash_suffix>.py"
                     )
+        version_files.sort(
+            key=lambda f: int(os.path.basename(f).split("_")[-2]),
+            reverse=True,
+        )
         return version_files
 
 @dataclass(frozen=True)

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -189,6 +189,65 @@ class TestRollbackConfig:
     def test_is_rollback_version_file_format(self, file_name, expected):
         assert RollbackConfig.is_rollback_version_file_format(file_name) == expected
 
+class TestRollbackVersionFileOrdering:
+
+    def test_search_returns_files_in_descending_timestamp_order(self, tmp_path):
+        """Rollback files must execute newest-first (LIFO).
+        search_rollback_version_files() should return them sorted by
+        the embedded nanosecond timestamp in descending order."""
+        run_uuid = "test-uuid"
+        context_dir_name = f"1000000000-{run_uuid}"
+        context_dir = tmp_path / context_dir_name
+        context_dir.mkdir()
+
+        timestamps = [200000000, 100000000, 300000000]
+        for ts in timestamps:
+            (context_dir / f"scenario_{ts}_aBcDeFgH.py").write_text("")
+
+        RollbackConfig._instances.clear()
+        RollbackConfig.register(
+            auto=True,
+            versions_directory=str(tmp_path),
+        )
+        try:
+            result = RollbackConfig.search_rollback_version_files(run_uuid)
+            result_basenames = [os.path.basename(f) for f in result]
+            assert result_basenames == [
+                "scenario_300000000_aBcDeFgH.py",
+                "scenario_200000000_aBcDeFgH.py",
+                "scenario_100000000_aBcDeFgH.py",
+            ]
+        finally:
+            RollbackConfig._instances.clear()
+
+    def test_search_returns_files_across_contexts_in_descending_order(self, tmp_path):
+        """When multiple context directories exist, files from newer
+        contexts should appear before files from older contexts."""
+        run_uuid = "multi-uuid"
+        older_ctx = tmp_path / f"1000000000-{run_uuid}"
+        newer_ctx = tmp_path / f"2000000000-{run_uuid}"
+        older_ctx.mkdir()
+        newer_ctx.mkdir()
+
+        (older_ctx / "scenario_100000000_aBcDeFgH.py").write_text("")
+        (newer_ctx / "scenario_300000000_aBcDeFgH.py").write_text("")
+
+        RollbackConfig._instances.clear()
+        RollbackConfig.register(
+            auto=True,
+            versions_directory=str(tmp_path),
+        )
+        try:
+            result = RollbackConfig.search_rollback_version_files(run_uuid)
+            result_basenames = [os.path.basename(f) for f in result]
+            assert result_basenames == [
+                "scenario_300000000_aBcDeFgH.py",
+                "scenario_100000000_aBcDeFgH.py",
+            ]
+        finally:
+            RollbackConfig._instances.clear()
+
+
 class TestRollbackCommand:
 
     @pytest.mark.parametrize("auto_rollback", [True, False], ids=["enabled_rollback", "disabled_rollback"])


### PR DESCRIPTION
   Fixes #1487
# Type of change
  
  - [ ] Refactor
  - [ ] New feature
  - [x] Bug fix
  - [ ] Optimization

  # Description

  Rollback version files and context directories were being processed in arbitrary (filesystem) order. This caused rollbacks to execute in non-deterministic order instead of LIFO (newest-first), which is required for correct rollback semantics.

  This fix sorts:
  1. Rollback context directories by their embedded nanosecond timestamp in descending order
  2. Version files by their embedded nanosecond timestamp in descending order

  ## Related Tickets & Documents

  - Related Issue #: 1487
  - Closes #: 1487
  
  # Documentation
  - [ ] **Is documentation needed for this update?**

  # Checklist before requesting a review
  - [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
  - [x] I have performed a self-review of my code
  - [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

  *REQUIRED*:
  Description of combination of tests performed and output of run
  
  ```bash
  python -m unittest tests.test_rollback -v

  Two new test cases added:
  - test_search_returns_files_in_descending_timestamp_order — verifies LIFO ordering within a single context directory
  - test_search_returns_files_across_contexts_in_descending_order — verifies correct ordering across multiple context directories