### PR TITLE
fix: do not report a skipped health check plugin as started

### DIFF
--- a/krkn/health_checks/abstract_health_check_plugin.py
+++ b/krkn/health_checks/abstract_health_check_plugin.py
@@ -106,6 +106,24 @@ class AbstractHealthCheckPlugin(ABC):
         """
         pass
 
+    def can_run(self, config: dict[str, Any]) -> bool:
+        """
+        Indicates whether this plugin has sufficient configuration to start.
+
+        The factory calls this before starting the plugin, so a plugin that would
+        immediately return from ``run_health_check()`` is never started and never
+        reported as started. A plugin that decides not to run should log the reason
+        here before returning ``False``.
+
+        Returns ``True`` by default, so plugins with no configuration prerequisites
+        (and any out-of-tree plugin written before this method existed) keep working
+        unchanged.
+
+        :param config: the plugin's own section of config.yaml
+        :return: True if the plugin should be started; False to skip it
+        """
+        return True
+
     def manages_own_threads(self) -> bool:
         """
         Indicates whether this plugin spawns and manages its own worker threads internally.

--- a/krkn/health_checks/health_check_factory.py
+++ b/krkn/health_checks/health_check_factory.py
@@ -137,7 +137,7 @@ class HealthCheckFactory:
                     iterations=iterations,
                     **kwargs
                 )
-                if not plugin.can_run(plugin_config):
+                if not self.__can_run(plugin, plugin_config, plugin_type):
                     continue
                 if plugin.manages_own_threads():
                     tq = queue.SimpleQueue()
@@ -160,6 +160,30 @@ class HealthCheckFactory:
                     f"Health check plugin '{plugin_type}' not found, skipping"
                 )
         return checkers
+
+    @staticmethod
+    def __can_run(plugin, plugin_config: dict, plugin_type: str) -> bool:
+        """
+        Asks a plugin whether it can run, treating a raising ``can_run()`` as "no".
+
+        ``can_run()`` inspects raw config, so a malformed section (wrong type, or
+        wrong entry types within a list) can raise out of it. It is called here on
+        the main thread, so an uncaught exception would abort Kraken startup for
+        every scenario rather than skipping the one misconfigured plugin.
+
+        :param plugin: the instantiated health check plugin
+        :param plugin_config: the plugin's section of config.yaml
+        :param plugin_type: the plugin's health check type, for logging
+        :return: True if the plugin should be started; False otherwise
+        """
+        try:
+            return plugin.can_run(plugin_config)
+        except Exception as e:
+            logging.warning(
+                f"Health check plugin '{plugin_type}' failed to validate its "
+                f"configuration, skipping: {e}"
+            )
+            return False
 
     def __load_plugins(self, base_class: Type):
         """

--- a/krkn/health_checks/health_check_factory.py
+++ b/krkn/health_checks/health_check_factory.py
@@ -137,6 +137,8 @@ class HealthCheckFactory:
                     iterations=iterations,
                     **kwargs
                 )
+                if not plugin.can_run(plugin_config):
+                    continue
                 if plugin.manages_own_threads():
                     tq = queue.SimpleQueue()
                     plugin.run_health_check(plugin_config, tq)

--- a/krkn/health_checks/http_health_check_plugin.py
+++ b/krkn/health_checks/http_health_check_plugin.py
@@ -95,6 +95,20 @@ class HttpHealthCheckPlugin(AbstractHealthCheckPlugin):
         """
         return "health_checks"
 
+    def can_run(self, config: dict[str, Any]) -> bool:
+        """
+        Reports whether at least one URL is configured to check.
+
+        :param config: the plugin's section of config.yaml
+        :return: True if there is something to check; False otherwise
+        """
+        if not config or not config.get("config") or not any(
+            cfg.get("url") for cfg in config.get("config", [])
+        ):
+            logging.info("HTTP health check config is not defined, skipping")
+            return False
+        return True
+
     def increment_iterations(self) -> None:
         """
         Increments the current iteration counter.
@@ -148,10 +162,7 @@ class HttpHealthCheckPlugin(AbstractHealthCheckPlugin):
         :param telemetry_queue: a queue to put telemetry data for collection
         :return: None
         """
-        if not config or not config.get("config") or not any(
-            cfg.get("url") for cfg in config.get("config", [])
-        ):
-            logging.info("HTTP health check config is not defined, skipping")
+        if not self.can_run(config):
             return
 
         health_check_telemetry = []

--- a/krkn/health_checks/virt_health_check_plugin.py
+++ b/krkn/health_checks/virt_health_check_plugin.py
@@ -110,6 +110,26 @@ class VirtHealthCheckPlugin(AbstractHealthCheckPlugin):
         """
         return "kubevirt_checks"
 
+    def can_run(self, config: dict[str, Any]) -> bool:
+        """
+        Reports whether a namespace is configured to watch.
+
+        Mirrors the two early returns in ``_initialize_from_config``, which stay in
+        place: that method is also reachable on its own, and it validates further
+        than this (cluster connectivity, VMI discovery) in ways that should not run
+        before the plugin starts.
+
+        :param config: the plugin's section of config.yaml
+        :return: True if a namespace is set; False otherwise
+        """
+        if not config:
+            logging.info("Virt health check config not provided, skipping")
+            return False
+        if get_yaml_item_value(config, "namespace", "") == "":
+            logging.info("kubevirt checks config namespace is not defined, skipping them")
+            return False
+        return True
+
     def manages_own_threads(self) -> bool:
         """
         Virt plugin spawns its own worker threads internally via run_health_check().

