### PR TITLE
Failure paths

### DIFF
--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -150,22 +150,34 @@ class AbstractScenarioPlugin(ABC):
             scenario_telemetry.end_timestamp = time.time()
             start_time = int(scenario_telemetry.start_timestamp)
             end_time = int(scenario_telemetry.end_timestamp)
-            utils.collect_and_put_ocp_logs(
-                telemetry,
-                parsed_scenario_config,
-                telemetry.get_telemetry_request_id(),
-                start_time,
-                end_time
-            )
-
-            if events_backup:
-                utils.populate_cluster_events(
-                    krkn_config,
+            try:
+                utils.collect_and_put_ocp_logs(
+                    telemetry,
                     parsed_scenario_config,
-                    telemetry.get_lib_kubernetes(),
+                    telemetry.get_telemetry_request_id(),
                     start_time,
                     end_time
                 )
+            except Exception as e:
+                logging.error(
+                    f"failed to collect OCP logs for scenario "
+                    f"'{scenario_config}': {e}"
+                )
+
+            if events_backup:
+                try:
+                    utils.populate_cluster_events(
+                        krkn_config,
+                        parsed_scenario_config,
+                        telemetry.get_lib_kubernetes(),
+                        start_time,
+                        end_time
+                    )
+                except Exception as e:
+                    logging.error(
+                        f"failed to collect cluster events for scenario "
+                        f"'{scenario_config}': {e}"
+                    )
 
             if scenario_telemetry.exit_status != 0:
                 failed_scenarios.append(scenario_config)

--- a/krkn/utils/functions.py
+++ b/krkn/utils/functions.py
@@ -15,6 +15,7 @@ import krkn_lib.utils
 from krkn_lib.k8s import KrknKubernetes
 from krkn_lib.models.telemetry import ScenarioTelemetry
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+from kubernetes.client.exceptions import ApiException
 from tzlocal.unix import get_localzone
 import logging
 
@@ -59,11 +60,26 @@ def collect_and_put_ocp_logs(
     start_timestamp: int,
     end_timestamp: int,
 ):
+    try:
+        is_k8s = telemetry_ocp.get_lib_kubernetes().is_kubernetes()
+    except ApiException as e:
+        logging.error(
+            f"API error ({e.status}) checking cluster type for OCP log "
+            f"collection, skipping: {e.reason}"
+        )
+        return
+    except Exception as e:
+        logging.error(
+            f"unexpected error checking cluster type for OCP log "
+            f"collection, skipping: {e}"
+        )
+        return
+
     if (
         telemetry_ocp.get_telemetry_config()
         and telemetry_ocp.get_telemetry_config()["enabled"]
         and telemetry_ocp.get_telemetry_config()["logs_backup"]
-        and not telemetry_ocp.get_lib_kubernetes().is_kubernetes()
+        and not is_k8s
     ):
         namespaces = __retrieve_namespaces(
             scenario_config, telemetry_ocp.get_lib_kubernetes()


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization

# Description  
Making sure when there is a failure trying to connect to the cluster we are still able to produce a fail status

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: 
- Closes #: 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python run_kraken.py
...
<---insert test results output--->
```

OR


```bash
python -m coverage run -a -m unittest discover -s tests -v
...
<---insert test results output--->
```
