### PR TITLE
feat(pod-disruption): support parallel pod deletion

### DIFF
--- a/krkn/scenario_plugins/pod_disruption/models/models.py
+++ b/krkn/scenario_plugins/pod_disruption/models/models.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from dataclasses import dataclass
 
 @dataclass
@@ -21,6 +22,9 @@ class InputParams:
             self.timeout = config["timeout"] if "timeout" in config else 120
             self.duration = config["duration"] if "duration" in config else 10
             self.kill_mode = config["kill_mode"] if "kill_mode" in config else "sequential"
+            if self.kill_mode not in ["sequential", "parallel"]:
+                logging.warning(f"Unknown kill_mode '{self.kill_mode}' in config. Defaulting to 'sequential'.")
+                self.kill_mode = "sequential"
             self.krkn_pod_recovery_time = config["krkn_pod_recovery_time"] if "krkn_pod_recovery_time" in config else 120
             self.label_selector = config["label_selector"] if "label_selector" in config else ""
             self.namespace_pattern = config["namespace_pattern"] if "namespace_pattern" in config else ""

--- a/krkn/scenario_plugins/pod_disruption/models/models.py
+++ b/krkn/scenario_plugins/pod_disruption/models/models.py
@@ -20,6 +20,7 @@ class InputParams:
             self.kill = config["kill"] if "kill" in config else 1
             self.timeout = config["timeout"] if "timeout" in config else 120
             self.duration = config["duration"] if "duration" in config else 10
+            self.kill_mode = config["kill_mode"] if "kill_mode" in config else "sequential"
             self.krkn_pod_recovery_time = config["krkn_pod_recovery_time"] if "krkn_pod_recovery_time" in config else 120
             self.label_selector = config["label_selector"] if "label_selector" in config else ""
             self.namespace_pattern = config["namespace_pattern"] if "namespace_pattern" in config else ""
@@ -33,6 +34,7 @@ class InputParams:
     timeout: int
     duration: int
     kill: int
+    kill_mode: str
     label_selector: str
     name_pattern: str
     node_label_selector: str

--- a/krkn/scenario_plugins/pod_disruption/models/models.py
+++ b/krkn/scenario_plugins/pod_disruption/models/models.py
@@ -21,10 +21,9 @@ class InputParams:
             self.kill = config["kill"] if "kill" in config else 1
             self.timeout = config["timeout"] if "timeout" in config else 120
             self.duration = config["duration"] if "duration" in config else 10
-            self.kill_mode = config["kill_mode"] if "kill_mode" in config else "sequential"
-            if self.kill_mode not in ["sequential", "parallel"]:
-                logging.warning(f"Unknown kill_mode '{self.kill_mode}' in config. Defaulting to 'sequential'.")
-                self.kill_mode = "sequential"
+            self.execution = config["execution"] if "execution" in config else "serial"
+            if self.execution not in ["serial", "parallel"]:
+                raise ValueError(f"Unknown execution '{self.execution}' in config. Supported values are: serial, parallel.")
             self.krkn_pod_recovery_time = config["krkn_pod_recovery_time"] if "krkn_pod_recovery_time" in config else 120
             self.label_selector = config["label_selector"] if "label_selector" in config else ""
             self.namespace_pattern = config["namespace_pattern"] if "namespace_pattern" in config else ""
@@ -38,7 +37,7 @@ class InputParams:
     timeout: int
     duration: int
     kill: int
-    kill_mode: str
+    execution: str
     label_selector: str
     name_pattern: str
     node_label_selector: str

--- a/krkn/scenario_plugins/pod_disruption/models/models.py
+++ b/krkn/scenario_plugins/pod_disruption/models/models.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import logging
 from dataclasses import dataclass
 
 @dataclass

--- a/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
+++ b/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
@@ -14,6 +14,8 @@
 import logging
 import random
 import time
+import queue
+import threading
 from asyncio import Future
 import traceback
 import yaml
@@ -236,12 +238,20 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
                 return 1
             
             random.shuffle(pods)
