### PR TITLE
changing setuptools version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
           pip install -r requirements.txt
           pip install coverage
           # Force setuptools==81.0.0 after all deps (some may try to upgrade it to 82+, which removes pkg_resources)
-          pip install --force-reinstall --no-deps setuptools==81.0.0
+          #pip install --force-reinstall --no-deps setuptools==81.0.0
 
       - name: Deploy test workloads
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ requests>=2.32.4  # Fixes GHSA-9hjg-9r4m-mvj7, GHSA-9wx4-h78v-vm56, GHSA-gc5v-m9
 urllib3>=2.7.0  # Fixes GHSA-qccp-gfcp-xxvc, GHSA-38jv-5279-wg99, GHSA-gm62-xv2j-4w53, GHSA-2xpw-w6gg-jr37
 service_identity==24.1.0
 PyYAML==6.0.1
-setuptools==83.0.0  # Has pkg_resources (required by VMware SDK) + newer vendored jaraco-context
+setuptools<82.0.0  # Has pkg_resources (required by VMware SDK) + newer vendored jaraco-context
 wheel>=0.46.2  # Fixes GHSA-8rrh-rw8j-w5fx
 colorlog==6.10.1
 


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  
The pkg_resources module was removed in setuptools version 82.0.0 and above, so a change was made in requirements.txt to install a version of setuptools<82.0.0, and the force install of 81.0.0 is removed in the test workflow. 