### PR TITLE
Split the general group into kraken and tunings

### DIFF
--- a/containers/krknctl-input.json
+++ b/containers/krknctl-input.json
@@ -57,6 +57,18 @@
     "group": "kraken"
   },
   {
+    "name": "krkn-debug",
+    "short_description": "Krkn debug mode",
+    "description": "Enables debug mode for Krkn",
+    "variable": "KRKN_DEBUG",
+    "type": "enum",
+    "allowed_values": "True,False",
+    "separator": ",",
+    "default": "False",
+    "required": "false",
+    "group": "kraken"
+  },
+  {
     "name": "tunings",
     "short_description": "Tunings group",
     "description": "Group containing chaos scenario timing and repetition configuration options",
@@ -91,44 +103,6 @@
     "default": "False",
     "required": "false",
     "group": "tunings"
-  },
-  {
-    "name": "general",
-    "short_description": "General group",
-    "description": "Group containing general krkn configuration options",
-    "type": "Group"
-  },
-  {
-    "name": "ssh-public-key",
-    "short_description": "Krkn ssh public key path",
-    "description": "Sets the path where krkn will search for ssh public key (in container)",
-    "variable": "KRKN_SSH_PUBLIC",
-    "type": "string",
-    "default": "",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "ssh-private-key",
-    "short_description": "Krkn ssh private key path",
-    "description": "Sets the path where krkn will search for ssh private key (in container)",
-    "variable": "KRKN_SSH_PRIVATE",
-    "type": "string",
-    "default": "",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "krkn-debug",
-    "short_description": "Krkn debug mode",
-    "description": "Enables debug mode for Krkn",
-    "variable": "KRKN_DEBUG",
-    "type": "enum",
-    "allowed_values": "True,False",
-    "separator": ",",
-    "default": "False",
-    "required": "false",
-    "group": "general"
   },
   {
     "name": "prometheus",

--- a/containers/krknctl-input.json
+++ b/containers/krknctl-input.json
@@ -29,6 +29,70 @@
     "group": "cerberus"
   },
   {
+    "name": "kraken",
+    "short_description": "Kraken group",
+    "description": "Group containing core krkn run configuration options",
+    "type": "Group"
+  },
+  {
+    "name": "krkn-kubeconfig",
+    "short_description": "Krkn kubeconfig path",
+    "description": "Sets the path where krkn will search for kubeconfig (in container)",
+    "variable": "KRKN_KUBE_CONFIG",
+    "type": "string",
+    "default": "/home/krkn/.kube/config",
+    "required": "false",
+    "group": "kraken"
+  },
+  {
+    "name": "generate-pdf-report",
+    "short_description": "Generate PDF report",
+    "description": "Generate a PDF summary report after the chaos run",
+    "variable": "GENERATE_PDF_REPORT",
+    "type": "enum",
+    "allowed_values": "True,False",
+    "separator": ",",
+    "default": "True",
+    "required": "false",
+    "group": "kraken"
+  },
+  {
+    "name": "tunings",
+    "short_description": "Tunings group",
+    "description": "Group containing chaos scenario timing and repetition configuration options",
+    "type": "Group"
+  },
+  {
+    "name": "wait-duration",
+    "short_description": "Post chaos wait duration",
+    "description": "waits for a certain amount of time after the scenario",
+    "variable": "WAIT_DURATION",
+    "type": "number",
+    "default": "1",
+    "group": "tunings"
+  },
+  {
+    "name": "iterations",
+    "short_description": "Chaos scenario iterations",
+    "description": "number of times the same chaos scenario will be executed",
+    "variable": "ITERATIONS",
+    "type": "number",
+    "default": "1",
+    "group": "tunings"
+  },
+  {
+    "name": "daemon-mode",
+    "short_description": "Sets krkn daemon mode",
+    "description": "if set the scenario will execute forever",
+    "variable": "DAEMON_MODE",
+    "type": "enum",
+    "allowed_values": "True,False",
+    "separator": ",",
+    "default": "False",
+    "required": "false",
+    "group": "tunings"
+  },
+  {
     "name": "general",
     "short_description": "General group",
     "description": "Group containing general krkn configuration options",
@@ -51,68 +115,6 @@
     "variable": "KRKN_SSH_PRIVATE",
     "type": "string",
     "default": "",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "krkn-kubeconfig",
-    "short_description": "Krkn kubeconfig path",
-    "description": "Sets the path where krkn will search for kubeconfig (in container)",
-    "variable": "KRKN_KUBE_CONFIG",
-    "type": "string",
-    "default": "/home/krkn/.kube/config",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "wait-duration",
-    "short_description": "Post chaos wait duration",
-    "description": "waits for a certain amount of time after the scenario",
-    "variable": "WAIT_DURATION",
-    "type": "number",
-    "default": "1",
-    "group": "general"
-  },
-  {
-    "name": "iterations",
-    "short_description": "Chaos scenario iterations",
-    "description": "number of times the same chaos scenario will be executed",
-    "variable": "ITERATIONS",
-    "type": "number",
-    "default": "1",
-    "group": "general"
-  },
-  {
-    "name": "daemon-mode",
-    "short_description": "Sets krkn daemon mode",
-    "description": "if set the scenario will execute forever",
-    "variable": "DAEMON_MODE",
-    "type": "enum",
-    "allowed_values": "True,False",
-    "separator": ",",
-    "default": "False",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "uuid",
-    "short_description": "Sets krkn run uuid",
-    "description": "sets krkn run uuid instead of generating it",
-    "variable": "UUID",
-    "type": "string",
-    "default": "",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "generate-pdf-report",
-    "short_description": "Generate PDF report",
-    "description": "Generate a PDF summary report after the chaos run",
-    "variable": "GENERATE_PDF_REPORT",
-    "type": "enum",
-    "allowed_values": "True,False",
-    "separator": ",",
-    "default": "True",
     "required": "false",
     "group": "general"
   },
