### PR TITLE
feat(zone_outage): add Azure support via subnet NSG isolation

### DIFF
--- a/krkn/scenario_plugins/node_actions/az_node_scenarios.py
+++ b/krkn/scenario_plugins/node_actions/az_node_scenarios.py
@@ -34,8 +34,16 @@ class Azure:
         logger = logging.getLogger("azure")
         logger.setLevel(logging.WARNING)
         subscription_id = os.getenv("AZURE_SUBSCRIPTION_ID")
-        self.compute_client = ComputeManagementClient(credentials, subscription_id,logging=logger)
-        self.network_client = NetworkManagementClient(credentials, subscription_id,logging=logger)
+        if not subscription_id:
+            try:
+                import subprocess
+                out = subprocess.check_output(["az", "account", "show", "--query", "id", "-o", "tsv"], text=True)
+                subscription_id = out.strip()
+                logging.info(f"Auto-detected Azure subscription_id: {subscription_id}")
+            except Exception as sub_err:
+                logging.warning(f"Could not auto-detect Azure subscription_id from CLI: {sub_err}")
+        self.compute_client = ComputeManagementClient(credentials, subscription_id, logging=logger)
+        self.network_client = NetworkManagementClient(credentials, subscription_id, logging=logger)
 
     # Get the instance ID of the node
     def get_instance_id(self, node_name):
@@ -45,6 +53,14 @@ class Azure:
             if node_name == vm.name:
                 resource_group = array[4]
                 return vm.name, resource_group
+        
+        vmss_list = self.compute_client.virtual_machine_scale_sets.list_all()
+        for vmss in vmss_list:
+            rg = vmss.id.split("/")[4]
+            for vm in self.compute_client.virtual_machine_scale_set_vms.list(rg, vmss.name):
+                if vm.os_profile and vm.os_profile.computer_name == node_name:
+                    return f"vmss:{vmss.name}:{vm.instance_id}", rg
+        
         logging.error("Couldn't find vm with name " + str(node_name))
 
     # Get the instance ID of the node
@@ -67,7 +83,11 @@ class Azure:
     # Start the node instance
     def start_instances(self, group_name, vm_name):
         try:
