### PR TITLE
fix(prometheus): return critical alert count from alerts()

### DIFF
--- a/krkn/prometheus/client.py
+++ b/krkn/prometheus/client.py
@@ -42,7 +42,7 @@ def alerts(
     end_time,
     alert_profile,
     elastic_alerts_index
-):
+) -> int:
 
     if alert_profile is None or os.path.exists(alert_profile) is False:
         logging.error(f"{alert_profile} alert profile does not exist")
@@ -70,10 +70,11 @@ def alerts(
                 datetime.datetime.fromtimestamp(start_time),
                 datetime.datetime.fromtimestamp(end_time),
             )
-            if processed_alert[0] and processed_alert[1]:
-                if alert["severity"] == "critical":
-                    failure_alert_count += 1
-                if alert["severity"] == "error":
+            if (
+                processed_alert[0] is not None
+                and processed_alert[1] is not None
+            ):
+                if str(alert.get("severity", "")).lower().strip() in ["critical", "error"]:
                     failure_alert_count += 1
                 if elastic:
                     elastic_alert = ElasticAlert(
@@ -85,6 +86,7 @@ def alerts(
                     result = elastic.push_alert(elastic_alert, elastic_alerts_index)
                     if result == -1:
                         logging.error("failed to save alert on ElasticSearch")
+
         return failure_alert_count
 
 

--- a/tests/test_prometheus_client.py
+++ b/tests/test_prometheus_client.py
@@ -138,6 +138,98 @@ class TestAlertsKeyValidation(unittest.TestCase):
         finally:
             os.unlink(profile_path)
 
+    def test_alerts_returns_critical_and_error_firing_count(self):
+        """alerts() should return the count of firing alerts with severity critical or error."""
+        profile_path = self._write_alert_profile(
+            '- expr: "up == 0"\n'
+            '  description: "critical alert"\n'
+            '  severity: "critical"\n'
+            '- expr: "node == 0"\n'
+            '  description: "error alert"\n'
+            '  severity: "error"\n'
+            '- expr: "mem > 80"\n'
+            '  description: "warning alert"\n'
+            '  severity: "warning"\n'
+        )
+        try:
+            self.prom_cli.process_alert.side_effect = [
+                (self.start_time, "critical alert"),
+                (self.start_time, "error alert"),
+                (self.start_time, "warning alert"),
+            ]
+            self.elastic.push_alert.return_value = 0
+
+            count = client.alerts(
+                self.prom_cli,
+                self.elastic,
+                self.run_uuid,
+                self.start_time,
+                self.end_time,
+                profile_path,
+                self.elastic_alerts_index,
+            )
+
+            self.assertEqual(count, 2)
+        finally:
+            os.unlink(profile_path)
+
+    def test_alerts_returns_zero_when_no_alerts_fire(self):
+        """alerts() should return 0 when no critical/error alerts fire."""
+        profile_path = self._write_alert_profile(
+            '- expr: "up == 0"\n'
+            '  description: "critical alert"\n'
+            '  severity: "critical"\n'
+        )
+        try:
+            self.prom_cli.process_alert.return_value = (None, None)
+
+            count = client.alerts(
+                self.prom_cli,
+                self.elastic,
+                self.run_uuid,
+                self.start_time,
+                self.end_time,
+                profile_path,
+                self.elastic_alerts_index,
+            )
+
+            self.assertEqual(count, 0)
+        finally:
+            os.unlink(profile_path)
+
+    def test_alerts_handles_case_insensitive_severity(self):
+        """alerts() should match severities case-insensitively (e.g. CRITICAL or Error)."""
+        profile_path = self._write_alert_profile(
+            '- expr: "up == 0"\n'
+            '  description: "uppercase critical"\n'
+            '  severity: "CRITICAL"\n'
+            '- expr: "node == 0"\n'
+            '  description: "capitalized error"\n'
+            '  severity: "Error"\n'
+        )
+        try:
+            self.prom_cli.process_alert.side_effect = [
+                (self.start_time, "uppercase critical"),
+                (self.start_time, "capitalized error"),
+            ]
+            self.elastic.push_alert.return_value = 0
+
+            count = client.alerts(
+                self.prom_cli,
+                self.elastic,
+                self.run_uuid,
+                self.start_time,
+                self.end_time,
+                profile_path,
+                self.elastic_alerts_index,
+            )
+
+            self.assertEqual(count, 2)
+        finally:
+            os.unlink(profile_path)
+
+
+
 
 class TestAlertsFailureCount(unittest.TestCase):
     """Tests that alerts() returns the correct failure count for critical/error severity."""


### PR DESCRIPTION
# Type of change

- [x] Bug fix

# Description  
Updated `alerts()` in `krkn/prometheus/client.py` to return the integer count of firing critical and error alerts (`failure_alert_count`). Also added hardened `is not None` timestamp checks, case-insensitive severity evaluation, and added unit tests in `tests/test_prometheus_client.py`.

## Related Tickets & Documents

Issue: 

## Related Documentation PR (if applicable)  

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python -m unittest tests/test_prometheus_client.py
```

```text
.......ERROR:root:wrong alert {'expr': 'up == 0', 'description': 'target down'}, skipping
....ERROR:root:wrong alert {'wrong_key': 'up == 0', 'another_bad_key': 'test', 'third_bad_key': 'info'}, skipping
.ERROR:root:wrong alert {'wrong_key': 'bad', 'other': 'bad', 'extra': 'bad'}, skipping
.................
----------------------------------------------------------------------
Ran 29 tests in 0.014s

OK
```