@@ -149,6 +151,16 @@
     "short_description": "Prometheus bearer token",
     "description": "Prometheus bearer token for prometheus url authentication",
     "variable": "PROMETHEUS_TOKEN",
+    "type": "string",
+    "default": "",
+    "required": "false",
+    "group": "prometheus"
+  },
+  {
+    "name": "uuid",
+    "short_description": "Sets krkn run uuid",
+    "description": "sets krkn run uuid instead of generating it",
+    "variable": "UUID",
     "type": "string",
     "default": "",
     "required": "false",

--- a/containers/krknctl-input.json
+++ b/containers/krknctl-input.json
@@ -29,6 +29,70 @@
     "group": "cerberus"
   },
   {
+    "name": "kraken",
+    "short_description": "Kraken group",
+    "description": "Group containing core krkn run configuration options",
+    "type": "Group"
+  },
+  {
+    "name": "krkn-kubeconfig",
+    "short_description": "Krkn kubeconfig path",
+    "description": "Sets the path where krkn will search for kubeconfig (in container)",
+    "variable": "KRKN_KUBE_CONFIG",
+    "type": "string",
+    "default": "/home/krkn/.kube/config",
+    "required": "false",
+    "group": "kraken"
+  },
+  {
+    "name": "generate-pdf-report",
+    "short_description": "Generate PDF report",
+    "description": "Generates a PDF report summarizing the chaos run results at the end of each scenario",
+    "variable": "GENERATE_PDF_REPORT",
+    "type": "enum",
+    "allowed_values": "True,False",
+    "separator": ",",
+    "default": "True",
+    "required": "false",
+    "group": "kraken"
+  },
+  {
+    "name": "tunings",
+    "short_description": "Tunings group",
+    "description": "Group containing chaos scenario timing and repetition configuration options",
+    "type": "Group"
+  },
+  {
+    "name": "wait-duration",
+    "short_description": "Post chaos wait duration",
+    "description": "waits for a certain amount of time after the scenario",
+    "variable": "WAIT_DURATION",
+    "type": "number",
+    "default": "1",
+    "group": "tunings"
+  },
+  {
+    "name": "iterations",
+    "short_description": "Chaos scenario iterations",
+    "description": "number of times the same chaos scenario will be executed",
+    "variable": "ITERATIONS",
+    "type": "number",
+    "default": "1",
+    "group": "tunings"
+  },
+  {
+    "name": "daemon-mode",
+    "short_description": "Sets krkn daemon mode",
+    "description": "if set the scenario will execute forever",
+    "variable": "DAEMON_MODE",
+    "type": "enum",
+    "allowed_values": "True,False",
+    "separator": ",",
+    "default": "False",
+    "required": "false",
+    "group": "tunings"
+  },
+  {
     "name": "general",
     "short_description": "General group",
     "description": "Group containing general krkn configuration options",
@@ -51,68 +115,6 @@
     "variable": "KRKN_SSH_PRIVATE",
     "type": "string",
     "default": "",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "krkn-kubeconfig",
-    "short_description": "Krkn kubeconfig path",
-    "description": "Sets the path where krkn will search for kubeconfig (in container)",
-    "variable": "KRKN_KUBE_CONFIG",
-    "type": "string",
-    "default": "/home/krkn/.kube/config",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "wait-duration",
-    "short_description": "Post chaos wait duration",
-    "description": "waits for a certain amount of time after the scenario",
-    "variable": "WAIT_DURATION",
-    "type": "number",
-    "default": "1",
-    "group": "general"
-  },
-  {
-    "name": "iterations",
-    "short_description": "Chaos scenario iterations",
-    "description": "number of times the same chaos scenario will be executed",
-    "variable": "ITERATIONS",
-    "type": "number",
-    "default": "1",
-    "group": "general"
-  },
-  {
-    "name": "daemon-mode",
-    "short_description": "Sets krkn daemon mode",
-    "description": "if set the scenario will execute forever",
-    "variable": "DAEMON_MODE",
-    "type": "enum",
-    "allowed_values": "True,False",
-    "separator": ",",
-    "default": "False",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "uuid",
-    "short_description": "Sets krkn run uuid",
-    "description": "sets krkn run uuid instead of generating it",
-    "variable": "UUID",
-    "type": "string",
-    "default": "",
-    "required": "false",
-    "group": "general"
-  },
-  {
-    "name": "generate-pdf-report",
-    "short_description": "Generate PDF report",
-    "description": "Generates a PDF report summarizing the chaos run results at the end of each scenario",
-    "variable": "GENERATE_PDF_REPORT",
-    "type": "enum",
-    "allowed_values": "True,False",
-    "separator": ",",
-    "default": "True",
     "required": "false",
     "group": "general"
   },
