### PR TITLE
align krknctl-input descriptions with the published docs

### DIFF
--- a/containers/krknctl-input.json
+++ b/containers/krknctl-input.json
@@ -107,7 +107,7 @@
   {
     "name": "generate-pdf-report",
     "short_description": "Generate PDF report",
-    "description": "Generate a PDF summary report after the chaos run",
+    "description": "Generates a PDF report summarizing the chaos run results at the end of each scenario",
     "variable": "GENERATE_PDF_REPORT",
     "type": "enum",
     "allowed_values": "True,False",
@@ -446,7 +446,7 @@
   {
     "name": "telemetry-archive-size",
     "short_description": "Telemetry archive size",
-    "description": "Maximum size for telemetry archives",
+    "description": "Maximum size for telemetry archives in KB",
     "variable": "TELEMETRY_ARCHIVE_SIZE",
     "type": "number",
     "default": "1000",
@@ -506,7 +506,7 @@
   {
     "name": "health-check-interval",
     "short_description": "Heath check interval",
-    "description": "How often to check the health check urls",
+    "description": "How often to check the health check urls (seconds)",
     "variable": "HEALTH_CHECK_INTERVAL",
     "type": "number",
     "default": "2",
@@ -576,7 +576,7 @@
   {
     "name": "kubevirt-check-interval",
     "short_description": "Kube Virt check interval",
-    "description": "How often to check the kube virt check Vms ssh status",
+    "description": "How often to check the KubeVirt VMs SSH status (seconds)",
     "variable": "KUBE_VIRT_CHECK_INTERVAL",
     "type": "number",
     "default": "2",
@@ -618,7 +618,7 @@
   {
     "name": "kubevirt-disconnected",
     "short_description": "KubeVirt checks in disconnected mode",
-    "description": "KubeVirt checks in disconnected mode, bypassing the clusters Api",
+    "description": "KubeVirt checks in disconnected mode, bypassing the cluster's API",
     "variable": "KUBE_VIRT_DISCONNECTED",
     "type": "enum",
     "allowed_values": "True,False,true,false",
@@ -630,7 +630,7 @@
   {
     "name": "kubevirt-ssh-node",
     "short_description": "KubeVirt node to ssh from",
-    "description": "KubeVirt node to ssh from, should be available whole chaos run",
+    "description": "KubeVirt backup node to SSH into when checking VMI IP address status",
     "variable": "KUBE_VIRT_SSH_NODE",
     "type": "string",
     "default": "",
@@ -687,7 +687,7 @@
   {
     "name": "disable-resiliency-score",
     "short_description": "Disable resiliency score calculation",
-    "description": "Disable resiliency score calculation",
+    "description": "Disables resiliency score calculation entirely",
     "variable": "DISABLE_RESILIENCY_SCORE",
     "type": "boolean",
     "required": "false",
@@ -696,7 +696,7 @@
   {
     "name": "resiliency-file",
     "short_description": "Resiliency Score metrics file",
-    "description": "Custom Resiliency score file",
+    "description": "Path to a YAML file containing SLO definitions for resiliency scoring, defaults to the alerts profile or config/alerts.yaml",
     "variable": "RESILIENCY_FILE",
     "type": "file",
     "required": "false",


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

Eight `description` values in `containers/krknctl-input.json` where the published page explains the flag better than `krknctl run <scenario> --help` does. Table of all eight in #1550.

Mostly units: three now say seconds or KB where the source said nothing. Descriptions only, no `name`, `variable`, `default` or `type` changes.

## Related Tickets & Documents

- Related Issue #: #1550
- Closes #1550

# Documentation

- [x] **Is documentation needed for this update?**

The wording comes from the published page, so the page already says this. 
However under krkn-chaos/website#320 the page is generated from this file, which is why the source needs to catch up before that lands.

# Checklist before requesting a review

- [ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

Not a core feature, no code changed.

*REQUIRED*:
Description of combination of tests performed and output of run

No krkn code path reads this file, so `run_kraken.py` exercises nothing here. 
It goes into the `krknctl.input_fields.global` LABEL via `containers/compile_dockerfile.sh` and is parsed by krknctl.

Checked each of the eight against its current value before writing, so nothing was overwritten blindly. 
Also the diff is exactly 8 lines, each of them being a a `description`. 