+            
+            pods_to_kill = []
             for i in range(config.kill):
                 pod = pods[i]
                 logging.info(pod)
                 if pod[0] in exclude_pods:
                     logging.info(f"Excluding {pod[0]} from chaos")
                 else:
+                    pods_to_kill.append(pod)
+                    
+            if config.kill_mode == "parallel":
+                self._delete_pods_parallel(pods_to_kill, kubecli)
+            else:
+                for pod in pods_to_kill:
                     logging.info(f'Deleting pod {pod[0]}')
                     kubecli.delete_pod(pod[0], pod[1])
             
@@ -272,3 +282,37 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
                 return 1
 
         return 0
+
+    def _delete_pods_parallel(self, pods: list, kubecli: KrknKubernetes):
+        """Delete pods concurrently using threading, mirroring the network_chaos_ng pattern."""
+        error_queue = queue.Queue()
+        threads = []
+
+        def _delete(pod):
+            try:
+                logging.info(f'[parallel] Deleting pod {pod[0]}')
+                kubecli.delete_pod(pod[0], pod[1])
+            except Exception as exc:
+                error_queue.put(exc)
+
+        for pod in pods:
+            t = threading.Thread(target=_delete, args=(pod,))
+            t.daemon = True
+            t.start()
+            threads.append(t)
+
+        for t in threads:
+            t.join()
+
+        errors = []
+        while True:
+            try:
+                errors.append(error_queue.get_nowait())
+            except queue.Empty:
+                break
+
+        if errors:
+            raise Exception(
+                f"parallel pod deletion failed with {len(errors)} error(s): "
+                + "; ".join(str(e) for e in errors)
+            )

--- a/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
+++ b/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
@@ -16,20 +16,21 @@ import random
 import time
 import queue
 import threading
-from asyncio import Future
 import traceback
+import concurrent.futures
+from asyncio import Future
+from datetime import datetime
+from dataclasses import dataclass
+
 import yaml
 from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.k8s.pod_monitor import select_and_monitor_by_namespace_pattern_and_label, \
     select_and_monitor_by_name_pattern_and_namespace_pattern
-
-from krkn.scenario_plugins.pod_disruption.models.models import InputParams
 from krkn_lib.models.telemetry import ScenarioTelemetry
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 from krkn_lib.models.pod_monitor.models import PodsSnapshot
-from datetime import datetime
-from dataclasses import dataclass
 
+from krkn.scenario_plugins.pod_disruption.models.models import InputParams
 from krkn.scenario_plugins.abstract_scenario_plugin import AbstractScenarioPlugin
 
 @dataclass
@@ -284,9 +285,8 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
         return 0
 
     def _delete_pods_parallel(self, pods: list, kubecli: KrknKubernetes):
-        """Delete pods concurrently using threading, mirroring the network_chaos_ng pattern."""
+        """Delete pods concurrently using a thread pool to avoid unbounded threads."""
         error_queue = queue.Queue()
-        threads = []
 
         def _delete(pod):
             try:
@@ -295,14 +295,11 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
             except Exception as exc:
                 error_queue.put(exc)
 
-        for pod in pods:
-            t = threading.Thread(target=_delete, args=(pod,))
-            t.daemon = True
-            t.start()
-            threads.append(t)
-
-        for t in threads:
-            t.join()
+        # Cap the number of workers to prevent overloading the apiserver
+        max_workers = min(10, len(pods)) if pods else 1
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [executor.submit(_delete, pod) for pod in pods]
+            concurrent.futures.wait(futures)
 
         errors = []
         while True:

--- a/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
+++ b/krkn/scenario_plugins/pod_disruption/pod_disruption_scenario_plugin.py
@@ -249,7 +249,7 @@ class PodDisruptionScenarioPlugin(AbstractScenarioPlugin):
                 else:
                     pods_to_kill.append(pod)
                     
-            if config.kill_mode == "parallel":
+            if config.execution == "parallel":
                 self._delete_pods_parallel(pods_to_kill, kubecli)
             else:
                 for pod in pods_to_kill:

--- a/scenarios/kube/pod.yml
+++ b/scenarios/kube/pod.yml
@@ -4,4 +4,5 @@
     name_pattern: ^nginx-.*$
     namespace_pattern: ^default$
     kill: 1