@@ -149,6 +151,16 @@
     "short_description": "Prometheus bearer token",
     "description": "Prometheus bearer token for prometheus url authentication",
     "variable": "PROMETHEUS_TOKEN",
+    "type": "string",
+    "default": "",
+    "required": "false",
+    "group": "prometheus"
+  },
+  {
+    "name": "uuid",
+    "short_description": "Sets krkn run uuid",
+    "description": "sets krkn run uuid instead of generating it",
+    "variable": "UUID",
     "type": "string",
     "default": "",
     "required": "false",


### PR DESCRIPTION
# Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

# Description

Splits `general` into `kraken` and `tunings` so every group maps onto one section of `config/config.yaml`. 
Reasoning in #1534.

Adds two `"type": "Group"` descriptors, moves seven parameters, drops the now-empty `general`. 
**78 parameters -> 76.**

| parameter | to | key |
| --- | --- | --- |
| `krkn-kubeconfig` | `kraken` | `kraken.kubeconfig_path` |
| `generate-pdf-report` | `kraken` | `kraken.generate_pdf_report` |
| `krkn-debug` | `kraken` | none, krknctl page already lists it under Kraken |
| `wait-duration` | `tunings` | `tunings.wait_duration` |
| `iterations` | `tunings` | `tunings.iterations` |
| `daemon-mode` | `tunings` | `tunings.daemon_mode` |
| `uuid` | `prometheus` | `performance_monitoring.uuid` |

Also removes `ssh-public-key` and `ssh-private-key`. 
No field other than `group` changed on any parameter that stays.

## Related Tickets & Documents

- Related Issue #: #1534
- Closes #1534

# Documentation

- [x] **Is documentation needed for this update?**

Both "All Scenarios Variables" pages take their headings from `group`, tracked in krkn-chaos/website#320. PR follows once this lands.

# Checklist before requesting a review

- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

Not a core feature, no code changed.

*REQUIRED*:
Description of combination of tests performed and output of run

No krkn code path reads this file. 
It goes into the `krknctl.input_fields.global` LABEL via `containers/compile_dockerfile.sh` and is parsed by krknctl. 
Diffed the parsed JSON before and after:

```
params 78 -> 76
groups  -general +kraken +tunings
removed: ssh-public-key, ssh-private-key
added:   none
non-group field changes: none
```

