### PR TITLE
handle None values in node summary for text report

### DIFF
--- a/krkn/summarized_reports/transform.py
+++ b/krkn/summarized_reports/transform.py
@@ -316,12 +316,12 @@ def build_chaos_report(chaos_output: dict) -> str:
         lines.append(f"  {'Type':<8} {'Count':<6} {'Instance':<14} {'Arch':<7} {'Kubelet':<10} OS")
         for ni in node_infos:
             lines.append(
-                f"  {ni.get('nodes_type', 'N/A'):<8} "
-                f"{ni.get('count', 'N/A'):<6} "
-                f"{ni.get('instance_type', 'N/A'):<14} "
-                f"{ni.get('architecture', 'N/A'):<7} "
-                f"{ni.get('kubelet_version', 'N/A'):<10} "
-                f"{ni.get('os_version', 'N/A')}"
+                f"  {ni.get('nodes_type') or 'N/A':<8} "
+                f"{'N/A' if ni.get('count') is None else ni.get('count'):<6} "
+                f"{ni.get('instance_type') or 'N/A':<14} "
+                f"{ni.get('architecture') or 'N/A':<7} "
+                f"{ni.get('kubelet_version') or 'N/A':<10} "
+                f"{ni.get('os_version') or 'N/A'}"
             )
 
     # --- Targets ---

--- a/tests/test_summarized_reports.py
+++ b/tests/test_summarized_reports.py
@@ -596,6 +596,24 @@ class TestBuildChaosReportClusterOverview(unittest.TestCase):
         self.assertIn("worker", report)
         self.assertIn("m6i.xlarge", report)
 
+    def test_node_summary_with_none_values(self):
+        """Test that None node metadata fields render as N/A without crashing."""
+        output = _minimal_chaos_output()
+        output["telemetry"]["node_summary_infos"] = [{
+            "nodes_type": None,
+            "count": 3,
+            "instance_type": None,
+            "architecture": "amd64",
+            "kubelet_version": "v1.28.0",
+            "os_version": "Linux",
+        }]
+        report = build_chaos_report(output)
+        self.assertIn("CLUSTER OVERVIEW", report)
+        overview_start = report.index("CLUSTER OVERVIEW")
+        overview_section = report[overview_start:overview_start + 200]
+        self.assertIn("N/A", overview_section)
+        self.assertNotIn("None", overview_section)
+
     def test_no_overview_when_empty(self):
         output = _minimal_chaos_output()
         output["telemetry"]["node_summary_infos"] = []


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description  
 Fixed TypeError: unsupported format string passed to NoneType.__format__ crash in the text summary report when cluster node metadata fields (e.g.nodes_type, instance_type) are present but set to None. This occurs on minimal clusters like CRC where node metadata is incomplete. Changed .get('key', 'N/A') to .get('key') or 'N/A' so that both missing keys and explicit None values fall back to "N/A". Also removed leftover commented-out code and added a unit test covering this case.

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: #1519 
- Closes #: 


# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
The unit test creates a node_summary_infos entry with nodes_type and instance_type set to None (simulating a CRC/minimal cluster), builds the text report, and verifies the "CLUSTER OVERVIEW" section is still present, the None fields display as "N/A", and the string "None" does not appear in the cluster overview section. 

```bash
python -m coverage run -a -m unittest discover -s tests -v
...

Ran 1486 tests in 16.476s

OK

python -m unittest tests.test_summarized_reports.TestBuildChaosReportClusterOverview -v
  ...
  test_no_overview_when_empty ... ok
  test_node_summary_table ... ok
  test_node_summary_with_none_values ... ok

  ----------------------------------------------------------------------
Ran 3 tests in 0.000s
  
OK
<---insert test results output--->
```
