### PR TITLE
Adding summary instead of all output

### DIFF
--- a/run_kraken.py
+++ b/run_kraken.py
@@ -83,7 +83,7 @@ report_file = ""
 
 
 # Main function
-def main(options, command: Optional[str]) -> int:
+def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
     # Start kraken
     print(pyfiglet.figlet_format("krkn"))
     logging.info("Starting krkn")
@@ -679,6 +679,8 @@ def main(options, command: Optional[str]) -> int:
         try:
             text_summary = build_chaos_report(chaos_output_dict)
             logging.info(f"\n{text_summary}")
+            if out is not None:
+                out["text_summary"] = text_summary
         except Exception as e:
             logging.error(f"Failed to build text summary: {e}")
 
@@ -984,7 +986,8 @@ if __name__ == "__main__":
     else:
         # Check if command is provided as positional argument
         command = args[0] if args else None
-        retval = main(options, command)
+        out = {}
+        retval = main(options, command, out)
 
     junit_endtime = time.time()
 
@@ -994,7 +997,7 @@ if __name__ == "__main__":
             success=retval == 0,
             elapsed_seconds=junit_endtime - junit_start_time,
             test_case_description=options.junit_testcase,
-            test_stdout=tee_handler.get_output(),
+            test_stdout=out.get("text_summary") or tee_handler.get_output(),
             test_version=options.junit_testcase_version,
         )
 


### PR DESCRIPTION
# Type of change

- [X] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
Using summary details instead of all ouptut in xml 

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: 
- Closes #: 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
<testsuites tests="1" skipped="0" errors="0" failures="1" time="27"><testsuite name="chaos-krkn" tests="1" skipped="0" errors="0" failures="1" time="27" timestamp="2026-07-30T15:25:35"><properties><property name="TestVersion" value="4.20" /></properties><testcase name="test" classname="" time="27"><failure message="">================================================================================
KRKN RUN SUMMARY
================================================================================
Run UUID : f3f9ac86-a957-4725-8781-280e3448b6e9
Status   : FAIL
Cluster  : 4.20.4 (GCP, self-managed)
Window   : 2026-07-30 11:25:12 – 11:25:24
Nodes    : 6
Network  : OVNKubernetes
CLUSTER OVERVIEW
  Type     Count  Instance       Arch    Kubelet    OS
  master   3      n2-standard-4  amd64   v1.33.5    Red Hat Enterprise Linux CoreOS 9.6.20251110-1 (Plow)
  worker   3      n2-standard-4  amd64   v1.33.5    Red Hat Enterprise Linux CoreOS 9.6.20251110-1 (Plow)
TARGETS
  [1] Scenario  : scenarios/openshift/etcd.yml (pod_disruption_scenarios)
  Label Selector : k8s-app=etcd
  Namespace      : ^openshift-etcd$
  Pods Disrupted :
    - openshift-etcd/etcd-p.internal
KEY METRICS
  [1] Scenario: scenarios/openshift/etcd.yml
    Exit Status           : PASS (0)
    Pods Recovered        : 1
    Pods Unrecovered      : 0
    Total Recovery Time   : 1.62s
      ├─ Rescheduling Time: 0.05s
      └─ Readiness Time   : 1.57s
ALERTS &amp; SLOs
  SLOs Evaluated  : 27
  SLOs Passed     : 26 / 27
  SLOs Failed     : 1
  Critical Alerts : None
FAILED SLOs (per scenario)
  Scenario: scenarios/openshift/etcd.yml
    FAIL  [error   ]  10 minutes avg. 99th etcd fsync latency on {{$labels.pod}} higher than 10ms. {{$value}}s
RESILIENCY SCORE
  scenarios/openshift/etcd.yml : 97 / 100
  Overall Score                : 97 / 100  ✅
================================================================================</failure></testcase></testsuite></testsuites>
```