+    # kill_mode: sequential  # optional: sequential (default) | parallel
     krkn_pod_recovery_time: 120

--- a/scenarios/kube/pod.yml
+++ b/scenarios/kube/pod.yml
@@ -4,5 +4,5 @@
     name_pattern: ^nginx-.*$
     namespace_pattern: ^default$
     kill: 1
-    # kill_mode: sequential  # optional: sequential (default) | parallel
+    # execution: serial      # optional: serial (default) | parallel
     krkn_pod_recovery_time: 120

--- a/scenarios/openshift/etcd.yml
+++ b/scenarios/openshift/etcd.yml
@@ -3,5 +3,7 @@
   config:
     namespace_pattern: ^openshift-etcd$
     label_selector: k8s-app=etcd
+    kill: 2
+    kill_mode: parallel    # optional: sequential (default) | parallel
     krkn_pod_recovery_time: 120
     exclude_label: "" # excludes pods marked with this label from chaos

--- a/scenarios/openshift/etcd_quorum_loss.yml
+++ b/scenarios/openshift/etcd_quorum_loss.yml
@@ -3,5 +3,7 @@
   config:
     namespace_pattern: ^openshift-etcd$
     label_selector: k8s-app=etcd
+    kill: 2
+    kill_mode: parallel    # optional: sequential (default) | parallel
     krkn_pod_recovery_time: 120
     exclude_label: "" # excludes pods marked with this label from chaos

--- a/scenarios/openshift/etcd_quorum_loss.yml
+++ b/scenarios/openshift/etcd_quorum_loss.yml
@@ -4,6 +4,6 @@
     namespace_pattern: ^openshift-etcd$
     label_selector: k8s-app=etcd
     kill: 2
-    kill_mode: parallel    # optional: sequential (default) | parallel
+    execution: parallel    # optional: serial (default) | parallel
     krkn_pod_recovery_time: 120
     exclude_label: "" # excludes pods marked with this label from chaos

--- a/tests/test_pod_disruption_scenario_plugin.py
+++ b/tests/test_pod_disruption_scenario_plugin.py
@@ -70,6 +70,14 @@ class TestKillingPodsMode(unittest.TestCase):
         params = InputParams({"kill": 2, "kill_mode": "parallel"})
         self.assertEqual(params.kill_mode, "parallel")
 
+    def test_kill_mode_invalid_defaults_to_sequential(self):
+        """kill_mode defaults to 'sequential' and logs warning on unknown values."""
+        with self.assertLogs(level='WARNING') as cm:
+            params = InputParams({"kill": 2, "kill_mode": "invalid_mode"})
+        
+        self.assertEqual(params.kill_mode, "sequential")
+        self.assertTrue(any("Unknown kill_mode 'invalid_mode'" in log for log in cm.output))
+
     # --- killing_pods() behaviour ---
 
     def test_not_enough_pods_returns_error(self):
@@ -95,9 +103,20 @@ class TestKillingPodsMode(unittest.TestCase):
         self.kubecli.delete_pod.assert_any_call("pod2", "ns1")
 
     def test_parallel_mode_calls_delete_concurrently(self):
-        """Parallel mode deletes all selected pods and calls delete_pod for each."""
+        """Parallel mode deletes all selected pods and calls delete_pod for each concurrently."""
         config = InputParams({"kill": 2, "kill_mode": "parallel"})
-        self.plugin.get_pods.return_value = [("pod1", "ns1"), ("pod2", "ns1")]
+        pods = [("pod1", "ns1"), ("pod2", "ns1")]
+        self.plugin.get_pods.return_value = pods
+
+        # Use a barrier to prove threads run concurrently. If they run serially, 
+        # the first thread will block forever waiting for the second.
+        import threading
+        barrier = threading.Barrier(2, timeout=5)
+        
+        def side_effect(name, namespace):
+            barrier.wait()
+
+        self.kubecli.delete_pod.side_effect = side_effect
 
         result = self.plugin.killing_pods(config, self.kubecli)
 

