### PR TITLE
docs: add Dedicated Contributor level to contributor ladder

### DIFF
--- a/.github/ISSUE_TEMPLATE/dedicated_contributor_request.md
+++ b/.github/ISSUE_TEMPLATE/dedicated_contributor_request.md
@@ -1,0 +1,42 @@
+---
+name: Dedicated Contributor Application
+about: Apply to become a Dedicated Contributor of the Krkn project
+title: "Dedicated Contributor Application: <your GitHub handle>"
+labels: dedicated-contributor-application
+assignees: ''
+---
+
+## Dedicated Contributor Application
+
+Please fill out the sections below and check off each requirement you have met before submitting.
+
+---
+
+## Requirements Checklist
+
+- [ ] I have been actively contributing for **at least 2 months**
+- [ ] I have had **at least 2 non-trivial PRs** merged
+- [ ] I have reviewed **at least 3 PRs** from other contributors
+- [ ] I am familiar with the project's coding style, testing practices, and documentation standards
+- [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
+
+---
+
+## Merged PRs
+
+List at least 2 non-trivial PRs you authored that have been merged:
+
+1. 
+2. 
+
+## PR Reviews
+
+List at least 3 PR reviews you participated in:
+
+1. 
+2. 
+3. 
+
+## About Your Involvement
+
+Briefly describe how you have been contributing to the project and why you would like to become a Dedicated Contributor:

--- a/.github/ISSUE_TEMPLATE/member_request.md
+++ b/.github/ISSUE_TEMPLATE/member_request.md
@@ -14,25 +14,18 @@ Please fill out the sections below and check off each requirement you have met b
 
 ## Requirements Checklist
 
-- [ ] I have been actively contributing to Krkn for **at least 3 months**
-- [ ] I have had **at least 3 non-trivial PRs** merged
-- [ ] I have reviewed **at least 5 PRs** from other contributors
-- [ ] I am familiar with the project's coding style, testing practices, and documentation standards
+- [ ] I have been an active **Dedicated Contributor for at least 3 months**
+- [ ] I have had **at least 5 non-trivial PRs** merged
+- [ ] I have reviewed **at least 10 PRs** from other contributors
+- [ ] I have helped onboard or mentor at least one newer contributor
+- [ ] I have demonstrated deep familiarity with at least one subsystem or area of the codebase
 - [ ] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
 
 ---
 
 ## Merged PRs
 
-List at least 3 non-trivial PRs you authored that have been merged:
-
-1. 
-2. 
-3. 
-
-## PR Reviews
-
-List at least 5 PR reviews you participated in:
+List at least 5 non-trivial PRs you authored that have been merged:
 
 1. 
 2. 
@@ -40,7 +33,30 @@ List at least 5 PR reviews you participated in:
 4. 
 5. 
 
+## PR Reviews
+
+List at least 10 PR reviews you participated in:
+
+1. 
+2. 
+3. 
+4. 
+5. 
+6. 
+7. 
+8. 
+9. 
+10. 
+
+## Mentoring and Onboarding
+
+Describe how you have helped onboard or mentor newer contributors (e.g., guided a PR, answered questions in Slack, co-reviewed work):
+
+## Subsystem Expertise
+
+Describe which area(s) of the codebase you are most familiar with and how your contributions reflect that depth:
+
 ## About Your Involvement
 
-Briefly describe how you have been contributing to the project and why you would like to become a Member:
+Briefly describe your overall involvement in the project and why you would like to become a Member:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,15 +73,33 @@ To get started:
 1. Find something to work on in the [open issues](https://github.com/krkn-chaos/krkn/issues?q=is%3Aissue+state%3Aopen+label%3A%22good+first+issue%22), or open one of your own.
 2. Join the [#krkn channel on Kubernetes Slack](https://kubernetes.slack.com/archives/C05SFMHRWK1) to introduce yourself and ask questions.
 
-### Member
+### Dedicated Contributor
 
-Members are active contributors who review PRs and have demonstrated a solid understanding of the project's codebase and conventions.
+Dedicated Contributors are active contributors who have moved beyond one-off participation and are consistently engaging with the project. This is the first formal step on the contributor ladder and requires an application.
 
 **Requirements** — before applying, you should have:
-- Been actively contributing for **at least 3 months**
-- Submitted **at least 3 non-trivial PRs** that have been merged
-- Reviewed **at least 5 PRs** from other contributors
+- Been actively contributing for **at least 2 months**
+- Submitted **at least 2 non-trivial PRs** that have been merged
+- Reviewed **at least 3 PRs** from other contributors
 - Shown familiarity with the project's coding style, testing practices, and documentation standards
+
+**How to apply:**
+
+1. Open a [Dedicated Contributor Application issue](https://github.com/krkn-chaos/krkn/issues/new?template=dedicated_contributor_request.md) and complete all sections.
+2. Tag two current Maintainers to review your application.
+
+Maintainers will evaluate the application and respond within **two weeks**. A simple majority vote of Maintainers is required for approval. Once approved, you will be added to [MAINTAINERS.md](MAINTAINERS.md) and acknowledged in the project community.
+
+### Member
+
+Members are Dedicated Contributors who have demonstrated sustained, high-quality involvement in the project — becoming a reliable presence in reviews, discussions, and mentoring. This role recognizes community members who are on the path toward Maintainership but have not yet taken on the full responsibilities of project oversight.
+
+**Requirements** — before applying, you should have:
+- Been an active **Dedicated Contributor for at least 3 months**
+- Submitted **at least 5 non-trivial PRs** that have been merged
+- Reviewed **at least 10 PRs** from other contributors
+- Helped onboard or mentor at least one newer contributor (e.g., guided them through a PR, answered questions in Slack, or co-reviewed their work)
+- Demonstrated deep familiarity with at least one subsystem or area of the codebase
 
 **How to apply:**
 1. Open a [Member Application issue](https://github.com/krkn-chaos/krkn/issues/new?template=member_request.md) and complete all sections.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -40,14 +40,23 @@ Anyone can become a contributor by participating in discussions, reporting bugs,
 - Report bugs and suggest new features
 - Contribute high-quality code and documentation
 
+### Dedicated Contributor
+
+Dedicated Contributors are active contributors who have moved beyond one-off participation and are consistently engaging with the project. This is the first formal role on the contributor ladder and requires an application (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+
+**Responsibilities:**
+- Engage consistently with the project through PRs, reviews, and community discussions
+- Adhere to the project's coding style, testing practices, and documentation standards
+
 ### Member
 
-Members are active contributors who have demonstrated a solid understanding of the project's codebase and conventions.
+Members are Dedicated Contributors who have demonstrated sustained, high-quality involvement — becoming a reliable presence in reviews, discussions, and mentoring. This role recognizes community members who are on the path toward Maintainership (see [CONTRIBUTING.md](CONTRIBUTING.md)).
 
 **Responsibilities:**
 - Review pull requests for correctness, quality, and adherence to project standards
 - Provide constructive and timely feedback to contributors
 - Ensure contributions are well-tested and documented
+- Help onboard and mentor newer contributors
 - Work with maintainers to support a smooth release process
 
 ### Maintainer

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -28,7 +28,9 @@ This project follows a contributor ladder model, where contributors can take on 
 The roles are:
 * Contributor: A contributor to the community whether it be with code, docs or issues
 
-* Member: A contributor who is active in the community and reviews pull requests.
+* Dedicated Contributor: A contributor who is consistently engaging with the project and has applied for formal recognition.
+
+* Member: A Dedicated Contributor who is active in the community, reviews pull requests, and helps mentor others.
 
 * Maintainer: A contributor who is responsible for the overall health and direction of the project.
 
@@ -38,7 +40,7 @@ The roles are:
 ## Maintainer Levels
 
 ### Contributor
-Contributors contributor to the community. Anyone can become a contributor by participating in discussions, reporting bugs, or contributing code or documentation.
+Contributors contribute to the community. Anyone can become a contributor by participating in discussions, reporting bugs, or contributing code or documentation.
 
 #### Responsibilities:
 
@@ -49,8 +51,18 @@ Report bugs and suggest new features.
 Contribute high-quality code and documentation.
 
 
+### Dedicated Contributor
+Dedicated Contributors are active contributors who have moved beyond one-off participation and are consistently engaging with the project. This is the first formal role on the contributor ladder and requires an application.
+
+#### Responsibilities:
+
+Engage consistently with the project through PRs, reviews, and community discussions.
+
+Adhere to the project's coding style, testing practices, and documentation standards.
+
+
 ### Member
-Members are active contributors to the community. Members have demonstrated a strong understanding of the project's codebase and conventions.
+Members are Dedicated Contributors who have demonstrated sustained, high-quality involvement in the project — becoming a reliable presence in reviews, discussions, and mentoring.
 
 #### Responsibilities:
 
@@ -59,6 +71,8 @@ Review pull requests for correctness, quality, and adherence to project standard
 Provide constructive and timely feedback to contributors.
 
 Ensure that all contributions are well-tested and documented.
+
+Help onboard and mentor newer contributors.
 
 Work with maintainers to ensure a smooth and efficient release process.
 


### PR DESCRIPTION

# Type of change

- [X] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
Adds a new Dedicated Contributor role between Member and Maintainer, with its own application process and issue template.


## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: 
- Closes #: 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python run_kraken.py
...
<---insert test results output--->
```

OR


```bash
python -m coverage run -a -m unittest discover -s tests -v
...
<---insert test results output--->
```
