### PR TITLE
Migrate legacy network chaos test to v2 Python suite with bandwidth coverage

### DIFF
--- a/CI/tests_v2/pytest.ini
+++ b/CI/tests_v2/pytest.ini
@@ -20,4 +20,5 @@ markers =
     no_workload: skip workload deployment for this test (e.g. negative tests)
     order: set test order (pytest-order)
     xdist_group: assign tests to a named xdist group so they run on the same worker (no parallel tc conflicts)
+    network_chaos_legacy: marks a test as a legacy network chaos scenario test
 junit_family = xunit2


### PR DESCRIPTION
Replaces #1514 with DCO sign-off and rebase onto latest main.