--- a/tests/test_pod_disruption_scenario_plugin.py
+++ b/tests/test_pod_disruption_scenario_plugin.py
@@ -16,6 +16,7 @@ from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 
 from krkn.scenario_plugins.pod_disruption.pod_disruption_scenario_plugin import PodDisruptionScenarioPlugin
+from krkn.scenario_plugins.pod_disruption.models.models import InputParams
 
 
 class TestPodDisruptionScenarioPlugin(unittest.TestCase):
@@ -38,6 +39,118 @@ class TestPodDisruptionScenarioPlugin(unittest.TestCase):
 
         self.assertEqual(result, ["pod_disruption_scenarios"])
         self.assertEqual(len(result), 1)
+
+class TestKillingPodsMode(unittest.TestCase):
+    def setUp(self):
+        """Set up test fixtures for killing_pods mode tests."""
+        self.plugin = PodDisruptionScenarioPlugin()
+        self.kubecli = MagicMock(spec=KrknKubernetes)
+        self.plugin.get_pods = MagicMock()
+        self.plugin.wait_for_pods = MagicMock(return_value=0)
+
+    def tearDown(self):
+        """Clean up after each test to prevent state leakage."""
+        self.plugin = None
+        self.kubecli = None
+
+    # --- InputParams.kill_mode parsing ---
+
+    def test_kill_mode_defaults_to_sequential(self):
+        """kill_mode defaults to 'sequential' when not specified in config."""
+        params = InputParams({"kill": 2})
+        self.assertEqual(params.kill_mode, "sequential")
+
+    def test_kill_mode_sequential_explicit(self):
+        """kill_mode is correctly parsed when explicitly set to 'sequential'."""
+        params = InputParams({"kill": 2, "kill_mode": "sequential"})
+        self.assertEqual(params.kill_mode, "sequential")
+
+    def test_kill_mode_parallel_explicit(self):
+        """kill_mode is correctly parsed when explicitly set to 'parallel'."""
+        params = InputParams({"kill": 2, "kill_mode": "parallel"})
+        self.assertEqual(params.kill_mode, "parallel")
+
+    # --- killing_pods() behaviour ---
+
+    def test_not_enough_pods_returns_error(self):
+        """Returns 1 and never calls delete_pod when fewer pods exist than kill count."""
+        config = InputParams({"kill": 3, "kill_mode": "sequential"})
+        self.plugin.get_pods.return_value = [("pod1", "ns1"), ("pod2", "ns1")]
+
+        result = self.plugin.killing_pods(config, self.kubecli)
+
+        self.assertEqual(result, 1)
+        self.kubecli.delete_pod.assert_not_called()
+
+    def test_sequential_mode_calls_delete_in_order(self):
+        """Sequential mode deletes all selected pods one at a time."""
+        config = InputParams({"kill": 2, "kill_mode": "sequential"})
+        self.plugin.get_pods.return_value = [("pod1", "ns1"), ("pod2", "ns1")]
+
+        result = self.plugin.killing_pods(config, self.kubecli)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(self.kubecli.delete_pod.call_count, 2)
+        self.kubecli.delete_pod.assert_any_call("pod1", "ns1")
+        self.kubecli.delete_pod.assert_any_call("pod2", "ns1")
+
+    def test_parallel_mode_calls_delete_concurrently(self):
+        """Parallel mode deletes all selected pods and calls delete_pod for each."""
+        config = InputParams({"kill": 2, "kill_mode": "parallel"})
+        self.plugin.get_pods.return_value = [("pod1", "ns1"), ("pod2", "ns1")]
+
+        result = self.plugin.killing_pods(config, self.kubecli)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(self.kubecli.delete_pod.call_count, 2)
+        self.kubecli.delete_pod.assert_any_call("pod1", "ns1")
+        self.kubecli.delete_pod.assert_any_call("pod2", "ns1")
+
+    def test_parallel_mode_propagates_delete_exception(self):
+        """Exceptions raised during parallel deletion bubble up correctly."""
+        config = InputParams({"kill": 2, "kill_mode": "parallel"})
+        self.plugin.get_pods.return_value = [("pod1", "ns1"), ("pod2", "ns1")]
+
+        def side_effect(name, namespace):
+            if name == "pod1":
+                raise RuntimeError("failed to delete")
+
+        self.kubecli.delete_pod.side_effect = side_effect
+
+        with self.assertRaises(Exception) as context:
+            self.plugin.killing_pods(config, self.kubecli)
+
+        self.assertIn("parallel pod deletion failed", str(context.exception))
+        self.assertIn("failed to delete", str(context.exception))
+
+    def test_excluded_pods_are_not_deleted_in_sequential_mode(self):
+        """Pods matched by exclude_label are skipped and never passed to delete_pod (sequential)."""
+        config = InputParams({"kill": 2, "kill_mode": "sequential", "exclude_label": "protected=true"})
+        # get_pods is called twice: first for target pods, then for excluded pods
+        self.plugin.get_pods.side_effect = [
+            [("pod1", "ns1"), ("pod2", "ns1")],  # target pods
+            [("pod1", "ns1")],                    # excluded pods
+        ]
+
+        result = self.plugin.killing_pods(config, self.kubecli)
+
+        self.assertEqual(result, 0)
+        # Only pod2 should be deleted; pod1 is excluded
+        self.kubecli.delete_pod.assert_called_once_with("pod2", "ns1")
+
+    def test_excluded_pods_are_not_deleted_in_parallel_mode(self):
+        """Pods matched by exclude_label are skipped and never passed to delete_pod (parallel)."""
+        config = InputParams({"kill": 2, "kill_mode": "parallel", "exclude_label": "protected=true"})
+        self.plugin.get_pods.side_effect = [
+            [("pod1", "ns1"), ("pod2", "ns1")],  # target pods
+            [("pod1", "ns1")],                    # excluded pods
+        ]
+
+        result = self.plugin.killing_pods(config, self.kubecli)
+
+        self.assertEqual(result, 0)
+        # Only pod2 should be deleted; pod1 is excluded
+        self.kubecli.delete_pod.assert_called_once_with("pod2", "ns1")
 
 
 if __name__ == "__main__":