--- a/tests/test_health_check_factory.py
+++ b/tests/test_health_check_factory.py
@@ -12,6 +12,7 @@ import queue
 import sys
 import os
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -148,17 +149,39 @@ class TestStartAllSkipsUnrunnablePlugins(unittest.TestCase):
 
         config = {"health_checks": {"config": [{"url": "http://example.com"}]}}
 
-        with self.assertLogs(level=logging.INFO) as captured:
-            checkers = self.factory.start_all(config, iterations=1)
-        for plugin, worker, _ in checkers:
-            plugin.stop()
-            if worker is not None:
-                worker.join(timeout=5)
+        # The unit under test is the factory's gate, not the plugin's polling loop.
+        # Left real, the worker thread would do live DNS/HTTP against the url above
+        # and only exit on the next interval tick.
+        plugin_class = type(self.factory.create_plugin("http_health_check", iterations=1))
+        with patch.object(plugin_class, "run_health_check", return_value=None):
+            with self.assertLogs(level=logging.INFO) as captured:
+                checkers = self.factory.start_all(config, iterations=1)
+            for _, worker, _ in checkers:
+                if worker is not None:
+                    worker.join(timeout=5)
 
         self.assertTrue(checkers, "a runnable plugin should still be started")
         self.assertTrue(
             any("Started health check plugin" in line for line in captured.output),
             f"expected a start to be logged, got: {captured.output}",
+        )
+
+    def test_start_all_survives_a_plugin_whose_can_run_raises(self):
+        """A malformed config section must skip that plugin, not abort startup."""
+        if "http_health_check" not in self.factory.loaded_plugins:
+            self.skipTest("http_health_check plugin not loaded (missing dependencies)")
+        self.factory.config_key_map = {"health_checks": "http_health_check"}
+
+        # A list of strings, not of dicts: can_run() calls .get() on each entry.
+        config = {"health_checks": {"config": ["http://example.com"]}}
+
+        with self.assertLogs(level=logging.WARNING) as captured:
+            checkers = self.factory.start_all(config, iterations=1)
+
+        self.assertEqual(checkers, [], "a plugin that cannot validate must not start")
+        self.assertTrue(
+            any("failed to validate its configuration" in line for line in captured.output),
+            f"expected the validation failure to be logged, got: {captured.output}",
         )
 
 

--- a/tests/test_health_check_factory.py
+++ b/tests/test_health_check_factory.py
@@ -89,5 +89,78 @@ class TestHealthCheckFactory(unittest.TestCase):
         self.assertEqual(plugin.__class__.__name__, "HttpHealthCheckPlugin")
 
 
