### PR TITLE
feat(gpu): add GPU device plugin disruption scenario

### DIFF
--- a/krkn/health_checks/gpu_health_check_plugin.py
+++ b/krkn/health_checks/gpu_health_check_plugin.py
@@ -1,0 +1,235 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+GPU Health Check Plugin
+
+Continuously monitors GPU availability on GPU nodes throughout a chaos run and
+records downtime windows into telemetry. The primary signal is node
+``nvidia.com/gpu`` allocatable: when the NVIDIA device plugin dies (or a node
+loses its GPUs), allocatable drops and this plugin captures the outage window
+(start/end/duration). Optionally validates driver-level health via nvidia-smi.
+
+This is a passive, read-only monitor. It does not modify the cluster; pair it
+with a disruption scenario (e.g. ``gpu_device_plugin_scenarios``) to measure how
+long GPU scheduling was unavailable during the disruption.
+
+Example configuration in config.yaml:
+    gpu_health_checks:
+      interval: 5                       # seconds between polls (default: 5)
+      namespace: nvidia-gpu-operator    # GPU Operator namespace (default)
+      validate_gpu_health: false        # also run nvidia-smi (default: false)
+      exit_on_failure: false            # fail the krkn run on GPU downtime
+"""
+
+import logging
+import queue
+import time
+from datetime import datetime
+from typing import Any
+
+from krkn_lib.models.telemetry.models import HealthCheck
+
+from krkn.health_checks.abstract_health_check_plugin import (
+    AbstractHealthCheckPlugin,
+)
+from krkn.utils.gpu import (
+    discover_gpu_nodes,
+    get_node_gpu_allocatable,
+    validate_gpu_health_on_node,
+)
+
+
+class GpuHealthCheckPlugin(AbstractHealthCheckPlugin):
+    """
+    Monitors GPU allocatable (and optionally nvidia-smi health) on GPU nodes
+    and records availability/downtime periods to telemetry.
+    """
+
+    def __init__(
+        self,
+        health_check_type: str = "gpu_health_check",
+        iterations: int = 1,
+        krkn_lib=None,
+        **kwargs,
+    ):
+        """
+        :param health_check_type: the health check type identifier
+        :param iterations: number of chaos iterations to monitor
+        :param krkn_lib: KrknKubernetes client forwarded by the factory
+            (``start_all(..., krkn_lib=kubecli)``)
+        """
+        super().__init__(health_check_type)
+        self.iterations = iterations
+        self.current_iterations = 0
+        self.kubecli = krkn_lib
+
+    def get_health_check_types(self) -> list[str]:
+        return ["gpu_health_check"]
+
+    def get_config_key(self) -> str:
+        return "gpu_health_checks"
+
+    def increment_iterations(self) -> None:
+        self.current_iterations += 1
+
+    def _probe_node(
+        self,
+        node_name: str,
+        baseline: int,
+        namespace: str,
+        validate_health: bool,
+    ) -> tuple[bool, str]:
+        """
+        Probe a single node's GPU availability.
+
+        :return: (healthy, status_code) where status_code is the current
+            allocatable count as a string, or an error marker.
+        """
+        try:
+            current = get_node_gpu_allocatable(self.kubecli, node_name)
+        except Exception as e:
+            logging.error(
+                f"GPU health check: failed to read allocatable on "
+                f"{node_name}: {e}"
+            )
+            return False, "error"
+
+        healthy = current >= baseline
+        if healthy and validate_health:
+            healthy = validate_gpu_health_on_node(
+                self.kubecli, node_name, namespace=namespace
+            )
+        return healthy, str(current)
+
+    def run_health_check(
+        self,
+        config: dict[str, Any],
+        telemetry_queue: queue.Queue,
+    ) -> None:
+        """
+        Runs the GPU health monitoring loop until the configured number of
+        chaos iterations completes (or an early stop is signalled). Records a
+        telemetry entry for every availability state change and a final entry
+        per node when the loop ends.
+        """
+        if self.kubecli is None:
+            logging.error(
+                "GPU health check: no Kubernetes client available, skipping"
+            )
+            return
+
+        config = config or {}
+        interval = config.get("interval", 5)
+        namespace = config.get("namespace", "nvidia-gpu-operator")
+        validate_health = config.get("validate_gpu_health", False)
+        exit_on_failure = config.get("exit_on_failure", False)
+
+        gpu_nodes = discover_gpu_nodes(self.kubecli)
+        if not gpu_nodes:
+            logging.warning(
+                "GPU health check: no GPU nodes found, nothing to monitor"
+            )
+            return
+
+        baselines = {n["name"]: n["gpu_count"] for n in gpu_nodes}
+        logging.info(
+            f"GPU health check monitoring {len(baselines)} node(s): "
+            f"{baselines}"
+        )
+
+        health_check_telemetry: list[HealthCheck] = []
+        # node -> {"healthy": bool, "status_code": str, "start_timestamp": dt}
+        tracker: dict[str, dict[str, Any]] = {}
+
+        while (
+            self.current_iterations < self.iterations
+            and not self._stop_event.is_set()
+        ):
+            for node_name, baseline in baselines.items():
+                healthy, status_code = self._probe_node(
+                    node_name, baseline, namespace, validate_health
+                )
+                now = datetime.now()
+
+                if node_name not in tracker:
+                    tracker[node_name] = {
+                        "healthy": healthy,
+                        "status_code": status_code,
+                        "start_timestamp": now,
+                    }
+                    if not healthy:
+                        logging.error(
+                            f"GPU health check: {node_name} unhealthy "
+                            f"(allocatable={status_code}, baseline={baseline})"
+                        )
+                        if exit_on_failure and self.ret_value == 0:
+                            self.ret_value = 3
+                elif healthy != tracker[node_name]["healthy"]:
+                    # State changed: record the period that just ended.
+                    prev = tracker[node_name]
+                    duration = (now - prev["start_timestamp"]).total_seconds()
+                    health_check_telemetry.append(
+                        HealthCheck(
+                            {
+                                "url": f"gpu://{node_name}",
+                                "status": prev["healthy"],
+                                "status_code": prev["status_code"],
+                                "start_timestamp": prev[
+                                    "start_timestamp"
+                                ].isoformat(),
+                                "end_timestamp": now.isoformat(),
+                                "duration": duration,
+                            }
+                        )
+                    )
+                    if healthy:
+                        logging.info(
+                            f"GPU health check: {node_name} recovered after "
+                            f"{duration:.2f}s (allocatable={status_code})"
+                        )
+                    else:
+                        logging.error(
+                            f"GPU health check: {node_name} unhealthy "
+                            f"(allocatable={status_code}, baseline={baseline})"
+                        )
+                        if exit_on_failure and self.ret_value == 0:
+                            self.ret_value = 3
+                    tracker[node_name] = {
+                        "healthy": healthy,
+                        "status_code": status_code,
+                        "start_timestamp": now,
+                    }
+
+            time.sleep(interval)
+
+        # Flush the final open period for each node.
+        end_timestamp = datetime.now()
+        for node_name, state in tracker.items():
+            duration = (
+                end_timestamp - state["start_timestamp"]
+            ).total_seconds()
+            health_check_telemetry.append(
+                HealthCheck(
+                    {
+                        "url": f"gpu://{node_name}",
+                        "status": state["healthy"],
+                        "status_code": state["status_code"],
+                        "start_timestamp": state["start_timestamp"].isoformat(),
+                        "end_timestamp": end_timestamp.isoformat(),
+                        "duration": duration,
+                    }
+                )
+            )
+
+        telemetry_queue.put(health_check_telemetry)

--- a/krkn/scenario_plugins/gpu_device/__init__.py
+++ b/krkn/scenario_plugins/gpu_device/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/krkn/scenario_plugins/gpu_device/gpu_device_scenario_plugin.py
+++ b/krkn/scenario_plugins/gpu_device/gpu_device_scenario_plugin.py
@@ -154,7 +154,7 @@ class GpuDeviceScenarioPlugin(AbstractScenarioPlugin):
         if config.validate_gpu_health:
             for node_info in target_nodes:
                 node_name = node_info["name"]
-                if not validate_gpu_health_on_node(kubecli, node_name):
+                if not validate_gpu_health_on_node(kubecli, node_name, namespace=config.namespace):
                     logging.error(
                         f"pre-disruption GPU health check failed on "
                         f"node {node_name}"
@@ -177,15 +177,14 @@ class GpuDeviceScenarioPlugin(AbstractScenarioPlugin):
             f"{config.krkn_pod_recovery_time}s"
         )
 
-        # Register rollback
-        for pod_name, pod_ns in target_pods:
-            self.rollback_handler.set_rollback_callable(
-                self.rollback_verify_device_plugin,
-                RollbackContent(
-                    namespace=pod_ns,
-                    resource_identifier=config.pod_label_selector,
-                ),
-            )
+        # Register rollback (once — args are invariant across pods)
+        self.rollback_handler.set_rollback_callable(
+            self.rollback_verify_device_plugin,
+            RollbackContent(
+                namespace=config.namespace,
+                resource_identifier=config.pod_label_selector,
+            ),
+        )
 
         # Inject: delete device plugin pods
         for pod_name, pod_ns in target_pods:
@@ -204,6 +203,12 @@ class GpuDeviceScenarioPlugin(AbstractScenarioPlugin):
             )
             if config.expected_recovery:
                 return 1
+            else:
+                logging.info(
+                    "expected_recovery=False: skipping remaining "
+                    "verification for intentionally unrecovered pods"
+                )
+                return 0
 
         # Verify GPU allocatable restored
         if config.verify_allocatable:
@@ -220,7 +225,7 @@ class GpuDeviceScenarioPlugin(AbstractScenarioPlugin):
         if config.validate_gpu_health:
             for node_info in target_nodes:
                 node_name = node_info["name"]
-                if not validate_gpu_health_on_node(kubecli, node_name):
+                if not validate_gpu_health_on_node(kubecli, node_name, namespace=config.namespace):
                     logging.error(
                         f"post-disruption GPU health check failed on "
                         f"node {node_name}"

--- a/krkn/scenario_plugins/gpu_device/gpu_device_scenario_plugin.py
+++ b/krkn/scenario_plugins/gpu_device/gpu_device_scenario_plugin.py
@@ -196,6 +196,17 @@ class GpuDeviceScenarioPlugin(AbstractScenarioPlugin):
         result = snapshot.get_pods_status()
         scenario_telemetry.affected_pods = result
 
+        for pod in result.recovered:
+            logging.info(
+                "device plugin pod %s on %s recovered in %.2fs "
+                "(rescheduling %.2fs, readiness %.2fs)",
+                pod.pod_name,
+                pod.namespace,
+                pod.total_recovery_time or 0.0,
+                pod.pod_rescheduling_time or 0.0,
+                pod.pod_readiness_time or 0.0,
+            )
+
         if len(result.unrecovered) > 0:
             logging.error(
                 f"device plugin pods did not recover: "

--- a/krkn/scenario_plugins/gpu_device/gpu_device_scenario_plugin.py
+++ b/krkn/scenario_plugins/gpu_device/gpu_device_scenario_plugin.py
@@ -1,0 +1,262 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import traceback
+
+import yaml
+from krkn_lib.k8s import KrknKubernetes
+from krkn_lib.k8s.pod_monitor import (
+    select_and_monitor_by_namespace_pattern_and_label,
+)
+from krkn_lib.models.telemetry import ScenarioTelemetry
+from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+
+from krkn.scenario_plugins.abstract_scenario_plugin import (
+    AbstractScenarioPlugin,
+)
+from krkn.scenario_plugins.gpu_device.models.models import InputParams
+from krkn.rollback.config import RollbackContent
+from krkn.rollback.handler import set_rollback_context_decorator
+from krkn.utils.gpu import (
+    discover_gpu_nodes,
+    find_gpu_operator_pods,
+    get_node_gpu_allocatable,
+    validate_gpu_health_on_node,
+    validate_gpu_operator_present,
+    wait_for_gpu_allocatable,
+)
+
+
+class GpuDeviceScenarioPlugin(AbstractScenarioPlugin):
+
+    @set_rollback_context_decorator
+    def run(
+        self,
+        run_uuid: str,
+        scenario: str,
+        lib_telemetry: KrknTelemetryOpenshift,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        try:
+            kubecli = lib_telemetry.get_lib_kubernetes()
+
+            with open(scenario, "r") as f:
+                scenario_config = yaml.safe_load(f)
+
+            for item in scenario_config:
+                config = InputParams(item["config"])
+                result = self._run_disruption(
+                    config, kubecli, scenario_telemetry
+                )
+                if result != 0:
+                    return 1
+
+        except Exception as e:
+            logging.error("Stack trace:\n%s", traceback.format_exc())
+            logging.error(
+                "GpuDeviceScenarioPlugin exiting due to exception: %s", e
+            )
+            return 1
+
+        return 0
+
+    def get_scenario_types(self) -> list[str]:
+        return ["gpu_device_plugin_scenarios"]
+
+    def _run_disruption(
+        self,
+        config: InputParams,
+        kubecli: KrknKubernetes,
+        scenario_telemetry: ScenarioTelemetry,
+    ) -> int:
+        # Pre-flight
+        if not validate_gpu_operator_present(kubecli, config.namespace):
+            logging.error("GPU Operator not found, aborting scenario")
+            return 1
+
+        device_plugin_pods = find_gpu_operator_pods(
+            kubecli, config.namespace, config.pod_label_selector
+        )
+        if not device_plugin_pods:
+            logging.error(
+                f"no device plugin pods found with label "
+                f"'{config.pod_label_selector}' in namespace "
+                f"'{config.namespace}'"
+            )
+            return 1
+
+        logging.info(
+            f"found {len(device_plugin_pods)} device plugin pod(s): "
+            f"{[p[0] for p in device_plugin_pods]}"
+        )
+
+        # Discover GPU nodes and select targets
+        gpu_nodes = discover_gpu_nodes(kubecli)
+        if not gpu_nodes:
+            logging.error("no GPU nodes found in the cluster")
+            return 1
+
+        if config.node_selector:
+            matching_nodes = kubecli.list_nodes(config.node_selector)
+            gpu_nodes = [n for n in gpu_nodes if n["name"] in matching_nodes]
+            if not gpu_nodes:
+                logging.error(
+                    f"no GPU nodes match node_selector "
+                    f"'{config.node_selector}'"
+                )
+                return 1
+
+        target_nodes = gpu_nodes[: config.number_of_nodes]
+        target_node_names = [n["name"] for n in target_nodes]
+        logging.info(f"targeting GPU nodes: {target_node_names}")
+
+        # Match device plugin pods to target nodes
+        target_pods = []
+        for pod_name, pod_ns in device_plugin_pods:
+            pod_info = kubecli.read_pod(pod_name, pod_ns)
+            if pod_info and pod_info.spec.node_name in target_node_names:
+                target_pods.append((pod_name, pod_ns))
+
+        if not target_pods:
+            logging.error(
+                "no device plugin pods found on targeted GPU nodes"
+            )
+            return 1
+
+        logging.info(
+            f"target device plugin pods: {[p[0] for p in target_pods]}"
+        )
+
+        # Snapshot GPU allocatable counts
+        gpu_snapshots = {}
+        for node_info in target_nodes:
+            node_name = node_info["name"]
+            gpu_snapshots[node_name] = get_node_gpu_allocatable(
+                kubecli, node_name
+            )
+            logging.info(
+                f"node {node_name} GPU allocatable snapshot: "
+                f"{gpu_snapshots[node_name]}"
+            )
+
+        # Pre-disruption GPU health check
+        if config.validate_gpu_health:
+            for node_info in target_nodes:
+                node_name = node_info["name"]
+                if not validate_gpu_health_on_node(kubecli, node_name):
+                    logging.error(
+                        f"pre-disruption GPU health check failed on "
+                        f"node {node_name}"
+                    )
+                    return 1
+                logging.info(
+                    f"pre-disruption GPU health check passed on "
+                    f"node {node_name}"
+                )
+
+        # Start monitoring for pod recovery
+        future_snapshot = select_and_monitor_by_namespace_pattern_and_label(
+            namespace_pattern=f"^{config.namespace}$",
+            label_selector=config.pod_label_selector,
+            max_timeout=config.krkn_pod_recovery_time,
+            v1_client=kubecli.cli,
+        )
+        logging.info(
+            f"monitoring device plugin pods for up to "
+            f"{config.krkn_pod_recovery_time}s"
+        )
+
+        # Register rollback
+        for pod_name, pod_ns in target_pods:
+            self.rollback_handler.set_rollback_callable(
+                self.rollback_verify_device_plugin,
+                RollbackContent(
+                    namespace=pod_ns,
+                    resource_identifier=config.pod_label_selector,
+                ),
+            )
+
+        # Inject: delete device plugin pods
+        for pod_name, pod_ns in target_pods:
+            logging.info(f"deleting device plugin pod {pod_name} in {pod_ns}")
+            kubecli.delete_pod(pod_name, pod_ns)
+
+        # Verify recovery
+        snapshot = future_snapshot.result()
+        result = snapshot.get_pods_status()
+        scenario_telemetry.affected_pods = result
+
+        if len(result.unrecovered) > 0:
+            logging.error(
+                f"device plugin pods did not recover: "
+                f"{[p.name for p in result.unrecovered]}"
+            )
+            if config.expected_recovery:
+                return 1
+
+        # Verify GPU allocatable restored
+        if config.verify_allocatable:
+            for node_name, expected_count in gpu_snapshots.items():
+                if not wait_for_gpu_allocatable(
+                    kubecli, node_name, expected_count, config.recovery_timeout
+                ):
+                    logging.error(
+                        f"GPU allocatable not restored on node {node_name}"
+                    )
+                    return 1
+
+        # Post-disruption GPU health check
+        if config.validate_gpu_health:
+            for node_info in target_nodes:
+                node_name = node_info["name"]
+                if not validate_gpu_health_on_node(kubecli, node_name):
+                    logging.error(
+                        f"post-disruption GPU health check failed on "
+                        f"node {node_name}"
+                    )
+                    return 1
+                logging.info(
+                    f"post-disruption GPU health check passed on "
+                    f"node {node_name}"
+                )
+
+        logging.info("GPU device plugin disruption scenario completed")
+        return 0
+
+    @staticmethod
+    def rollback_verify_device_plugin(
+        rollback_content: RollbackContent,
+        lib_telemetry: KrknTelemetryOpenshift,
+    ):
+        try:
+            namespace = rollback_content.namespace
+            label_selector = rollback_content.resource_identifier
+            kubecli = lib_telemetry.get_lib_kubernetes()
+            pods = kubecli.select_pods_by_namespace_pattern_and_label(
+                namespace_pattern=f"^{namespace}$",
+                label_selector=label_selector,
+                field_selector="status.phase=Running",
+            )
+            if pods:
+                logging.info(
+                    f"rollback: device plugin pod(s) recovered: "
+                    f"{[p[0] for p in pods]}"
+                )
+            else:
+                logging.warning(
+                    f"rollback: no running device plugin pods found "
+                    f"with label '{label_selector}' in '{namespace}'"
+                )
+        except Exception as e:
+            logging.error(f"rollback verification failed: {e}")

--- a/krkn/scenario_plugins/gpu_device/models/__init__.py
+++ b/krkn/scenario_plugins/gpu_device/models/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/krkn/scenario_plugins/gpu_device/models/models.py
+++ b/krkn/scenario_plugins/gpu_device/models/models.py
@@ -11,26 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dataclasses import dataclass
+from typing import Any
 
 
-@dataclass
 class InputParams:
-    def __init__(self, config: dict[str, any] = None):
-        if config is not None:
-            self.namespace = config.get("namespace", "nvidia-gpu-operator")
-            self.node_selector = config.get("node_selector", "")
-            self.number_of_nodes = config.get("number_of_nodes", 1)
-            self.pod_label_selector = config.get(
-                "pod_label_selector", "app=nvidia-device-plugin-daemonset"
-            )
-            self.recovery_timeout = config.get("recovery_timeout", 120)
-            self.expected_recovery = config.get("expected_recovery", True)
-            self.verify_allocatable = config.get("verify_allocatable", True)
-            self.krkn_pod_recovery_time = config.get(
-                "krkn_pod_recovery_time", 120
-            )
-            self.validate_gpu_health = config.get("validate_gpu_health", True)
+    """Configuration for the GPU device plugin disruption scenario."""
 
     namespace: str
     node_selector: str
@@ -41,3 +26,19 @@ class InputParams:
     verify_allocatable: bool
     krkn_pod_recovery_time: int
     validate_gpu_health: bool
+
+    def __init__(self, config: dict[str, Any] | None = None):
+        config = config or {}
+        self.namespace = config.get("namespace", "nvidia-gpu-operator")
+        self.node_selector = config.get("node_selector", "")
+        self.number_of_nodes = config.get("number_of_nodes", 1)
+        self.pod_label_selector = config.get(
+            "pod_label_selector", "app=nvidia-device-plugin-daemonset"
+        )
+        self.recovery_timeout = config.get("recovery_timeout", 120)
+        self.expected_recovery = config.get("expected_recovery", True)
+        self.verify_allocatable = config.get("verify_allocatable", True)
+        self.krkn_pod_recovery_time = config.get(
+            "krkn_pod_recovery_time", 120
+        )
+        self.validate_gpu_health = config.get("validate_gpu_health", True)

--- a/krkn/scenario_plugins/gpu_device/models/models.py
+++ b/krkn/scenario_plugins/gpu_device/models/models.py
@@ -1,0 +1,43 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from dataclasses import dataclass
+
+
+@dataclass
+class InputParams:
+    def __init__(self, config: dict[str, any] = None):
+        if config is not None:
+            self.namespace = config.get("namespace", "nvidia-gpu-operator")
+            self.node_selector = config.get("node_selector", "")
+            self.number_of_nodes = config.get("number_of_nodes", 1)
+            self.pod_label_selector = config.get(
+                "pod_label_selector", "app=nvidia-device-plugin-daemonset"
+            )
+            self.recovery_timeout = config.get("recovery_timeout", 120)
+            self.expected_recovery = config.get("expected_recovery", True)
+            self.verify_allocatable = config.get("verify_allocatable", True)
+            self.krkn_pod_recovery_time = config.get(
+                "krkn_pod_recovery_time", 120
+            )
+            self.validate_gpu_health = config.get("validate_gpu_health", True)
+
+    namespace: str
+    node_selector: str
+    number_of_nodes: int
+    pod_label_selector: str
+    recovery_timeout: int
+    expected_recovery: bool
+    verify_allocatable: bool
+    krkn_pod_recovery_time: int
+    validate_gpu_health: bool

--- a/krkn/summarized_reports/__init__.py
+++ b/krkn/summarized_reports/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/krkn/summarized_reports/transform.py
+++ b/krkn/summarized_reports/transform.py
@@ -1,3 +1,16 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import logging
 import os
 from datetime import datetime

--- a/krkn/utils/gpu.py
+++ b/krkn/utils/gpu.py
@@ -1,0 +1,135 @@
+# Copyright 2025 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import time
+
+from krkn_lib.k8s import KrknKubernetes
+
+GPU_RESOURCE_KEY = "nvidia.com/gpu"
+
+
+def discover_gpu_nodes(kubecli: KrknKubernetes) -> list[dict]:
+    gpu_nodes = []
+    node_names = kubecli.list_nodes()
+    for name in node_names:
+        count = get_node_gpu_allocatable(kubecli, name)
+        if count > 0:
+            gpu_nodes.append({"name": name, "gpu_count": count})
+            logging.info(f"discovered GPU node: {name} with {count} GPU(s)")
+    if not gpu_nodes:
+        logging.warning("no GPU nodes found in the cluster")
+    return gpu_nodes
+
+
+def get_node_gpu_allocatable(kubecli: KrknKubernetes, node_name: str) -> int:
+    node = kubecli.cli.read_node(node_name)
+    allocatable = node.status.allocatable or {}
+    return int(allocatable.get(GPU_RESOURCE_KEY, "0"))
+
+
+def wait_for_gpu_allocatable(
+    kubecli: KrknKubernetes,
+    node_name: str,
+    expected_count: int,
+    timeout: int,
+) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
+        current = get_node_gpu_allocatable(kubecli, node_name)
+        if current >= expected_count:
+            logging.info(
+                f"node {node_name} GPU allocatable restored: {current}"
+            )
+            return True
+        logging.info(
+            f"node {node_name} GPU allocatable: {current}, "
+            f"expected: {expected_count}, waiting..."
+        )
+        time.sleep(5)
+    logging.error(
+        f"timeout waiting for GPU allocatable on node {node_name} "
+        f"to reach {expected_count}"
+    )
+    return False
+
+
+def validate_gpu_health_on_node(
+    kubecli: KrknKubernetes,
+    node_name: str,
+    namespace: str = "nvidia-gpu-operator",
+) -> bool:
+    driver_pods = kubecli.select_pods_by_namespace_pattern_and_label(
+        namespace_pattern=f"^{namespace}$",
+        label_selector="app.kubernetes.io/component=nvidia-driver",
+        field_selector=f"spec.nodeName={node_name},status.phase=Running",
+    )
+    if not driver_pods:
+        logging.error(
+            f"no running nvidia-driver pod found on node {node_name}"
+        )
+        return False
+
+    driver_pod_name = driver_pods[0][0]
+    driver_pod_ns = driver_pods[0][1]
+    try:
+        output = kubecli.exec_cmd_in_pod(
+            command=["nvidia-smi", "--query-gpu=name,uuid,memory.total",
+                     "--format=csv,noheader"],
+            pod_name=driver_pod_name,
+            namespace=driver_pod_ns,
+            container="nvidia-driver-ctr",
+        )
+        logging.info(f"nvidia-smi on {node_name}: {output.strip()}")
+        if "GPU" not in output and "NVIDIA" not in output.upper():
+            logging.error(
+                f"nvidia-smi output on {node_name} does not indicate "
+                f"healthy GPU: {output}"
+            )
+            return False
+        return True
+    except Exception as e:
+        logging.error(f"nvidia-smi failed on node {node_name}: {e}")
+        return False
+
+
+def find_gpu_operator_pods(
+    kubecli: KrknKubernetes,
+    namespace: str,
+    label_selector: str,
+) -> list[tuple[str, str]]:
+    return kubecli.select_pods_by_namespace_pattern_and_label(
+        namespace_pattern=f"^{namespace}$",
+        label_selector=label_selector,
+        field_selector="status.phase=Running",
+    )
+
+
+def validate_gpu_operator_present(
+    kubecli: KrknKubernetes,
+    namespace: str,
+) -> bool:
+    try:
+        pods = kubecli.list_pods(namespace)
+        if not pods:
+            logging.error(
+                f"no pods found in GPU Operator namespace '{namespace}'"
+            )
+            return False
+        logging.info(
+            f"GPU Operator namespace '{namespace}' has {len(pods)} pod(s)"
+        )
+        return True
+    except Exception as e:
+        logging.error(f"failed to validate GPU Operator: {e}")
+        return False

--- a/krkn/utils/gpu.py
+++ b/krkn/utils/gpu.py
@@ -86,31 +86,48 @@ def validate_gpu_health_on_node(
         output = kubecli.exec_cmd_in_pod(
             command=[
                 "nvidia-smi --query-gpu=name,uuid,memory.total "
-                "--format=csv,noheader"
+                "--format=csv,noheader; echo KRKN_EXIT:$?"
             ],
             pod_name=driver_pod_name,
             namespace=driver_pod_ns,
             container="nvidia-driver-ctr",
         )
-        stripped = output.strip()
-        logging.info(f"nvidia-smi on {node_name}: {stripped}")
+
+        # Parse exit code from command output
+        exit_code = None
+        lines = output.strip().splitlines()
+        if lines and lines[-1].startswith("KRKN_EXIT:"):
+            exit_code = int(lines[-1].split(":")[1])
+            gpu_output = "\n".join(lines[:-1]).strip()
+        else:
+            gpu_output = output.strip()
+
+        logging.info(f"nvidia-smi on {node_name}: {gpu_output}")
+
+        # Check exit code first — nvidia-smi returns non-zero on failure
+        if exit_code is not None and exit_code != 0:
+            logging.error(
+                f"nvidia-smi exited with code {exit_code} on "
+                f"node {node_name}: {gpu_output}"
+            )
+            return False
 
         # Detect nvidia-smi error messages that still contain "NVIDIA"
         error_indicators = ["has failed", "no devices", "driver not loaded",
-                            "unable to", "error", "not found"]
-        lower_output = stripped.lower()
+                            "unable to", "not found"]
+        lower_output = gpu_output.lower()
         for indicator in error_indicators:
             if indicator in lower_output:
                 logging.error(
-                    f"nvidia-smi error detected on {node_name}: {stripped}"
+                    f"nvidia-smi error detected on {node_name}: {gpu_output}"
                 )
                 return False
 
         # Validate CSV output contains expected GPU info
-        if not stripped or ("," not in stripped):
+        if not gpu_output or ("," not in gpu_output):
             logging.error(
                 f"nvidia-smi output on {node_name} does not indicate "
-                f"healthy GPU: {stripped}"
+                f"healthy GPU: {gpu_output}"
             )
             return False
         return True

--- a/krkn/utils/gpu.py
+++ b/krkn/utils/gpu.py
@@ -84,17 +84,33 @@ def validate_gpu_health_on_node(
     driver_pod_ns = driver_pods[0][1]
     try:
         output = kubecli.exec_cmd_in_pod(
-            command=["nvidia-smi", "--query-gpu=name,uuid,memory.total",
-                     "--format=csv,noheader"],
+            command=[
+                "nvidia-smi --query-gpu=name,uuid,memory.total "
+                "--format=csv,noheader"
+            ],
             pod_name=driver_pod_name,
             namespace=driver_pod_ns,
             container="nvidia-driver-ctr",
         )
-        logging.info(f"nvidia-smi on {node_name}: {output.strip()}")
-        if "GPU" not in output and "NVIDIA" not in output.upper():
+        stripped = output.strip()
+        logging.info(f"nvidia-smi on {node_name}: {stripped}")
+
+        # Detect nvidia-smi error messages that still contain "NVIDIA"
+        error_indicators = ["has failed", "no devices", "driver not loaded",
+                            "unable to", "error", "not found"]
+        lower_output = stripped.lower()
+        for indicator in error_indicators:
+            if indicator in lower_output:
+                logging.error(
+                    f"nvidia-smi error detected on {node_name}: {stripped}"
+                )
+                return False
+
+        # Validate CSV output contains expected GPU info
+        if not stripped or ("," not in stripped):
             logging.error(
                 f"nvidia-smi output on {node_name} does not indicate "
-                f"healthy GPU: {output}"
+                f"healthy GPU: {stripped}"
             )
             return False
         return True

--- a/scenarios/kube/gpu_device_plugin.yaml
+++ b/scenarios/kube/gpu_device_plugin.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=../plugin.schema.json
+- id: gpu-device-plugin-disruption
+  config:
+    namespace: nvidia-gpu-operator
+    pod_label_selector: "app=nvidia-device-plugin-daemonset"
+    number_of_nodes: 1
+    recovery_timeout: 120
+    expected_recovery: true
+    verify_allocatable: true
+    validate_gpu_health: true

--- a/tests/test_gpu_device_scenario_plugin.py
+++ b/tests/test_gpu_device_scenario_plugin.py
@@ -257,6 +257,54 @@ class TestGpuUtils(unittest.TestCase):
 
         self.assertFalse(result)
 
+    def test_validate_gpu_health_on_node_error_output(self):
+        """nvidia-smi error message should fail health check even though it contains 'NVIDIA'"""
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.select_pods_by_namespace_pattern_and_label.return_value = [
+            ("nvidia-driver-daemonset-abc", "nvidia-gpu-operator")
+        ]
+        kubecli.exec_cmd_in_pod.return_value = (
+            "NVIDIA-SMI has failed because it couldn't communicate "
+            "with the NVIDIA driver."
+        )
+
+        result = validate_gpu_health_on_node(kubecli, "gpu-node")
+
+        self.assertFalse(result)
+
+    def test_validate_gpu_health_on_node_empty_output(self):
+        """Empty nvidia-smi output should fail health check"""
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.select_pods_by_namespace_pattern_and_label.return_value = [
+            ("nvidia-driver-daemonset-abc", "nvidia-gpu-operator")
+        ]
+        kubecli.exec_cmd_in_pod.return_value = ""
+
+        result = validate_gpu_health_on_node(kubecli, "gpu-node")
+
+        self.assertFalse(result)
+
+    def test_validate_gpu_health_custom_namespace(self):
+        """Health check should use the provided namespace"""
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.select_pods_by_namespace_pattern_and_label.return_value = [
+            ("nvidia-driver-daemonset-abc", "custom-ns")
+        ]
+        kubecli.exec_cmd_in_pod.return_value = (
+            "NVIDIA A30, GPU-abc123, 24576 MiB"
+        )
+
+        result = validate_gpu_health_on_node(
+            kubecli, "gpu-node", namespace="custom-ns"
+        )
+
+        self.assertTrue(result)
+        kubecli.select_pods_by_namespace_pattern_and_label.assert_called_once_with(
+            namespace_pattern="^custom-ns$",
+            label_selector="app.kubernetes.io/component=nvidia-driver",
+            field_selector="spec.nodeName=gpu-node,status.phase=Running",
+        )
+
 
 class TestGpuDeviceDisruption(unittest.TestCase):
 
@@ -442,6 +490,52 @@ class TestGpuDeviceDisruption(unittest.TestCase):
 
         self.assertEqual(result, 1)
         mock_wait_alloc.assert_called_once()
+
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.validate_gpu_operator_present")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.find_gpu_operator_pods")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.discover_gpu_nodes")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.get_node_gpu_allocatable")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.select_and_monitor_by_namespace_pattern_and_label")
+    def test_expected_recovery_false_returns_success(
+        self,
+        mock_monitor,
+        mock_get_alloc,
+        mock_discover,
+        mock_find_pods,
+        mock_validate_op,
+    ):
+        """When expected_recovery=False and pods don't recover, scenario should pass"""
+        mock_validate_op.return_value = True
+        mock_find_pods.return_value = [
+            ("nvidia-device-plugin-abc", "nvidia-gpu-operator")
+        ]
+        mock_discover.return_value = [{"name": "gpu-node", "gpu_count": 1}]
+        mock_get_alloc.return_value = 1
+
+        self.kubecli.read_pod.return_value = self._make_pod_info("gpu-node")
+
+        unrecovered_pod = MagicMock()
+        unrecovered_pod.name = "nvidia-device-plugin-abc"
+        mock_snapshot = MagicMock()
+        mock_status = MagicMock()
+        mock_status.unrecovered = [unrecovered_pod]
+        mock_snapshot.get_pods_status.return_value = mock_status
+        mock_future = MagicMock()
+        mock_future.result.return_value = mock_snapshot
+        mock_monitor.return_value = mock_future
+
+        self.plugin.rollback_handler = MagicMock()
+
+        config = InputParams({
+            "expected_recovery": False,
+            "validate_gpu_health": False,
+        })
+        telemetry = MagicMock()
+
+        result = self.plugin._run_disruption(config, self.kubecli, telemetry)
+
+        # Should return 0 (success) since we don't expect recovery
+        self.assertEqual(result, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_gpu_device_scenario_plugin.py
+++ b/tests/test_gpu_device_scenario_plugin.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+
+"""
+Test suite for GpuDeviceScenarioPlugin and GPU utilities
+
+Usage:
+    python -m coverage run -a -m unittest tests/test_gpu_device_scenario_plugin.py -v
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+from dataclasses import dataclass
+
+from krkn_lib.k8s import KrknKubernetes
+
+from krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin import (
+    GpuDeviceScenarioPlugin,
+)
+from krkn.scenario_plugins.gpu_device.models.models import InputParams
+from krkn.utils.gpu import (
+    discover_gpu_nodes,
+    get_node_gpu_allocatable,
+    validate_gpu_operator_present,
+    find_gpu_operator_pods,
+    wait_for_gpu_allocatable,
+    validate_gpu_health_on_node,
+)
+
+
+class TestGpuDeviceScenarioPlugin(unittest.TestCase):
+
+    def setUp(self):
+        self.plugin = GpuDeviceScenarioPlugin()
+
+    def tearDown(self):
+        self.plugin = None
+
+    def test_get_scenario_types(self):
+        result = self.plugin.get_scenario_types()
+        self.assertEqual(result, ["gpu_device_plugin_scenarios"])
+        self.assertEqual(len(result), 1)
+
+
+class TestInputParams(unittest.TestCase):
+
+    def test_defaults(self):
+        params = InputParams({})
+        self.assertEqual(params.namespace, "nvidia-gpu-operator")
+        self.assertEqual(params.node_selector, "")
+        self.assertEqual(params.number_of_nodes, 1)
+        self.assertEqual(
+            params.pod_label_selector, "app=nvidia-device-plugin-daemonset"
+        )
+        self.assertEqual(params.recovery_timeout, 120)
+        self.assertTrue(params.expected_recovery)
+        self.assertTrue(params.verify_allocatable)
+        self.assertEqual(params.krkn_pod_recovery_time, 120)
+        self.assertTrue(params.validate_gpu_health)
+
+    def test_explicit_values(self):
+        config = {
+            "namespace": "custom-ns",
+            "node_selector": "gpu=true",
+            "number_of_nodes": 3,
+            "pod_label_selector": "app=custom-plugin",
+            "recovery_timeout": 300,
+            "expected_recovery": False,
+            "verify_allocatable": False,
+            "krkn_pod_recovery_time": 60,
+            "validate_gpu_health": False,
+        }
+        params = InputParams(config)
+        self.assertEqual(params.namespace, "custom-ns")
+        self.assertEqual(params.node_selector, "gpu=true")
+        self.assertEqual(params.number_of_nodes, 3)
+        self.assertEqual(params.pod_label_selector, "app=custom-plugin")
+        self.assertEqual(params.recovery_timeout, 300)
+        self.assertFalse(params.expected_recovery)
+        self.assertFalse(params.verify_allocatable)
+        self.assertEqual(params.krkn_pod_recovery_time, 60)
+        self.assertFalse(params.validate_gpu_health)
+
+    def test_partial_config_uses_defaults(self):
+        params = InputParams({"namespace": "my-ns"})
+        self.assertEqual(params.namespace, "my-ns")
+        self.assertEqual(params.recovery_timeout, 120)
+        self.assertTrue(params.verify_allocatable)
+
+
+class TestGpuUtils(unittest.TestCase):
+
+    def _make_mock_node(self, name, gpu_count):
+        node = MagicMock()
+        node.metadata.name = name
+        node.status.allocatable = (
+            {"nvidia.com/gpu": str(gpu_count)} if gpu_count > 0 else {}
+        )
+        return node
+
+    def test_discover_gpu_nodes(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.list_nodes.return_value = ["node1", "node2", "node3"]
+
+        node1 = self._make_mock_node("node1", 2)
+        node2 = self._make_mock_node("node2", 0)
+        node3 = self._make_mock_node("node3", 1)
+        kubecli.cli.read_node.side_effect = lambda name: {
+            "node1": node1,
+            "node2": node2,
+            "node3": node3,
+        }[name]
+
+        result = discover_gpu_nodes(kubecli)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0], {"name": "node1", "gpu_count": 2})
+        self.assertEqual(result[1], {"name": "node3", "gpu_count": 1})
+
+    def test_discover_gpu_nodes_none_found(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.list_nodes.return_value = ["node1"]
+
+        node1 = self._make_mock_node("node1", 0)
+        kubecli.cli.read_node.return_value = node1
+
+        result = discover_gpu_nodes(kubecli)
+        self.assertEqual(result, [])
+
+    def test_get_node_gpu_allocatable(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        node = self._make_mock_node("gpu-node", 4)
+        kubecli.cli.read_node.return_value = node
+
+        count = get_node_gpu_allocatable(kubecli, "gpu-node")
+        self.assertEqual(count, 4)
+
+    def test_get_node_gpu_allocatable_no_gpu(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        node = self._make_mock_node("cpu-node", 0)
+        kubecli.cli.read_node.return_value = node
+
+        count = get_node_gpu_allocatable(kubecli, "cpu-node")
+        self.assertEqual(count, 0)
+
+    def test_get_node_gpu_allocatable_none_allocatable(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        node = MagicMock()
+        node.status.allocatable = None
+        kubecli.cli.read_node.return_value = node
+
+        count = get_node_gpu_allocatable(kubecli, "node")
+        self.assertEqual(count, 0)
+
+    def test_validate_gpu_operator_present_success(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.list_pods.return_value = ["pod1", "pod2"]
+
+        self.assertTrue(
+            validate_gpu_operator_present(kubecli, "nvidia-gpu-operator")
+        )
+
+    def test_validate_gpu_operator_present_no_pods(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.list_pods.return_value = []
+
+        self.assertFalse(
+            validate_gpu_operator_present(kubecli, "nvidia-gpu-operator")
+        )
+
+    def test_validate_gpu_operator_present_exception(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.list_pods.side_effect = Exception("namespace not found")
+
+        self.assertFalse(
+            validate_gpu_operator_present(kubecli, "nonexistent")
+        )
+
+    def test_find_gpu_operator_pods(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.select_pods_by_namespace_pattern_and_label.return_value = [
+            ("nvidia-device-plugin-abc", "nvidia-gpu-operator")
+        ]
+
+        pods = find_gpu_operator_pods(
+            kubecli,
+            "nvidia-gpu-operator",
+            "app=nvidia-device-plugin-daemonset",
+        )
+
+        self.assertEqual(len(pods), 1)
+        self.assertEqual(pods[0][0], "nvidia-device-plugin-abc")
+        kubecli.select_pods_by_namespace_pattern_and_label.assert_called_once_with(
+            namespace_pattern="^nvidia-gpu-operator$",
+            label_selector="app=nvidia-device-plugin-daemonset",
+            field_selector="status.phase=Running",
+        )
+
+    @patch("krkn.utils.gpu.time.sleep", return_value=None)
+    def test_wait_for_gpu_allocatable_success(self, mock_sleep):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        node_recovering = self._make_mock_node("node1", 0)
+        node_recovered = self._make_mock_node("node1", 2)
+        kubecli.cli.read_node.side_effect = [
+            node_recovering,
+            node_recovered,
+        ]
+
+        result = wait_for_gpu_allocatable(kubecli, "node1", 2, 60)
+        self.assertTrue(result)
+
+    @patch("krkn.utils.gpu.time.sleep", return_value=None)
+    def test_wait_for_gpu_allocatable_timeout(self, mock_sleep):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        node = self._make_mock_node("node1", 0)
+        kubecli.cli.read_node.return_value = node
+
+        result = wait_for_gpu_allocatable(kubecli, "node1", 2, 1)
+        self.assertFalse(result)
+
+    def test_validate_gpu_health_on_node_success(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.select_pods_by_namespace_pattern_and_label.return_value = [
+            ("nvidia-driver-daemonset-abc", "nvidia-gpu-operator")
+        ]
+        kubecli.exec_cmd_in_pod.return_value = (
+            "NVIDIA A30, GPU-abc123, 24576 MiB"
+        )
+
+        result = validate_gpu_health_on_node(kubecli, "gpu-node")
+
+        self.assertTrue(result)
+        kubecli.select_pods_by_namespace_pattern_and_label.assert_called_once_with(
+            namespace_pattern="^nvidia-gpu-operator$",
+            label_selector="app.kubernetes.io/component=nvidia-driver",
+            field_selector="spec.nodeName=gpu-node,status.phase=Running",
+        )
+        kubecli.exec_cmd_in_pod.assert_called_once()
+
+    def test_validate_gpu_health_on_node_failure(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.select_pods_by_namespace_pattern_and_label.return_value = [
+            ("nvidia-driver-daemonset-abc", "nvidia-gpu-operator")
+        ]
+        kubecli.exec_cmd_in_pod.side_effect = Exception(
+            "nvidia-smi not found"
+        )
+
+        result = validate_gpu_health_on_node(kubecli, "gpu-node")
+
+        self.assertFalse(result)
+
+    def test_validate_gpu_health_on_node_no_driver_pod(self):
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.select_pods_by_namespace_pattern_and_label.return_value = []
+
+        result = validate_gpu_health_on_node(kubecli, "gpu-node")
+
+        self.assertFalse(result)
+
+
+class TestGpuDeviceDisruption(unittest.TestCase):
+
+    def setUp(self):
+        self.plugin = GpuDeviceScenarioPlugin()
+        self.kubecli = MagicMock(spec=KrknKubernetes)
+
+    def tearDown(self):
+        self.plugin = None
+        self.kubecli = None
+
+    def _make_pod_info(self, node_name):
+        pod_info = MagicMock()
+        pod_info.spec.node_name = node_name
+        return pod_info
+
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.validate_gpu_operator_present")
+    def test_preflight_fails_no_gpu_operator(self, mock_validate):
+        mock_validate.return_value = False
+        config = InputParams({})
+        telemetry = MagicMock()
+
+        result = self.plugin._run_disruption(config, self.kubecli, telemetry)
+
+        self.assertEqual(result, 1)
+        mock_validate.assert_called_once()
+
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.validate_gpu_operator_present")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.find_gpu_operator_pods")
+    def test_preflight_fails_no_device_plugin_pods(
+        self, mock_find, mock_validate
+    ):
+        mock_validate.return_value = True
+        mock_find.return_value = []
+        config = InputParams({})
+        telemetry = MagicMock()
+
+        result = self.plugin._run_disruption(config, self.kubecli, telemetry)
+
+        self.assertEqual(result, 1)
+
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.validate_gpu_operator_present")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.find_gpu_operator_pods")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.discover_gpu_nodes")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.get_node_gpu_allocatable")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.validate_gpu_health_on_node")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.wait_for_gpu_allocatable")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.select_and_monitor_by_namespace_pattern_and_label")
+    def test_successful_disruption_and_recovery(
+        self,
+        mock_monitor,
+        mock_wait_alloc,
+        mock_health,
+        mock_get_alloc,
+        mock_discover,
+        mock_find_pods,
+        mock_validate_op,
+    ):
+        mock_validate_op.return_value = True
+        mock_find_pods.return_value = [
+            ("nvidia-device-plugin-abc", "nvidia-gpu-operator")
+        ]
+        mock_discover.return_value = [{"name": "gpu-node", "gpu_count": 1}]
+        mock_get_alloc.return_value = 1
+        mock_health.return_value = True
+        mock_wait_alloc.return_value = True
+
+        # Mock pod info for node matching
+        self.kubecli.read_pod.return_value = self._make_pod_info("gpu-node")
+
+        # Mock monitoring future
+        mock_snapshot = MagicMock()
+        mock_status = MagicMock()
+        mock_status.unrecovered = []
+        mock_snapshot.get_pods_status.return_value = mock_status
+        mock_future = MagicMock()
+        mock_future.result.return_value = mock_snapshot
+        mock_monitor.return_value = mock_future
+
+        # Mock rollback handler
+        self.plugin.rollback_handler = MagicMock()
+
+        config = InputParams(
+            {"verify_allocatable": True, "validate_gpu_health": True}
+        )
+        telemetry = MagicMock()
+
+        result = self.plugin._run_disruption(config, self.kubecli, telemetry)
+
+        self.assertEqual(result, 0)
+        self.kubecli.delete_pod.assert_called_once_with(
+            "nvidia-device-plugin-abc", "nvidia-gpu-operator"
+        )
+        mock_wait_alloc.assert_called_once()
+        # Pre + post health checks
+        self.assertEqual(mock_health.call_count, 2)
+
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.validate_gpu_operator_present")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.find_gpu_operator_pods")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.discover_gpu_nodes")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.get_node_gpu_allocatable")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.select_and_monitor_by_namespace_pattern_and_label")
+    def test_recovery_timeout_unrecovered_pods(
+        self,
+        mock_monitor,
+        mock_get_alloc,
+        mock_discover,
+        mock_find_pods,
+        mock_validate_op,
+    ):
+        mock_validate_op.return_value = True
+        mock_find_pods.return_value = [
+            ("nvidia-device-plugin-abc", "nvidia-gpu-operator")
+        ]
+        mock_discover.return_value = [{"name": "gpu-node", "gpu_count": 1}]
+        mock_get_alloc.return_value = 1
+
+        self.kubecli.read_pod.return_value = self._make_pod_info("gpu-node")
+
+        unrecovered_pod = MagicMock()
+        unrecovered_pod.name = "nvidia-device-plugin-abc"
+        mock_snapshot = MagicMock()
+        mock_status = MagicMock()
+        mock_status.unrecovered = [unrecovered_pod]
+        mock_snapshot.get_pods_status.return_value = mock_status
+        mock_future = MagicMock()
+        mock_future.result.return_value = mock_snapshot
+        mock_monitor.return_value = mock_future
+
+        self.plugin.rollback_handler = MagicMock()
+
+        config = InputParams({"validate_gpu_health": False})
+        telemetry = MagicMock()
+
+        result = self.plugin._run_disruption(config, self.kubecli, telemetry)
+
+        self.assertEqual(result, 1)
+
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.validate_gpu_operator_present")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.find_gpu_operator_pods")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.discover_gpu_nodes")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.get_node_gpu_allocatable")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.validate_gpu_health_on_node")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.wait_for_gpu_allocatable")
+    @patch("krkn.scenario_plugins.gpu_device.gpu_device_scenario_plugin.select_and_monitor_by_namespace_pattern_and_label")
+    def test_allocatable_not_restored(
+        self,
+        mock_monitor,
+        mock_wait_alloc,
+        mock_health,
+        mock_get_alloc,
+        mock_discover,
+        mock_find_pods,
+        mock_validate_op,
+    ):
+        mock_validate_op.return_value = True
+        mock_find_pods.return_value = [
+            ("nvidia-device-plugin-abc", "nvidia-gpu-operator")
+        ]
+        mock_discover.return_value = [{"name": "gpu-node", "gpu_count": 1}]
+        mock_get_alloc.return_value = 1
+        mock_health.return_value = True
+        mock_wait_alloc.return_value = False
+
+        self.kubecli.read_pod.return_value = self._make_pod_info("gpu-node")
+
+        mock_snapshot = MagicMock()
+        mock_status = MagicMock()
+        mock_status.unrecovered = []
+        mock_snapshot.get_pods_status.return_value = mock_status
+        mock_future = MagicMock()
+        mock_future.result.return_value = mock_snapshot
+        mock_monitor.return_value = mock_future
+
+        self.plugin.rollback_handler = MagicMock()
+
+        config = InputParams(
+            {"verify_allocatable": True, "validate_gpu_health": False}
+        )
+        telemetry = MagicMock()
+
+        result = self.plugin._run_disruption(config, self.kubecli, telemetry)
+
+        self.assertEqual(result, 1)
+        mock_wait_alloc.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gpu_device_scenario_plugin.py
+++ b/tests/test_gpu_device_scenario_plugin.py
@@ -223,7 +223,7 @@ class TestGpuUtils(unittest.TestCase):
             ("nvidia-driver-daemonset-abc", "nvidia-gpu-operator")
         ]
         kubecli.exec_cmd_in_pod.return_value = (
-            "NVIDIA A30, GPU-abc123, 24576 MiB"
+            "NVIDIA A30, GPU-abc123, 24576 MiB\nKRKN_EXIT:0"
         )
 
         result = validate_gpu_health_on_node(kubecli, "gpu-node")
@@ -265,7 +265,7 @@ class TestGpuUtils(unittest.TestCase):
         ]
         kubecli.exec_cmd_in_pod.return_value = (
             "NVIDIA-SMI has failed because it couldn't communicate "
-            "with the NVIDIA driver."
+            "with the NVIDIA driver.\nKRKN_EXIT:6"
         )
 
         result = validate_gpu_health_on_node(kubecli, "gpu-node")
@@ -278,7 +278,7 @@ class TestGpuUtils(unittest.TestCase):
         kubecli.select_pods_by_namespace_pattern_and_label.return_value = [
             ("nvidia-driver-daemonset-abc", "nvidia-gpu-operator")
         ]
-        kubecli.exec_cmd_in_pod.return_value = ""
+        kubecli.exec_cmd_in_pod.return_value = "\nKRKN_EXIT:0"
 
         result = validate_gpu_health_on_node(kubecli, "gpu-node")
 
@@ -291,7 +291,7 @@ class TestGpuUtils(unittest.TestCase):
             ("nvidia-driver-daemonset-abc", "custom-ns")
         ]
         kubecli.exec_cmd_in_pod.return_value = (
-            "NVIDIA A30, GPU-abc123, 24576 MiB"
+            "NVIDIA A30, GPU-abc123, 24576 MiB\nKRKN_EXIT:0"
         )
 
         result = validate_gpu_health_on_node(
@@ -304,6 +304,20 @@ class TestGpuUtils(unittest.TestCase):
             label_selector="app.kubernetes.io/component=nvidia-driver",
             field_selector="spec.nodeName=gpu-node,status.phase=Running",
         )
+
+    def test_validate_gpu_health_nonzero_exit_code(self):
+        """nvidia-smi non-zero exit code should fail health check"""
+        kubecli = MagicMock(spec=KrknKubernetes)
+        kubecli.select_pods_by_namespace_pattern_and_label.return_value = [
+            ("nvidia-driver-daemonset-abc", "nvidia-gpu-operator")
+        ]
+        kubecli.exec_cmd_in_pod.return_value = (
+            "Some unexpected output\nKRKN_EXIT:15"
+        )
+
+        result = validate_gpu_health_on_node(kubecli, "gpu-node")
+
+        self.assertFalse(result)
 
 
 class TestGpuDeviceDisruption(unittest.TestCase):

--- a/tests/test_gpu_health_check_plugin.py
+++ b/tests/test_gpu_health_check_plugin.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Test suite for GpuHealthCheckPlugin.
+
+Covers:
+- Factory discovery, health check type, and config key
+- Early-return guards (no kube client, no GPU nodes)
+- Allocatable-based outage detection and recovery telemetry
+- exit_on_failure return-code behavior
+- Optional nvidia-smi validation
+- Probe exception handling
+
+Run:
+    python -m unittest tests.test_gpu_health_check_plugin -v
+"""
+
+import os
+import queue
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
+from krkn.health_checks import HealthCheckFactory
+
+PLUGIN_MODULE = "krkn.health_checks.gpu_health_check_plugin"
+
+
+class _CountingAllocatable:
+    """Side effect that returns queued allocatable values while advancing the
+    plugin's iteration counter so the monitoring loop terminates."""
+
+    def __init__(self, plugin, values):
+        self.plugin = plugin
+        self.values = list(values)
+        self.calls = 0
+
+    def __call__(self, kubecli, node_name):
+        value = self.values[min(self.calls, len(self.values) - 1)]
+        self.calls += 1
+        self.plugin.current_iterations += 1
+        return value
+
+
+class TestGpuHealthCheckPlugin(unittest.TestCase):
+    def setUp(self):
+        self.factory = HealthCheckFactory()
+        if "gpu_health_check" not in self.factory.loaded_plugins:
+            self.skipTest("GPU health check plugin not loaded")
+        self.kubecli = object()  # opaque; all cluster calls are mocked
+        self.queue = queue.Queue()
+
+    def _plugin(self, iterations=1):
+        return self.factory.create_plugin(
+            "gpu_health_check", iterations=iterations, krkn_lib=self.kubecli
+        )
+
+    def _drain(self):
+        try:
+            return self.queue.get_nowait()
+        except queue.Empty:
+            return None
+
+    # --- discovery / contract -------------------------------------------
+    def test_factory_discovery(self):
+        self.assertIn("gpu_health_check", self.factory.loaded_plugins)
+        # config_key wiring is verified end-to-end in a single-factory run;
+        # assert the plugin's own declaration here (loaded_plugins is a
+        # class-level cache shared across factory instances in-process).
+        self.assertEqual(self._plugin().get_config_key(), "gpu_health_checks")
+
+    def test_types_and_config_key(self):
+        plugin = self._plugin()
+        self.assertEqual(plugin.get_health_check_types(), ["gpu_health_check"])
+        self.assertEqual(plugin.get_config_key(), "gpu_health_checks")
+
+    def test_increment_iterations(self):
+        plugin = self._plugin(iterations=5)
+        plugin.increment_iterations()
+        self.assertEqual(plugin.current_iterations, 1)
+
+    # --- guards ----------------------------------------------------------
+
+    def test_no_kube_client_returns_early(self):
+        plugin = self.factory.create_plugin(
+            "gpu_health_check", iterations=1, krkn_lib=None
+        )
+        plugin.run_health_check({}, self.queue)
+        self.assertIsNone(self._drain())
+
+    def test_no_gpu_nodes_returns_early(self):
+        plugin = self._plugin()
+        with patch(f"{PLUGIN_MODULE}.discover_gpu_nodes", return_value=[]):
+            plugin.run_health_check({}, self.queue)
+        self.assertIsNone(self._drain())
+
+    # --- monitoring behavior --------------------------------------------
+
+    def test_healthy_throughout(self):
+        plugin = self._plugin(iterations=2)
+        with patch(
+            f"{PLUGIN_MODULE}.discover_gpu_nodes",
+            return_value=[{"name": "gpu-node", "gpu_count": 1}],
+        ), patch(
+            f"{PLUGIN_MODULE}.get_node_gpu_allocatable",
+            side_effect=_CountingAllocatable(plugin, [1, 1]),
+        ), patch(f"{PLUGIN_MODULE}.time.sleep"):
+            plugin.run_health_check({"interval": 0}, self.queue)
+
+        telemetry = self._drain()
+        self.assertIsNotNone(telemetry)
+        self.assertTrue(all(rec.status for rec in telemetry))
+        self.assertEqual(plugin.get_return_value(), 0)
+
+    def test_outage_detected_and_recovered(self):
+        plugin = self._plugin(iterations=3)
+        with patch(
+            f"{PLUGIN_MODULE}.discover_gpu_nodes",
+            return_value=[{"name": "gpu-node", "gpu_count": 1}],
+        ), patch(
+            f"{PLUGIN_MODULE}.get_node_gpu_allocatable",
+            side_effect=_CountingAllocatable(plugin, [1, 0, 1]),
+        ), patch(f"{PLUGIN_MODULE}.time.sleep"):
+            plugin.run_health_check({"interval": 0}, self.queue)
+
+        telemetry = self._drain()
+        self.assertIsNotNone(telemetry)
+        outages = [rec for rec in telemetry if not rec.status]
+        self.assertEqual(len(outages), 1, "expected exactly one outage window")
+        self.assertEqual(outages[0].url, "gpu://gpu-node")
+        self.assertEqual(outages[0].status_code, "0")
+        # exit_on_failure defaults to False -> run is not failed
+        self.assertEqual(plugin.get_return_value(), 0)
+
+    def test_exit_on_failure_sets_return_value(self):
+        plugin = self._plugin(iterations=2)
+        with patch(
+            f"{PLUGIN_MODULE}.discover_gpu_nodes",
+            return_value=[{"name": "gpu-node", "gpu_count": 1}],
+        ), patch(
+            f"{PLUGIN_MODULE}.get_node_gpu_allocatable",
+            side_effect=_CountingAllocatable(plugin, [1, 0]),
+        ), patch(f"{PLUGIN_MODULE}.time.sleep"):
+            plugin.run_health_check(
+                {"interval": 0, "exit_on_failure": True}, self.queue
+            )
+
+        self.assertEqual(plugin.get_return_value(), 3)
+
+    def test_validate_gpu_health_invoked(self):
+        plugin = self._plugin(iterations=1)
+        with patch(
+            f"{PLUGIN_MODULE}.discover_gpu_nodes",
+            return_value=[{"name": "gpu-node", "gpu_count": 1}],
+        ), patch(
+            f"{PLUGIN_MODULE}.get_node_gpu_allocatable",
+            side_effect=_CountingAllocatable(plugin, [1]),
+        ), patch(
+            f"{PLUGIN_MODULE}.validate_gpu_health_on_node", return_value=False
+        ) as mock_smi, patch(f"{PLUGIN_MODULE}.time.sleep"):
+            plugin.run_health_check(
+                {"interval": 0, "validate_gpu_health": True}, self.queue
+            )
+
+        mock_smi.assert_called_with(
+            self.kubecli, "gpu-node", namespace="nvidia-gpu-operator"
+        )
+        telemetry = self._drain()
+        # allocatable healthy but nvidia-smi failed -> node reported unhealthy
+        self.assertTrue(any(not rec.status for rec in telemetry))
+
+    def test_probe_exception_marks_unhealthy(self):
+        plugin = self._plugin(iterations=1)
+
+        def boom(kubecli, node_name):
+            plugin.current_iterations += 1
+            raise RuntimeError("api error")
+
+        with patch(
+            f"{PLUGIN_MODULE}.discover_gpu_nodes",
+            return_value=[{"name": "gpu-node", "gpu_count": 1}],
+        ), patch(
+            f"{PLUGIN_MODULE}.get_node_gpu_allocatable", side_effect=boom
+        ), patch(f"{PLUGIN_MODULE}.time.sleep"):
+            plugin.run_health_check({"interval": 0}, self.queue)
+
+        telemetry = self._drain()
+        self.assertIsNotNone(telemetry)
+        self.assertTrue(any(rec.status_code == "error" for rec in telemetry))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **Scenario plugin** (`gpu_device_plugin_scenarios`) that kills NVIDIA device plugin pods on GPU nodes, simulating device plugin crashes and verifying recovery (CHAOS-2162).
- **GPU health check plugin** (`gpu_health_check`) — a passive, continuous monitor that tracks `nvidia.com/gpu` allocatable across the whole run and records GPU **downtime** to telemetry. Reusable by any scenario, not just this one.
- **Shared GPU utilities** in `krkn/utils/gpu.py` — node discovery, allocatable tracking, nvidia-smi health validation — consumed by both the scenario and the health check.
- Unit tests for the plugin, config model, GPU utilities, disruption flow, and the health check.

## Files

| File | Purpose |
|------|---------|
| `krkn/scenario_plugins/gpu_device/gpu_device_scenario_plugin.py` | Scenario: disruption logic + rollback |
| `krkn/scenario_plugins/gpu_device/models/models.py` | `InputParams` config model |
| `krkn/utils/gpu.py` | Shared GPU utilities (node discovery, allocatable, nvidia-smi health) |
| `krkn/health_checks/gpu_health_check_plugin.py` | **New:** continuous GPU availability/downtime monitor |
| `scenarios/kube/gpu_device_plugin.yaml` | Example scenario config |
| `tests/test_gpu_device_scenario_plugin.py` | Scenario + utils unit tests |
| `tests/test_gpu_health_check_plugin.py` | **New:** health check unit tests |

## Scenario flow

1. **Pre-flight** — validate GPU Operator namespace, find device plugin pods
2. **Discover** — identify GPU nodes via `nvidia.com/gpu` allocatable, match pods to nodes
3. **Baseline** — snapshot allocatable, run nvidia-smi pre-check via driver container
4. **Inject** — delete device plugin pod(s), monitor DaemonSet recovery
5. **Verify** — pod recovery (with per-pod recovery timing logged), allocatable restored, nvidia-smi post-check

## Minimal working config

`config.yaml`:

```yaml
kraken:
    kubeconfig_path: ~/.kube/config
    chaos_scenarios:
       - gpu_device_plugin_scenarios:
           - scenarios/kube/gpu_device_plugin.yaml
tunings:
    iterations: 1
    daemon_mode: False

# Optional: continuous GPU availability / downtime monitoring during the run.
# Auto-discovered by config key; no other wiring needed.
gpu_health_checks:
    interval: 2                     # seconds between allocatable polls
    namespace: nvidia-gpu-operator
    validate_gpu_health: false      # also exec nvidia-smi (driver-level check)
    exit_on_failure: false          # true -> GPU downtime fails the run (exit 3)
```

`scenarios/kube/gpu_device_plugin.yaml`:

```yaml
- id: gpu-device-plugin-disruption
  config:
    namespace: nvidia-gpu-operator
    pod_label_selector: "app=nvidia-device-plugin-daemonset"
    number_of_nodes: 1
    recovery_timeout: 120
    expected_recovery: true
    verify_allocatable: true
    validate_gpu_health: true
```

Run: `python run_kraken.py -c config.yaml`

**Prereqs:** cluster with GPU nodes, NVIDIA GPU Operator installed, `nvidia.com/gpu` visible in node allocatable.

## Health check results

### During the scenario — continuous availability confirmed

A single device-plugin pod bounce recovers in ~3s and the kubelet retains `nvidia.com/gpu` allocatable across the restart, so **no GPU scheduling downtime occurs** — which the health check correctly reports as a continuous healthy window:

```
[INFO] Started health check plugin 'gpu_health_check' reading from config key 'gpu_health_checks'
[INFO] GPU health check monitoring 1 node(s): {'ocp-worker': 1}
[INFO] device plugin pod nvidia-device-plugin-daemonset-... recovered in 3.42s (rescheduling 0.25s, readiness 3.17s)
[INFO] node ocp-worker GPU allocatable restored: 1
```

Telemetry (`chaos_telemetry.health_checks`):

```json
"health_checks": [
  { "url": "gpu://ocp-worker", "status": true, "status_code": "1",
    "start_timestamp": "2026-08-17T14:16:48.165184",
    "end_timestamp":   "2026-08-17T14:17:07.829953",
    "duration": 19.664769 }
]
```

Run summary:

```
HEALTH CHECKS
  PASS   gpu://ocp-worker (19.66s)
```

## Full run log

<details>
<summary>krkn run output (scenario + health check)</summary>

```
 _         _          
| | ___ __| | ___ __  
| |/ / '__| |/ / '_ \ 
|   <| |  |   <| | | |
|_|\_\_|  |_|\_\_| |_|
                      

2026-08-17 14:16:38,126 [INFO] Starting krkn
2026-08-17 14:16:38,129 [INFO] Initializing client to talk to the Kubernetes cluster
2026-08-17 14:16:38,130 [INFO] Generated a uuid for the run: c3cb7506-1375-4c93-a1ec-5d3f1c9c9c86
2026-08-17 14:16:38,899 [INFO] Detected cluster platform: openshift
2026-08-17 14:16:38,899 [INFO] Fetching cluster info
2026-08-17 14:16:41,387 [INFO] 4.22.1
2026-08-17 14:16:41,388 [INFO] Server URL: https://api.ocp.local:6443
2026-08-17 14:16:41,388 [INFO] Daemon mode not enabled, will run through 1 iterations

2026-08-17 14:16:42,927 [INFO] 📣 `ScenarioPluginFactory`: types from config.yaml mapped to respective classes for execution:
2026-08-17 14:16:42,927 [INFO]   ✅ type: application_outages_scenarios ➡️ `ApplicationOutageScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: container_scenarios ➡️ `ContainerScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: gpu_device_plugin_scenarios ➡️ `GpuDeviceScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: hog_scenarios ➡️ `HogsScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: http_load_scenarios ➡️ `HttpLoadScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: kubevirt_vm_outage ➡️ `KubevirtVmOutageScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: managedcluster_scenarios ➡️ `ManagedClusterScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ types: [pod_network_scenarios, ingress_node_scenarios] ➡️ `NativeScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: network_chaos_scenarios ➡️ `NetworkChaosScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: network_chaos_ng_scenarios ➡️ `NetworkChaosNgScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: node_scenarios ➡️ `NodeActionsScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: pod_disruption_scenarios ➡️ `PodDisruptionScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: pvc_scenarios ➡️ `PvcScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: service_disruption_scenarios ➡️ `ServiceDisruptionScenarioPlugin` 
2026-08-17 14:16:42,928 [INFO]   ✅ type: service_hijacking_scenarios ➡️ `ServiceHijackingScenarioPlugin` 
2026-08-17 14:16:42,929 [INFO]   ✅ type: cluster_shut_down_scenarios ➡️ `ShutDownScenarioPlugin` 
2026-08-17 14:16:42,929 [INFO]   ✅ type: storage_throttle_scenarios ➡️ `StorageThrottleScenarioPlugin` 
2026-08-17 14:16:42,929 [INFO]   ✅ type: syn_flood_scenarios ➡️ `SynFloodScenarioPlugin` 
2026-08-17 14:16:42,929 [INFO]   ✅ type: time_scenarios ➡️ `TimeActionsScenarioPlugin` 
2026-08-17 14:16:42,929 [INFO]   ✅ type: zone_outages_scenarios ➡️ `ZoneOutageScenarioPlugin` 
2026-08-17 14:16:42,929 [INFO] 

2026-08-17 14:16:42,929 [INFO] 📣 `HealthCheckFactory`: Available health check plugins: ['gpu_health_check', 'http_health_check', 'simple_health_check', 'test_health_check', 'virt_health_check', 'kubevirt_health_check', 'vm_health_check']
2026-08-17 14:16:42,930 [INFO] Started health check plugin 'gpu_health_check' reading from config key 'gpu_health_checks'
2026-08-17 14:16:42,930 [INFO] HTTP health check config is not defined, skipping
2026-08-17 14:16:42,930 [INFO] Started health check plugin 'http_health_check' reading from config key 'health_checks'
2026-08-17 14:16:42,930 [INFO] Executing scenarios for iteration 0
2026-08-17 14:16:42,932 [INFO] Signal handlers registered globally
2026-08-17 14:16:42,933 [INFO] Running GpuDeviceScenarioPlugin: ['gpu_device_plugin_scenarios'] -> build/gpu_device_plugin_scenario.yaml
2026-08-17 14:16:42,933 [INFO] Set rollback_context: 1786956402933313839-c3cb7506-1375-4c93-a1ec-5d3f1c9c9c86 for scenario_type: gpu_device_plugin_scenarios RollbackHandler
2026-08-17 14:16:44,930 [INFO] GPU Operator namespace 'nvidia-gpu-operator' has 11 pod(s)
2026-08-17 14:16:46,085 [INFO] found 1 device plugin pod(s): ['nvidia-device-plugin-daemonset-f2t85']
2026-08-17 14:16:47,034 [INFO] discovered GPU node: ocp-worker with 1 GPU(s)
2026-08-17 14:16:47,034 [INFO] GPU health check monitoring 1 node(s): {'ocp-worker': 1}
2026-08-17 14:16:49,776 [INFO] discovered GPU node: ocp-worker with 1 GPU(s)
2026-08-17 14:16:49,776 [INFO] targeting GPU nodes: ['ocp-worker']
2026-08-17 14:16:50,768 [INFO] target device plugin pods: ['nvidia-device-plugin-daemonset-f2t85']
2026-08-17 14:16:51,775 [INFO] node ocp-worker GPU allocatable snapshot: 1
2026-08-17 14:16:54,728 [INFO] nvidia-smi on ocp-worker: NVIDIA A30, GPU-d8ef85ee-1b27-244c-79ae-75880a8c9b8a, 24576 MiB
2026-08-17 14:16:54,728 [INFO] pre-disruption GPU health check passed on node ocp-worker
2026-08-17 14:16:55,838 [INFO] Monitoring pods - tracking 1 initial pods
2026-08-17 14:16:55,838 [INFO] monitoring device plugin pods for up to 120s
2026-08-17 14:16:55,842 [INFO] Serialized callable written to build/rollback/1786956402933313839-c3cb7506-1375-4c93-a1ec-5d3f1c9c9c86/gpu_device_plugin_scenarios_1786956398043106566_sqzyazhz.py
2026-08-17 14:16:55,842 [INFO] Rollback callable serialized to build/rollback/1786956402933313839-c3cb7506-1375-4c93-a1ec-5d3f1c9c9c86/gpu_device_plugin_scenarios_1786956398043106566_sqzyazhz.py
2026-08-17 14:16:55,842 [INFO] deleting device plugin pod nvidia-device-plugin-daemonset-f2t85 in nvidia-gpu-operator
2026-08-17 14:17:01,160 [INFO] Pod nvidia-device-plugin-daemonset-dx5k2 recovery calculation: deletion_ts=1786956417.9888363, rescheduled_start_ts=1786956418.2358959, rescheduled_ready_ts=1786956421.1601934
2026-08-17 14:17:01,161 [INFO] device plugin pod nvidia-device-plugin-daemonset-dx5k2 on nvidia-gpu-operator recovered in 3.42s (rescheduling 0.25s, readiness 3.17s)
2026-08-17 14:17:02,385 [INFO] node ocp-worker GPU allocatable restored: 1
2026-08-17 14:17:05,316 [INFO] nvidia-smi on ocp-worker: NVIDIA A30, GPU-d8ef85ee-1b27-244c-79ae-75880a8c9b8a, 24576 MiB
2026-08-17 14:17:05,316 [INFO] post-disruption GPU health check passed on node ocp-worker
2026-08-17 14:17:05,317 [INFO] GPU device plugin disruption scenario completed
2026-08-17 14:17:05,317 [INFO] Skipped 5 non-matching entries in rollback versions directory
2026-08-17 14:17:05,318 [INFO] Cleaning up rollback version files for run_uuid=c3cb7506-1375-4c93-a1ec-5d3f1c9c9c86, scenario_type=gpu_device_plugin_scenarios
2026-08-17 14:17:05,318 [INFO] Removed build/rollback/1786956402933313839-c3cb7506-1375-4c93-a1ec-5d3f1c9c9c86/gpu_device_plugin_scenarios_1786956398043106566_sqzyazhz.py successfully.
2026-08-17 14:17:05,319 [INFO] waiting 1s for cluster to stabilize before collecting metrics
2026-08-17 14:17:07,830 [INFO] Collecting OCP cluster metadata (nodes, resources, network plugins)...
2026-08-17 14:17:59,253 [INFO] failed to get virtualmachines: (404)
Reason: Not Found
HTTP response headers: HTTPHeaderDict({'Audit-Id': 'af16f0b6-5db9-429e-a692-bdb021dc62b5', 'Cache-Control': 'no-cache, private', 'Content-Type': 'text/plain; charset=utf-8', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload', 'X-Content-Type-Options': 'nosniff', 'X-Kubernetes-Pf-Flowschema-Uid': 'a5f8e9de-6023-42a7-b5bb-7dd14930d968', 'X-Kubernetes-Pf-Prioritylevel-Uid': 'df4f4d58-c54d-4899-a4a9-4f6960b17e65', 'Date': 'Mon, 17 Aug 2026 08:47:17 GMT', 'Content-Length': '19'})
HTTP response body: 404 page not found


2026-08-17 14:17:59,257 [WARNING] V1ApiException -> 'none'
2026-08-17 14:17:59,515 [INFO] Chaos data:
{
    "telemetry": {
        "scenarios": [
            {
                "start_timestamp": 1786956402,
                "end_timestamp": 1786956426,
                "scenario": "build/gpu_device_plugin_scenario.yaml",
                "scenario_type": "gpu_device_plugin_scenarios",
                "exit_status": 0,
                "parameters_base64": "",
                "parameters": [
                    {
                        "config": {
                            "expected_recovery": true,
                            "namespace": "nvidia-gpu-operator",
                            "number_of_nodes": 1,
                            "pod_label_selector": "app=nvidia-device-plugin-daemonset",
                            "recovery_timeout": 120,
                            "validate_gpu_health": true,
                            "verify_allocatable": true
                        },
                        "id": "gpu-device-plugin-disruption"
                    }
                ],
                "affected_pods": {
                    "recovered": [
                        {
                            "pod_name": "nvidia-device-plugin-daemonset-dx5k2",
                            "namespace": "nvidia-gpu-operator",
                            "total_recovery_time": 3.418416738510132,
                            "pod_readiness_time": 3.1713571548461914,
                            "pod_rescheduling_time": 0.24705958366394043
                        }
                    ],
                    "unrecovered": [],
                    "error": null
                },
                "affected_vmis": {
                    "recovered": [],
                    "unrecovered": [],
                    "error": null
                },
                "affected_nodes": [],
                "cluster_events": []
            }
        ],
        "node_summary_infos": [
            {
                "count": 2,
                "architecture": "amd64",
                "instance_type": "unknown",
                "nodes_type": "worker",
                "kernel_version": "5.14.0-687.13.1.el9_8.x86_64",
                "kubelet_version": "v1.35.5",
                "os_version": "Red Hat Enterprise Linux CoreOS 9.8.20260605-0 (Plow)"
            }
        ],
        "node_taints": [],
        "kubernetes_objects_count": {
            "Deployment": 93,
            "Secret": 350,
            "Pod": 208,
            "ConfigMap": 842,
            "Build": 0,
            "Route": 14
        },
        "network_plugins": [
            "OVNKubernetes"
        ],
        "timestamp": "2026-08-17T08:46:41Z",
        "health_checks": [
            {
                "url": "gpu://ocp-worker",
                "status": true,
                "status_code": "1",
                "start_timestamp": "2026-08-17T14:16:48.165184",
                "end_timestamp": "2026-08-17T14:17:07.829953",
                "duration": 19.664769
            }
        ],
        "virt_checks": null,
        "error_logs": [],
        "overall_resiliency_report": {
            "scenarios": {},
            "resiliency_score": 0,
            "passed_slos": 0,
            "total_slos": 0
        },
        "failed_alerts": [],
        "total_node_count": 2,
        "cloud_infrastructure": "None",
        "cloud_type": "self-managed",
        "cluster_version": "4.22.1",
        "major_version": "4.22",
        "run_uuid": "c3cb7506-1375-4c93-a1ec-5d3f1c9c9c86",
        "post_virt_checks": null,
        "job_status": true,
        "build_url": "manual",
        "tag": "",
        "fips_enabled": false,
        "etcd_encryption_enabled": false,
        "ipsec_enabled": false
    },
    "critical_alerts": null
}
2026-08-17 14:17:59,517 [INFO] 
================================================================================
KRKN RUN SUMMARY
================================================================================
Run UUID : c3cb7506-1375-4c93-a1ec-5d3f1c9c9c86
Status   : PASS
Cluster  : 4.22.1 (None, self-managed)
Window   : 2026-08-17 14:16:42 – 14:17:06
Nodes    : 2
Network  : OVNKubernetes
CLUSTER OVERVIEW
  Type     Count  Instance       Arch    Kubelet    OS
  worker   2      unknown        amd64   v1.35.5    Red Hat Enterprise Linux CoreOS 9.8.20260605-0 (Plow)
TARGETS
  [1] Scenario  : build/gpu_device_plugin_scenario.yaml (gpu_device_plugin_scenarios)
  Namespace      : nvidia-gpu-operator
  Pods Disrupted :
    - nvidia-gpu-operator/nvidia-device-plugin-daemonset-dx5k2
KEY METRICS
  [1] Scenario: build/gpu_device_plugin_scenario.yaml
    Exit Status           : PASS (0)
    Pods Recovered        : 1
    Pods Unrecovered      : 0
    Total Recovery Time   : 3.42s
      ├─ Rescheduling Time: 0.25s
      └─ Readiness Time   : 3.17s
HEALTH CHECKS
  PASS   gpu://ocp-worker (HTTP 1, 19.66s)
ALERTS & SLOs
  SLOs Evaluated  : 0
  SLOs Passed     : 0 / 0
  SLOs Failed     : 0
  Critical Alerts : None
RESILIENCY SCORE
  Overall Score                : 0 / 100  ❌
================================================================================
2026-08-17 14:17:59,517 [INFO] api_url not set, skipping telemetry upload.
2026-08-17 14:17:59,518 [INFO] Kraken UUID for the run: c3cb7506-1375-4c93-a1ec-5d3f1c9c9c86. Report generated at kraken.report.
2026-08-17 14:17:59,519 [INFO] Successfully finished running Kraken, exiting
```

</details>

## Test plan

- [x] Unit tests pass — `python -m unittest tests.test_gpu_device_scenario_plugin tests.test_gpu_health_check_plugin` (38 tests)
- [x] Scenario + health check auto-discovered by their factories
- [x] Live cluster test on OpenShift 4.22 with NVIDIA A30 GPU — scenario PASS, device plugin recovered ~3s, allocatable restored, nvidia-smi healthy pre/post
- [x] Health check validated live — reports continuous availability during a normal bounce, and captures a 22.23s downtime window during a prolonged outage

**Related feature/docs**: https://github.com/krkn-chaos/website/pull/619