--- a/tests/test_pod_disruption_scenario_plugin.py
+++ b/tests/test_pod_disruption_scenario_plugin.py
@@ -53,36 +53,35 @@ class TestKillingPodsMode(unittest.TestCase):
         self.plugin = None
         self.kubecli = None
 
-    # --- InputParams.kill_mode parsing ---
+    # --- InputParams.execution parsing ---
 
-    def test_kill_mode_defaults_to_sequential(self):
-        """kill_mode defaults to 'sequential' when not specified in config."""
+    def test_execution_defaults_to_serial(self):
+        """execution defaults to 'serial' when not specified in config."""
         params = InputParams({"kill": 2})
-        self.assertEqual(params.kill_mode, "sequential")
+        self.assertEqual(params.execution, "serial")
 
-    def test_kill_mode_sequential_explicit(self):
-        """kill_mode is correctly parsed when explicitly set to 'sequential'."""
-        params = InputParams({"kill": 2, "kill_mode": "sequential"})
-        self.assertEqual(params.kill_mode, "sequential")
+    def test_execution_serial_explicit(self):
+        """execution is correctly parsed when explicitly set to 'serial'."""
+        params = InputParams({"kill": 2, "execution": "serial"})
+        self.assertEqual(params.execution, "serial")
 
-    def test_kill_mode_parallel_explicit(self):
-        """kill_mode is correctly parsed when explicitly set to 'parallel'."""
-        params = InputParams({"kill": 2, "kill_mode": "parallel"})
-        self.assertEqual(params.kill_mode, "parallel")
+    def test_execution_parallel_explicit(self):
+        """execution is correctly parsed when explicitly set to 'parallel'."""
+        params = InputParams({"kill": 2, "execution": "parallel"})
+        self.assertEqual(params.execution, "parallel")
 
