### PR TITLE
Migrate legacy network chaos test to v2 Python suite with bandwidth coverage

### DIFF
--- a/CI/tests_v2/pytest.ini
+++ b/CI/tests_v2/pytest.ini
@@ -8,11 +8,16 @@ addopts = -v
 markers =
     functional: marks a test as a functional test (deselect with '-m "not functional"')
     pod_disruption: marks a test as a pod disruption scenario test
+    pod_error_scenarios: marks a test as a pod error/failure-mode scenario test
     application_outage: marks a test as an application outage scenario test
     storage_throttle: marks a test as a storage throttle scenario test
     cpu_hog: marks a test as a CPU hog scenario test
     memory_hog: marks a test as a memory hog scenario test
+    container_scenarios: marks a test as a container_scenarios scenario test
     node_scenarios: marks a test as a node chaos scenario test (node reboot/stop-start)
+    node_network_chaos: marks a test as a node network chaos scenario test
+    namespace_deletion: marks a test as a namespace deletion (service_disruption) scenario test
     no_workload: skip workload deployment for this test (e.g. negative tests)
     order: set test order (pytest-order)
+    network_chaos_legacy: marks a test as a legacy network chaos scenario test
 junit_family = xunit2


### PR DESCRIPTION
## Summary

Legacy network chaos test script (CI/tests/test_net_chaos.sh) is not integrated into the v2 test framework. This PR creates a new Pytest-based test suite under CI/tests_v2/scenarios/network_chaos_legacy/ that covers happy-path and negative cases for the legacy network_chaos plugin, focusing on bandwidth, latency, loss, targeting, and cleanup. The NG plugin tests remain separate.

## Changes

- Create CI/tests_v2/scenarios/network_chaos_legacy/test_network_chaos_legacy.py with parametrized test cases for bandwidth/latency/loss injection, node targeting, interface selection, execution mode, and failure/cleanup verifications
- Add CI/tests_v2/scenarios/network_chaos_legacy/scenario_base.yaml providing a base scenario for the legacy network_chaos_scenarios plugin
- Register the network_chaos_legacy marker in CI/tests_v2/pytest.ini

## Validation

- Executed: `pytest CI/tests_v2/ -v -m network_chaos_legacy` on a kind cluster – pending local verification
- Executed: `pytest CI/tests_v2/ -v -m network_chaos_legacy --log-cli-level=DEBUG` – pending
- Manual check of residual tc rules and helper pod cleanup after test execution – pending

## Risks

- tc/iptables kernel modules may be absent on test clusters; tests must skip gracefully
- Legacy plugin behavior may vary across Kubernetes distributions; tests should be runnable on kind with fallbacks
- Concurrent execution with other node chaos tests could conflict; adequate isolation is required


Closes #1435