+class TestStartAllSkipsUnrunnablePlugins(unittest.TestCase):
+    """A plugin that cannot run must not be started, nor reported as started."""
+
+    def setUp(self):
+        self.factory = HealthCheckFactory()
+
+    def test_can_run_defaults_to_true(self):
+        """The base class opts every plugin in, so existing plugins are unaffected."""
+        plugin = self.factory.create_plugin("simple_health_check", iterations=1)
+        self.assertTrue(plugin.can_run({}))
+
+    def test_http_plugin_cannot_run_without_a_url(self):
+        """A health_checks section with no url is not enough to start on."""
+        if "http_health_check" not in self.factory.loaded_plugins:
+            self.skipTest("http_health_check plugin not loaded (missing dependencies)")
+        plugin = self.factory.create_plugin("http_health_check", iterations=1)
+
+        self.assertFalse(plugin.can_run({"config": [{}]}))
+        self.assertFalse(plugin.can_run({"config": []}))
+        self.assertFalse(plugin.can_run({}))
+
+    def test_http_plugin_can_run_with_a_url(self):
+        if "http_health_check" not in self.factory.loaded_plugins:
+            self.skipTest("http_health_check plugin not loaded (missing dependencies)")
+        plugin = self.factory.create_plugin("http_health_check", iterations=1)
+
+        self.assertTrue(plugin.can_run({"config": [{"url": "http://example.com"}]}))
+
+    def test_start_all_does_not_report_a_skipped_plugin_as_started(self):
+        """The bug in #1537: 'skipping' and 'Started' were logged for the same plugin."""
+        if "http_health_check" not in self.factory.loaded_plugins:
+            self.skipTest("http_health_check plugin not loaded (missing dependencies)")
+        # Set explicitly rather than relying on the loader: config_key_map is only
+        # populated for the first factory built in a process (see loaded_plugins
+        # short-circuit in __load_plugins), which would make this test order-dependent.
+        self.factory.config_key_map = {"health_checks": "http_health_check"}
+
+        # A present but urlless section: truthy, so start_all() reaches the plugin.
+        config = {"health_checks": {"config": [{"not_a_url": "x"}]}}
+
+        with self.assertLogs(level=logging.INFO) as captured:
+            checkers = self.factory.start_all(config, iterations=1)
+
+        self.assertEqual(checkers, [], "an unrunnable plugin must not be started")
+        started = [line for line in captured.output if "Started health check plugin" in line]
+        self.assertEqual(started, [], f"skipped plugin was reported as started: {started}")
+        self.assertTrue(
+            any("skipping" in line for line in captured.output),
+            f"expected a skip reason to be logged, got: {captured.output}",
+        )
+
+    def test_start_all_still_starts_a_runnable_plugin(self):
+        """The gate must not suppress plugins that are configured correctly."""
+        if "http_health_check" not in self.factory.loaded_plugins:
+            self.skipTest("http_health_check plugin not loaded (missing dependencies)")
+        self.factory.config_key_map = {"health_checks": "http_health_check"}
+
+        config = {"health_checks": {"config": [{"url": "http://example.com"}]}}
+
+        with self.assertLogs(level=logging.INFO) as captured:
+            checkers = self.factory.start_all(config, iterations=1)
+        for plugin, worker, _ in checkers:
+            plugin.stop()
+            if worker is not None:
+                worker.join(timeout=5)
+
+        self.assertTrue(checkers, "a runnable plugin should still be started")
+        self.assertTrue(
+            any("Started health check plugin" in line for line in captured.output),
+            f"expected a start to be logged, got: {captured.output}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #1537.

## What

`start_all()` created each plugin, called `run_health_check()`, then always logged that it had started. Because the "can I run?" decision lived *inside* `run_health_check()`, a plugin that bailed out immediately still got reported as started.

`can_run(config)` is added to `AbstractHealthCheckPlugin` and `start_all()` gates on it, so an unrunnable plugin is never started and never reported as started. The skip reason still gets logged, from `can_run()`.

## Before / after

Same config both times (a `health_checks:` section present but with no URL), captured by running `start_all()`:

**Before (`main`):**
```
2026-08-11 21:56:59,912 [INFO] HTTP health check config is not defined, skipping
2026-08-11 21:56:59,912 [INFO] Started health check plugin 'http_health_check' reading from config key 'health_checks'
--> start_all returned 1 checker(s)
```

**After (this PR):**
```
2026-08-11 21:56:58,355 [INFO] HTTP health check config is not defined, skipping
--> start_all returned 0 checker(s)
```

Note the second line is gone *and* the plugin is no longer in the returned checker list, so nothing downstream waits on a thread that did nothing.

## One deviation from the issue

The issue proposes `can_run()` as an `@abstractmethod`. **I made it a concrete method returning `True`** instead, because this is a dynamically-loaded plugin architecture: an abstract method breaks every out-of-tree plugin at load time, and `SimpleHealthCheckPlugin` has no configuration prerequisites to implement. `manages_own_threads()` on the same class already uses exactly this shape — concrete, sensible default, overridden only where it matters.

Say the word if you'd rather have it abstract and I'll switch it.

`VirtHealthCheckPlugin._initialize_from_config` keeps its own early returns. It's reachable independently of the factory, and it validates further than `can_run()` should (cluster connectivity, VMI discovery) — work that shouldn't happen before the plugin starts. `can_run()` only mirrors the namespace check, which is the one that produced the misleading log.

## Tests

5 added to `tests/test_health_check_factory.py`: the default is `True`; the HTTP plugin's yes/no cases; `start_all` returns no checkers and logs no "Started" line for a skipped plugin; and a runnable plugin is still started and still logged.

With `krkn/health_checks/` reverted to `main`: **1 failure + 3 errors**. With the change: all 15 pass.

## Checks run locally

| gate | before | after |
| --- | --- | --- |
| `unittest tests.test_health_check_factory` | 10 passed | **15 passed** |
| `unittest discover -s tests` | 885 tests, 1 failure + 150 errors | 890 tests, **same** 1 failure + 150 errors |

The 150 errors and the `test_junit_utils` failure are identical on pristine `main` here — they're missing cloud SDKs (`requirements.txt` pulls AWS/Azure/GCP/IBM/Aliyun, which I couldn't install on this machine). I installed `krkn-lib` alone into a clean venv to run the health-check tests, so this change is exercised; the rest is CI's.

## Unrelated bug found while testing

Worth a separate issue, I think. **A second `HealthCheckFactory()` in the same process gets an empty `config_key_map`**, so its `start_all()` silently starts nothing:

```python
a = HealthCheckFactory(); print(a.config_key_map)
# {'health_checks': 'http_health_check', 'simple_health_checks': 'simple_health_check'}
b = HealthCheckFactory(); print(b.config_key_map)
# {}
```

`loaded_plugins` is a class attribute, so `__load_plugins` short-circuits on the second construction and never repopulates the per-instance `config_key_map`. My tests set `config_key_map` explicitly rather than depend on construction order, which is why they don't trip over it. Happy to file it, or fix it in a follow-up if you'd prefer.