-    def test_kill_mode_invalid_defaults_to_sequential(self):
-        """kill_mode defaults to 'sequential' and logs warning on unknown values."""
-        with self.assertLogs(level='WARNING') as cm:
-            params = InputParams({"kill": 2, "kill_mode": "invalid_mode"})
+    def test_execution_invalid_raises_value_error(self):
+        """execution raises ValueError on unknown values."""
+        with self.assertRaises(ValueError) as context:
+            InputParams({"kill": 2, "execution": "invalid_mode"})
         
-        self.assertEqual(params.kill_mode, "sequential")
-        self.assertTrue(any("Unknown kill_mode 'invalid_mode'" in log for log in cm.output))
+        self.assertIn("Unknown execution 'invalid_mode'", str(context.exception))
 
     # --- killing_pods() behaviour ---
 
     def test_not_enough_pods_returns_error(self):
         """Returns 1 and never calls delete_pod when fewer pods exist than kill count."""
-        config = InputParams({"kill": 3, "kill_mode": "sequential"})
+        config = InputParams({"kill": 3, "execution": "serial"})
         self.plugin.get_pods.return_value = [("pod1", "ns1"), ("pod2", "ns1")]
 
         result = self.plugin.killing_pods(config, self.kubecli)
@@ -90,9 +89,9 @@ class TestKillingPodsMode(unittest.TestCase):
         self.assertEqual(result, 1)
         self.kubecli.delete_pod.assert_not_called()
 
-    def test_sequential_mode_calls_delete_in_order(self):
-        """Sequential mode deletes all selected pods one at a time."""
-        config = InputParams({"kill": 2, "kill_mode": "sequential"})
+    def test_serial_mode_calls_delete_in_order(self):
+        """Serial mode deletes all selected pods one at a time."""
+        config = InputParams({"kill": 2, "execution": "serial"})
         self.plugin.get_pods.return_value = [("pod1", "ns1"), ("pod2", "ns1")]
 
         result = self.plugin.killing_pods(config, self.kubecli)
@@ -104,7 +103,7 @@ class TestKillingPodsMode(unittest.TestCase):
 
     def test_parallel_mode_calls_delete_concurrently(self):
         """Parallel mode deletes all selected pods and calls delete_pod for each concurrently."""
-        config = InputParams({"kill": 2, "kill_mode": "parallel"})
+        config = InputParams({"kill": 2, "execution": "parallel"})
         pods = [("pod1", "ns1"), ("pod2", "ns1")]
         self.plugin.get_pods.return_value = pods
 
@@ -127,7 +126,7 @@ class TestKillingPodsMode(unittest.TestCase):
 
     def test_parallel_mode_propagates_delete_exception(self):
         """Exceptions raised during parallel deletion bubble up correctly."""
-        config = InputParams({"kill": 2, "kill_mode": "parallel"})
+        config = InputParams({"kill": 2, "execution": "parallel"})
         self.plugin.get_pods.return_value = [("pod1", "ns1"), ("pod2", "ns1")]
 
         def side_effect(name, namespace):
@@ -142,9 +141,9 @@ class TestKillingPodsMode(unittest.TestCase):
         self.assertIn("parallel pod deletion failed", str(context.exception))
         self.assertIn("failed to delete", str(context.exception))
 