-            self.compute_client.virtual_machines.begin_start(group_name, vm_name)
+            if vm_name.startswith("vmss:"):
+                _, vmss_name, instance_id = vm_name.split(":")
+                self.compute_client.virtual_machine_scale_set_vms.begin_start(group_name, vmss_name, instance_id)
+            else:
+                self.compute_client.virtual_machines.begin_start(group_name, vm_name)
             logging.info("vm name " + str(vm_name) + " started")
         except Exception as e:
             logging.error(
@@ -79,7 +99,11 @@ class Azure:
     # Stop the node instance
     def stop_instances(self, group_name, vm_name):
         try:
-            self.compute_client.virtual_machines.begin_power_off(group_name, vm_name)
+            if vm_name.startswith("vmss:"):
+                _, vmss_name, instance_id = vm_name.split(":")
+                self.compute_client.virtual_machine_scale_set_vms.begin_power_off(group_name, vmss_name, instance_id)
+            else:
+                self.compute_client.virtual_machines.begin_power_off(group_name, vm_name)
             logging.info("vm name " + str(vm_name) + " stopped")
         except Exception as e:
             logging.error(
@@ -91,7 +115,11 @@ class Azure:
     # Terminate the node instance
     def terminate_instances(self, group_name, vm_name):
         try:
-            self.compute_client.virtual_machines.begin_delete(group_name, vm_name)
+            if vm_name.startswith("vmss:"):
+                _, vmss_name, instance_id = vm_name.split(":")
+                self.compute_client.virtual_machine_scale_set_vms.begin_delete(group_name, vmss_name, instance_id)
+            else:
+                self.compute_client.virtual_machines.begin_delete(group_name, vm_name)
             logging.info("vm name " + str(vm_name) + " terminated")
         except Exception as e:
             logging.error(
@@ -104,7 +132,11 @@ class Azure:
     # Reboot the node instance
     def reboot_instances(self, group_name, vm_name):
         try:
-            self.compute_client.virtual_machines.begin_restart(group_name, vm_name)
+            if vm_name.startswith("vmss:"):
+                _, vmss_name, instance_id = vm_name.split(":")
+                self.compute_client.virtual_machine_scale_set_vms.begin_restart(group_name, vmss_name, instance_id)
+            else:
+                self.compute_client.virtual_machines.begin_restart(group_name, vm_name)
             logging.info("vm name " + str(vm_name) + " rebooted")
         except Exception as e:
             logging.error(
@@ -115,9 +147,15 @@ class Azure:
             raise RuntimeError()
 
     def get_vm_status(self, resource_group, vm_name):
-        statuses = self.compute_client.virtual_machines.instance_view(
-            resource_group, vm_name
-        ).statuses
+        if vm_name.startswith("vmss:"):
+            _, vmss_name, instance_id = vm_name.split(":")
+            statuses = self.compute_client.virtual_machine_scale_set_vms.get_instance_view(
+                resource_group, vmss_name, instance_id
+            ).statuses
+        else:
+            statuses = self.compute_client.virtual_machines.instance_view(
+                resource_group, vm_name
+            ).statuses
         status = len(statuses) >= 2 and statuses[1]
         return status
 
@@ -183,6 +221,84 @@ class Azure:
                     affected_node.set_affected_node_status("terminated", end_time - start_time)
                 return True
 
+
+    def create_subnet_deny_security_group(self, resource_group, name, region):
+        inbound_rule = SecurityRule(
+            name="denyInbound",
+            source_address_prefix="*",
+            source_port_range="*",
+            destination_address_prefix="*",
+            destination_port_range="*",
+            priority=100,
+            protocol="*",
+            access="Deny",
+            direction="Inbound",
+        )
+        outbound_rule = SecurityRule(
+            name="denyOutbound",
+            source_address_prefix="*",
+            source_port_range="*",
+            destination_address_prefix="*",
+            destination_port_range="*",
+            priority=100,
+            protocol="*",
+            access="Deny",
+            direction="Outbound",
+        )
+        nsg = self.network_client.network_security_groups.begin_create_or_update(
+            resource_group,
+            name,
+            parameters={"location": region, "security_rules": [inbound_rule, outbound_rule]},
+        )
+        return nsg.result().id
+
+    def update_subnet_nsg(self, resource_group, vnet_name, subnet_name, nsg_id):
+        subnet = self.network_client.subnets.get(
+            resource_group_name=resource_group,
+            virtual_network_name=vnet_name,
+            subnet_name=subnet_name,
+        )
+        old_nsg_id = (
+            subnet.network_security_group.id
+            if (subnet and subnet.network_security_group)
+            else None
+        )
+        if nsg_id:
+            from azure.mgmt.network.models import NetworkSecurityGroup
+            if not subnet.network_security_group:
+                subnet.network_security_group = NetworkSecurityGroup(id=nsg_id)
+            else:
+                subnet.network_security_group.id = nsg_id
+        else:
+            subnet.network_security_group = None
+
+        poller = self.network_client.subnets.begin_create_or_update(
+            resource_group_name=resource_group,
+            virtual_network_name=vnet_name,
+            subnet_name=subnet_name,
+            subnet_parameters=subnet,
+        )
+        poller.result()
+        return old_nsg_id
+
+    def get_subnet_nsg(self, resource_group, vnet_name, subnet_name):
+        subnet = self.network_client.subnets.get(
+            resource_group_name=resource_group,
+            virtual_network_name=vnet_name,
+            subnet_name=subnet_name,
+        )
+        return (
+            subnet.network_security_group.id
+            if (subnet and subnet.network_security_group)
+            else None
+        )
+
+    def get_subnet_location(self, resource_group, vnet_name, subnet_name=None):
+        vnet = self.network_client.virtual_networks.get(
+            resource_group_name=resource_group,
+            virtual_network_name=vnet_name,
+        )
+        return vnet.location
 
     def create_security_group(self, resource_group, name, region, ip_address): 
 

--- a/krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py
+++ b/krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py
@@ -33,6 +33,7 @@ from krkn.rollback.handler import set_rollback_context_decorator
 
 from krkn.scenario_plugins.node_actions.aws_node_scenarios import AWS
 from krkn.scenario_plugins.node_actions.gcp_node_scenarios import gcp_node_scenarios
+from krkn.scenario_plugins.node_actions.az_node_scenarios import Azure
 
 
 class ZoneOutageScenarioPlugin(AbstractScenarioPlugin):
@@ -56,6 +57,11 @@ class ZoneOutageScenarioPlugin(AbstractScenarioPlugin):
                     result = self.network_based_zone(scenario_config)
                     if result != 0:
                         return 1
+                elif cloud_type.lower() in ["azure", "az"]:
+                    self.cloud_object = Azure()
+                    result = self.network_based_zone_azure(scenario_config)
+                    if result != 0:
+                        return result
                 else:
                     kubecli = lib_telemetry.get_lib_kubernetes()
                     if cloud_type.lower() == "gcp":
@@ -183,6 +189,147 @@ class ZoneOutageScenarioPlugin(AbstractScenarioPlugin):
             logging.info("GCP zone outage rollback completed.")
         except Exception as e:
             logging.error("Failed to rollback GCP zone outage: %s" % e)
+            raise
+
+    def network_based_zone_azure(self, scenario_config: dict[str, any]) -> int:
+        chaos_nsg_id = None
+        resource_group = None
+        vnet_name = None
+        subnet_name = None
+        nsg_name = None
+        original_nsg_id = None
+        try:
+            resource_group = scenario_config["resource_group"]
+            vnet_name = scenario_config["vnet_name"]
+            subnet_name = scenario_config["subnet_name"]
+            duration = get_yaml_item_value(scenario_config, "duration", 60)
+            location = scenario_config.get("location")
+            nsg_prefix = scenario_config.get("nsg_name_prefix", "chaos-zone-deny")
+
+            if not location:
+                location = self.cloud_object.get_subnet_location(resource_group, vnet_name, subnet_name)
+
+            nsg_name = f"{nsg_prefix}-{subnet_name}"
+            logging.info(
+                f"Starting Azure network-based zone outage on subnet {subnet_name} "
+                f"in VNet {vnet_name} (resource group: {resource_group})"
+            )
+
+            # Get current NSG association
+            original_nsg_id = self.cloud_object.get_subnet_nsg(resource_group, vnet_name, subnet_name)
+
+            # Set rollback callable before creating deny NSG
+            rollback_data = {
+                "resource_group": resource_group,
+                "vnet_name": vnet_name,
+                "subnet_name": subnet_name,
+                "original_nsg_id": original_nsg_id,
+                "nsg_name": nsg_name,
+            }
+            encoded = base64.b64encode(
+                json.dumps(rollback_data).encode("utf-8")
+            ).decode("utf-8")
+            self.rollback_handler.set_rollback_callable(
+                self.rollback_azure_zone_outage,
+                RollbackContent(resource_identifier=encoded),
+            )
+
+            # Create deny-all security group
+            chaos_nsg_id = self.cloud_object.create_subnet_deny_security_group(
+                resource_group, nsg_name, location
+            )
+
+            # Associate deny NSG with target subnet
+            self.cloud_object.update_subnet_nsg(
+                resource_group, vnet_name, subnet_name, chaos_nsg_id
+            )
+            logging.info(
+                f"Subnet {subnet_name} isolated with deny-all NSG {nsg_name}. "
+                f"Waiting for duration of {duration} seconds."
+            )
+            time.sleep(duration)
+
+            # Restore original NSG association
+            self.cloud_object.update_subnet_nsg(
+                resource_group, vnet_name, subnet_name, original_nsg_id
+            )
+            logging.info(f"Subnet {subnet_name} restored to original NSG association.")
+
+            # Delete temporary deny NSG
+            self.cloud_object.delete_security_group(resource_group, nsg_name)
+            logging.info(f"Temporary chaos NSG {nsg_name} deleted successfully.")
+        except Exception as e:
+            logging.error(
+                f"Azure network-based zone outage scenario failed with exception: {e}"
+            )
+            if chaos_nsg_id and resource_group and vnet_name and subnet_name:
+                try:
+                    self.cloud_object.update_subnet_nsg(
+                        resource_group, vnet_name, subnet_name, original_nsg_id
+                    )
+                except Exception as restore_err:
+                    logging.error(
+                        f"Failed to restore original NSG during error recovery: {restore_err}"
+                    )
+                if nsg_name:
+                    try:
+                        self.cloud_object.delete_security_group(resource_group, nsg_name)
+                    except Exception as del_err:
+                        logging.warning(
+                            f"Failed to delete chaos NSG during error recovery: {del_err}"
+                        )
+            return 1
+        else:
+            return 0
+
+    @staticmethod
+    def rollback_azure_zone_outage(
+        rollback_content: RollbackContent,
+        lib_telemetry: KrknTelemetryOpenshift = None,
+    ):
+        """Rollback function to restore subnet NSG association after an Azure zone outage failure.
+
+        :param rollback_content: Rollback content containing encoded target IDs.
+        :param lib_telemetry: Instance of KrknTelemetryOpenshift (unused).
+        """
+        try:
+            decoded = base64.b64decode(
+                rollback_content.resource_identifier.encode("utf-8")
+            ).decode("utf-8")
+            rollback_data = json.loads(decoded)
+            resource_group = rollback_data["resource_group"]
+            vnet_name = rollback_data["vnet_name"]
+            subnet_name = rollback_data["subnet_name"]
+            original_nsg_id = rollback_data.get("original_nsg_id")
+            nsg_name = rollback_data.get("nsg_name")
+
+            from krkn.scenario_plugins.node_actions.az_node_scenarios import Azure
+            cloud_object = Azure()
+            logging.info(
+                f"Rolling back Azure zone outage: restoring subnet {subnet_name} in VNet {vnet_name}"
+            )
+            try:
+                cloud_object.update_subnet_nsg(
+                    resource_group, vnet_name, subnet_name, original_nsg_id
+                )
+                logging.info(f"Subnet {subnet_name} restored to original NSG: {original_nsg_id}")
+            except Exception as re_err:
+                logging.error(
+                    f"Failed to restore original NSG on subnet {subnet_name} during rollback: {re_err}"
+                )
+
+            if nsg_name:
+                try:
+                    cloud_object.delete_security_group(resource_group, nsg_name)
+                    logging.info(f"Deleted temporary chaos NSG {nsg_name} during rollback")
+                except Exception as del_err:
+                    logging.warning(
+                        f"Could not delete temporary chaos NSG {nsg_name} during rollback: {del_err}"
+                    )
+
+            logging.info("Azure zone outage rollback completed.")
+        except Exception as e:
+            logging.error(f"Failed to rollback Azure zone outage: {e}")
             raise
 
     def network_based_zone(self, scenario_config: dict[str, any]):

--- a/scenarios/openshift/zone_outage_azure.yaml
+++ b/scenarios/openshift/zone_outage_azure.yaml
@@ -1,0 +1,8 @@
+zone_outage:                                         # Scenario to create an outage of a zone by tweaking Azure subnet NSG
+  cloud_type: azure                                   # cloud type on which Kubernetes/OpenShift runs (azure or az)
+  resource_group: my-cluster-rg                       # Azure resource group containing the target VNet and subnet
+  vnet_name: my-cluster-vnet                          # Virtual Network name
+  subnet_name: my-cluster-worker-subnet               # Subnet to isolate with temporary deny-all NSG
+  duration: 600                                      # duration in seconds after which the subnet will be restored
+  location: centralindia                             # (Optional) Azure region. Auto-detected from VNet if omitted.
+  nsg_name_prefix: chaos-zone-deny                    # (Optional) Prefix for temporary deny NSG

--- a/tests/test_zone_outage_scenario_plugin.py
+++ b/tests/test_zone_outage_scenario_plugin.py
@@ -436,5 +436,102 @@ class TestZoneOutageRun(unittest.TestCase):
         self.assertEqual(result, 1)
 
 
+class TestAzureZoneOutage(unittest.TestCase):
+    """Tests for Azure zone outage functionality and rollback"""
+
+    def setUp(self):
+        self.plugin = ZoneOutageScenarioPlugin()
+        self.scenario_config = {
+            "resource_group": "rg-test",
+            "vnet_name": "vnet-test",
+            "subnet_name": "subnet-test",
+            "duration": 1,
+            "location": "centralindia",
+        }
+
+    @patch("krkn.scenario_plugins.zone_outage.zone_outage_scenario_plugin.Azure")
+    def test_run_dispatches_azure_branch(self, mock_azure_class):
+        """Test run() dispatches to network_based_zone_azure for cloud_type azure/az"""
+        mock_azure_instance = MagicMock()
+        mock_azure_class.return_value = mock_azure_instance
+
+        temp_dir = tempfile.TemporaryDirectory()
+        tmp_path = Path(temp_dir.name)
+        scenario_file = tmp_path / "azure_scenario.yaml"
+
+        with open(scenario_file, "w") as f:
+            yaml.dump({"zone_outage": {"cloud_type": "azure", **self.scenario_config}}, f)
+
+        mock_lib_telemetry = MagicMock()
+        mock_scenario_telemetry = MagicMock()
+
+        with patch.object(self.plugin, "network_based_zone_azure", return_value=0) as mock_method:
+            result = self.plugin.run("test-uuid", str(scenario_file), mock_lib_telemetry, mock_scenario_telemetry)
+            self.assertEqual(result, 0)
+            mock_method.assert_called_once()
+
+        temp_dir.cleanup()
+
+    @patch("time.sleep")
+    @patch("krkn.scenario_plugins.zone_outage.zone_outage_scenario_plugin.Azure")
+    def test_network_based_zone_azure_success(self, mock_azure_class, mock_sleep):
+        """Test successful Azure network-based zone outage execution"""
+        mock_azure_instance = MagicMock()
+        mock_azure_class.return_value = mock_azure_instance
+        self.plugin.cloud_object = mock_azure_instance
+
+        mock_azure_instance.get_subnet_nsg.return_value = "nsg-original-id"
+        mock_azure_instance.create_subnet_deny_security_group.return_value = "nsg-deny-id"
+
+        result = self.plugin.network_based_zone_azure(self.scenario_config)
+
+        self.assertEqual(result, 0)
+        mock_azure_instance.get_subnet_nsg.assert_called_with("rg-test", "vnet-test", "subnet-test")
+        mock_azure_instance.create_subnet_deny_security_group.assert_called_with(
+            "rg-test", "chaos-zone-deny-subnet-test", "centralindia"
+        )
+        self.assertEqual(mock_azure_instance.update_subnet_nsg.call_count, 2)
+        mock_azure_instance.update_subnet_nsg.assert_any_call("rg-test", "vnet-test", "subnet-test", "nsg-deny-id")
+        mock_azure_instance.update_subnet_nsg.assert_any_call("rg-test", "vnet-test", "subnet-test", "nsg-original-id")
+        mock_azure_instance.delete_security_group.assert_called_with("rg-test", "chaos-zone-deny-subnet-test")
+
+    @patch("krkn.scenario_plugins.zone_outage.zone_outage_scenario_plugin.Azure")
+    def test_network_based_zone_azure_failure(self, mock_azure_class):
+        """Test Azure zone outage failure handling"""
+        mock_azure_instance = MagicMock()
+        mock_azure_class.return_value = mock_azure_instance
+        self.plugin.cloud_object = mock_azure_instance
+
+        mock_azure_instance.get_subnet_nsg.return_value = "nsg-original-id"
+        mock_azure_instance.create_subnet_deny_security_group.side_effect = Exception("Azure API error")
+
+        result = self.plugin.network_based_zone_azure(self.scenario_config)
+
+        self.assertEqual(result, 1)
+
+    @patch("krkn.scenario_plugins.node_actions.az_node_scenarios.Azure")
+    def test_rollback_azure_zone_outage_success(self, mock_azure_class):
+        """Test successful rollback of Azure zone outage"""
+        rollback_data = {
+            "resource_group": "rg-test",
+            "vnet_name": "vnet-test",
+            "subnet_name": "subnet-test",
+            "original_nsg_id": "nsg-original-id",
+            "nsg_name": "chaos-zone-deny-subnet-test",
+        }
+        encoded = base64.b64encode(json.dumps(rollback_data).encode("utf-8")).decode("utf-8")
+        rollback_content = RollbackContent(resource_identifier=encoded)
+
+        mock_azure_instance = MagicMock()
+        mock_azure_class.return_value = mock_azure_instance
+
+        ZoneOutageScenarioPlugin.rollback_azure_zone_outage(rollback_content)
+
+        mock_azure_instance.update_subnet_nsg.assert_called_once_with(
+            "rg-test", "vnet-test", "subnet-test", "nsg-original-id"
+        )
+        mock_azure_instance.delete_security_group.assert_called_once_with("rg-test", "chaos-zone-deny-subnet-test")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
This PR adds native Azure support to `ZoneOutageScenarioPlugin` using subnet-level Network Security Group (NSG) isolation and crash-safe rollback handlers.

### Key Changes:
1. **Plugin Dispatch & Execution** (`krkn/scenario_plugins/zone_outage/zone_outage_scenario_plugin.py`):
   - Added support for `cloud_type` `azure` and `az`.
   - Implemented `network_based_zone_azure(scenario_config)` to dynamically create a temporary deny-all NSG (`*`), associate it with the target subnet, hold isolation for `duration`, restore the original NSG state, and delete the temporary deny NSG.
   - Added `@staticmethod rollback_azure_zone_outage()` handler to restore original subnet NSG state if scenario execution is interrupted or encounters an error.

2. **Azure Helper Enhancements** (`krkn/scenario_plugins/node_actions/az_node_scenarios.py`):
   - Added `create_subnet_deny_security_group`, `update_subnet_nsg` (with synchronous LRO poller wait), `get_subnet_nsg`, `get_subnet_location`, and CLI subscription auto-detection.

3. **Sample Scenario Config** (`scenarios/openshift/zone_outage_azure.yaml`):
   - Added sample Azure zone outage scenario configuration file.

4. **Unit Test Suite** (`tests/test_zone_outage_scenario_plugin.py`):
   - Added `TestAzureZoneOutage` test class covering dispatch, successful execution flow, error recovery, and rollback.

## Related Tickets & Documents
- Related Issue #1522 
- Closes #1522 

# Documentation  
- [x] **Is documentation needed for this update?**

## Related Documentation PR (if applicable)  
N/A

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

1. **Unit Test Suite**:
```bash
python3 -m pytest tests/test_zone_outage_scenario_plugin.py -v
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/shiva/github/krkn
collected 15 items

tests/test_zone_outage_scenario_plugin.py::TestZoneOutageScenarioPlugin::test_get_scenario_types PASSED [  6%]
tests/test_zone_outage_scenario_plugin.py::TestZoneOutageScenarioPlugin::test_run_aws_network_based_zone PASSED [ 13%]
tests/test_zone_outage_scenario_plugin.py::TestZoneOutageScenarioPlugin::test_run_aws_network_based_zone_failure PASSED [ 20%]
tests/test_zone_outage_scenario_plugin.py::TestZoneOutageScenarioPlugin::test_run_propagates_node_based_zone_failure PASSED [ 26%]
tests/test_zone_outage_scenario_plugin.py::TestZoneOutageScenarioPlugin::test_run_succeeds_when_node_based_zone_succeeds PASSED [ 33%]
tests/test_zone_outage_scenario_plugin.py::TestRollbackGcpZoneOutage::test_rollback_gcp_zone_outage_invalid_data PASSED [ 40%]
tests/test_zone_outage_scenario_plugin.py::TestRollbackGcpZoneOutage::test_rollback_gcp_zone_outage_partial_failure PASSED [ 46%]
tests/test_zone_outage_scenario_plugin.py::TestRollbackGcpZoneOutage::test_rollback_gcp_zone_outage_success PASSED [ 53%]
tests/test_zone_outage_scenario_plugin.py::TestZoneOutageRun::test_run_gcp_exception PASSED [ 60%]
tests/test_zone_outage_scenario_plugin.py::TestZoneOutageRun::test_run_gcp_success PASSED [ 66%]
tests/test_zone_outage_scenario_plugin.py::TestZoneOutageRun::test_run_unsupported_cloud_type PASSED [ 73%]
tests/test_zone_outage_scenario_plugin.py::TestAzureZoneOutage::test_network_based_zone_azure_failure PASSED [ 80%]
tests/test_zone_outage_scenario_plugin.py::TestAzureZoneOutage::test_network_based_zone_azure_success PASSED [ 86%]
tests/test_zone_outage_scenario_plugin.py::TestAzureZoneOutage::test_rollback_azure_zone_outage_success PASSED [ 93%]
tests/test_zone_outage_scenario_plugin.py::TestAzureZoneOutage::test_run_dispatches_azure_branch PASSED [100%]

============================== 15 passed in 2.20s ==============================
```

2. **Live Azure Infrastructure Verification Run**:
```text
2026-07-28 07:57:56,247 [INFO] Auto-detected Azure subscription_id: 1ebc6005-e172-44d7-afa4-a8ce1d36c22a
2026-07-28 07:57:56,248 [INFO] Starting Azure network-based zone outage on subnet krkn-test-subnet in VNet krkn-test-vnet (resource group: krkn-test-rg)
2026-07-28 07:58:12,012 [INFO] Subnet krkn-test-subnet isolated with deny-all NSG live-test-deny-krkn-test-subnet. Waiting for duration of 15 seconds.
2026-07-28 07:58:39,020 [INFO] Subnet krkn-test-subnet restored to original NSG association.
2026-07-28 07:58:40,383 [INFO] Temporary chaos NSG live-test-deny-krkn-test-subnet deleted successfully.
2026-07-28 07:58:40,384 [INFO] Live Azure zone outage plugin run result: 0
```