### PR TITLE
Register PVC rollback before creating temporary file

### DIFF
--- a/krkn/rollback/handler.py
+++ b/krkn/rollback/handler.py
@@ -276,5 +276,7 @@ class RollbackHandler:
                 callable, rollback_content, version
             )
             logger.info(f"Rollback callable serialized to {version_file}")
+            return True
         except Exception as e:
             logger.error(f"Failed to serialize rollback callable: {e}")
+            return False

--- a/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
+++ b/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
@@ -193,6 +193,28 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                 logging.debug("File size: %s KB" % file_size_kb)
 
                 file_name = "kraken.tmp"
+
+                full_path = "%s/%s" % (str(mount_path), str(file_name))
+                
+                # Set rollback callable to ensure temp file cleanup on failure or interruption
+                rollback_data = {
+                    "pod_name": pod_name,
+                    "container_name": container_name,
+                    "mount_path": mount_path,
+                    "file_name": file_name,
+                    "full_path": full_path,
+                }
+                json_str = json.dumps(rollback_data)
+                encoded_data = base64.b64encode(json_str.encode('utf-8')).decode('utf-8')
+                self.rollback_handler.set_rollback_callable(
+                    self.rollback_temp_file,
+                    RollbackContent(
+                        namespace=namespace,
+                        resource_identifier=encoded_data,
+                    ),
+                )
+                
+                # Create temp file in the PVC
                 logging.info(
                     "Creating %s file, %s KB size, in pod %s at %s (ns %s)"
                     % (
@@ -203,9 +225,6 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                         str(namespace),
                     )
                 )
-
-                # Create temp file in the PVC
-                full_path = "%s/%s" % (str(mount_path), str(file_name))
 
                 fallocate = lib_telemetry.get_lib_kubernetes().exec_cmd_in_pod(
                     ["command -v fallocate"],
@@ -256,24 +275,7 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                 logging.info("\n" + str(response))
                 if str(file_name).lower() in str(response).lower():
                     logging.info("%s file successfully created" % (str(full_path)))
-                    
-                    # Set rollback callable to ensure temp file cleanup on failure or interruption
-                    rollback_data = {
-                        "pod_name": pod_name,
-                        "container_name": container_name,
-                        "mount_path": mount_path,
-                        "file_name": file_name,
-                        "full_path": full_path,
-                    }
-                    json_str = json.dumps(rollback_data)
-                    encoded_data = base64.b64encode(json_str.encode('utf-8')).decode('utf-8')
-                    self.rollback_handler.set_rollback_callable(
-                        self.rollback_temp_file,
-                        RollbackContent(
-                            namespace=namespace,
-                            resource_identifier=encoded_data,
-                        ),
-                    )
+                      
                 else:
                     logging.error(
                         "PvcScenarioPlugin Failed to create tmp file with %s size"

--- a/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
+++ b/krkn/scenario_plugins/pvc/pvc_scenario_plugin.py
@@ -206,13 +206,18 @@ class PvcScenarioPlugin(AbstractScenarioPlugin):
                 }
                 json_str = json.dumps(rollback_data)
                 encoded_data = base64.b64encode(json_str.encode('utf-8')).decode('utf-8')
-                self.rollback_handler.set_rollback_callable(
+                success = self.rollback_handler.set_rollback_callable(
                     self.rollback_temp_file,
                     RollbackContent(
                         namespace=namespace,
                         resource_identifier=encoded_data,
                     ),
                 )
+                if not success:
+                    logging.error(
+                        "PvcScenarioPlugin Failed to register rollback context. Aborting scenario."
+                    )
+                    return 1
                 
                 # Create temp file in the PVC
                 logging.info(


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  
This PR changes the ordering of the PVC scenario so that the rollback context is registered **before** creating the temporary file used to fill the PVC.
Previously, the flow was:
```text
Create kraken.tmp
↓
Verify creation
↓
Register rollback callable
```
If rollback serialization failed after the file had already been created, the scenario could continue without any persisted rollback information.
The updated flow is:
```text
Prepare rollback metadata
↓
Register rollback callable
↓
Create kraken.tmp
↓
Verify creation
```
## Changes
- Register the rollback callable before creating `kraken.tmp`.
- Update `RollbackHandler.set_rollback_callable()` to return a boolean indicating whether rollback registration succeeded.
- Abort the PVC scenario if rollback registration fails.
- Preserve the existing behavior of other scenario plugins by allowing them to ignore the return value.

## Related Tickets & Documents

- Related Issue #1521 
- Closes #1521 

# Checklist before requesting a review
[x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

Description of combination of tests performed and output of run
<img width="907" height="123" alt="Screenshot 2026-07-31 at 9 32 34 PM" src="https://github.com/user-attachments/assets/faebb75b-9f50-4d19-ac26-0c81a73a1c2f" />