-    def test_excluded_pods_are_not_deleted_in_sequential_mode(self):
-        """Pods matched by exclude_label are skipped and never passed to delete_pod (sequential)."""
-        config = InputParams({"kill": 2, "kill_mode": "sequential", "exclude_label": "protected=true"})
+    def test_excluded_pods_are_not_deleted_in_serial_mode(self):
+        """Pods matched by exclude_label are skipped and never passed to delete_pod (serial)."""
+        config = InputParams({"kill": 2, "execution": "serial", "exclude_label": "protected=true"})
         # get_pods is called twice: first for target pods, then for excluded pods
         self.plugin.get_pods.side_effect = [
             [("pod1", "ns1"), ("pod2", "ns1")],  # target pods
@@ -159,7 +158,7 @@ class TestKillingPodsMode(unittest.TestCase):
 
     def test_excluded_pods_are_not_deleted_in_parallel_mode(self):
         """Pods matched by exclude_label are skipped and never passed to delete_pod (parallel)."""
-        config = InputParams({"kill": 2, "kill_mode": "parallel", "exclude_label": "protected=true"})
+        config = InputParams({"kill": 2, "execution": "parallel", "exclude_label": "protected=true"})
         self.plugin.get_pods.side_effect = [
             [("pod1", "ns1"), ("pod2", "ns1")],  # target pods
             [("pod1", "ns1")],                    # excluded pods


### PR DESCRIPTION
Introduce 'kill_mode' field to pod disruption scenario to support parallel deletion of pods. By default 'kill_mode' is 'sequential' preserving existing behavior. When set to 'parallel', it concurrently deletes pods using threading and queue, enabling effective testing of disruption scenarios like etcd quorum loss where simultaneous disruption is necessary.

Resolves: #1516

Assisted-by: Claude <noreply@anthropic.com>

# Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
Added an optional `kill_mode` (values: `sequential`, `parallel`) to the pod disruption scenario. 
- In `sequential` mode (default), pods are deleted in a blocking for-loop (existing behavior).
- In `parallel` mode, pods are deleted concurrently using a ThreadPool approach modeled after `network_chaos_ng_scenario_plugin.py`, with exceptions collected and bubbled up via a `queue.Queue`.
- Example scenario configs have been updated to document the new parameter.

## Related Tickets & Documents
- Related Issue #: #1516
- Closes #: #1516

# Documentation  
- [x] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
*(Leave this blank for now, you can open a docs PR later to update the website if they ask for it)*

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python -m unittest tests/test_pod_disruption_scenario_plugin.py -v

test_excluded_pods_are_not_deleted_in_parallel_mode (tests.test_pod_disruption_scenario_plugin.TestKillingPodsMode.test_excluded_pods_are_not_deleted_in_parallel_mode)
Pods matched by exclude_label are skipped and never passed to delete_pod (parallel). ... ok
test_excluded_pods_are_not_deleted_in_sequential_mode (tests.test_pod_disruption_scenario_plugin.TestKillingPodsMode.test_excluded_pods_are_not_deleted_in_sequential_mode)
Pods matched by exclude_label are skipped and never passed to delete_pod (sequential). ... ok
test_kill_mode_defaults_to_sequential (tests.test_pod_disruption_scenario_plugin.TestKillingPodsMode.test_kill_mode_defaults_to_sequential)
kill_mode defaults to 'sequential' when not specified in config. ... ok
test_kill_mode_parallel_explicit (tests.test_pod_disruption_scenario_plugin.TestKillingPodsMode.test_kill_mode_parallel_explicit)
kill_mode is correctly parsed when explicitly set to 'parallel'. ... ok
test_kill_mode_sequential_explicit (tests.test_pod_disruption_scenario_plugin.TestKillingPodsMode.test_kill_mode_sequential_explicit)
kill_mode is correctly parsed when explicitly set to 'sequential'. ... ok
test_not_enough_pods_returns_error (tests.test_pod_disruption_scenario_plugin.TestKillingPodsMode.test_not_enough_pods_returns_error)
Returns 1 and never calls delete_pod when fewer pods exist than kill count. ... ok
test_parallel_mode_calls_delete_concurrently (tests.test_pod_disruption_scenario_plugin.TestKillingPodsMode.test_parallel_mode_calls_delete_concurrently)
Parallel mode deletes all selected pods and calls delete_pod for each. ... ok
test_parallel_mode_propagates_delete_exception (tests.test_pod_disruption_scenario_plugin.TestKillingPodsMode.test_parallel_mode_propagates_delete_exception)
Exceptions raised during parallel deletion bubble up correctly. ... ok
test_sequential_mode_calls_delete_in_order (tests.test_pod_disruption_scenario_plugin.TestKillingPodsMode.test_sequential_mode_calls_delete_in_order)
Sequential mode deletes all selected pods one at a time. ... ok
test_get_scenario_types (tests.test_pod_disruption_scenario_plugin.TestPodDisruptionScenarioPlugin.test_get_scenario_types)
Test get_scenario_types returns correct scenario type ... ok

----------------------------------------------------------------------
Ran 10 tests in 0.018s

OK


