### PR TITLE
fix: skip unnecessary wait_duration sleep after the last scenario

### DIFF
--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -87,8 +87,7 @@ class AbstractScenarioPlugin(ABC):
         failed_scenarios = []
         wait_duration = krkn_config["tunings"]["wait_duration"]
         events_backup = krkn_config["telemetry"]["events_backup"]
-        total_scenarios = len(scenarios_list)
-        for i, scenario_config in enumerate(scenarios_list):
+        for scenario_config in scenarios_list:
             if isinstance(scenario_config, list):
                 logging.error(
                     "post scenarios have been deprecated, please "
@@ -124,7 +123,6 @@ class AbstractScenarioPlugin(ABC):
                     logging.info(
                         f"Running {self.__class__.__name__}: {self.get_scenario_types()} -> {scenario_config}"
                     )
-                    # pass all the parameters by kwargs to make `set_rollback_context_decorator` get the `run_uuid` and `scenario_type`
                     return_value = self.run(
                         run_uuid=run_uuid,
                         scenario=scenario_config,
@@ -143,11 +141,16 @@ class AbstractScenarioPlugin(ABC):
                     run_uuid, scenario_telemetry.scenario_type
                 )
             else:
-                # execute rollback files based on the return value
                 execute_rollback_version_files(
                     telemetry, run_uuid, scenario_telemetry.scenario_type
                 )
             scenario_telemetry.exit_status = return_value
+
+            logging.info(
+                f"waiting {wait_duration}s for cluster to stabilize "
+                f"before collecting metrics"
+            )
+            time.sleep(wait_duration)
             scenario_telemetry.end_timestamp = time.time()
             start_time = int(scenario_telemetry.start_timestamp)
             end_time = int(scenario_telemetry.end_timestamp)
@@ -183,11 +186,8 @@ class AbstractScenarioPlugin(ABC):
             if scenario_telemetry.exit_status != 0:
                 failed_scenarios.append(scenario_config)
             scenario_telemetries.append(scenario_telemetry)
-            cerberus.publish_kraken_status(start_time,end_time)
-            if i < total_scenarios - 1:
-                logging.info(f"waiting {wait_duration} before running the next scenario")
-                time.sleep(wait_duration)
-            
+            cerberus.publish_kraken_status(start_time, end_time)
+
         return failed_scenarios, scenario_telemetries
 
     

--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -87,7 +87,8 @@ class AbstractScenarioPlugin(ABC):
         failed_scenarios = []
         wait_duration = krkn_config["tunings"]["wait_duration"]
         events_backup = krkn_config["telemetry"]["events_backup"]
-        for scenario_config in scenarios_list:
+        total_scenarios = len(scenarios_list)
+        for i, scenario_config in enumerate(scenarios_list):
             if isinstance(scenario_config, list):
                 logging.error(
                     "post scenarios have been deprecated, please "
@@ -183,8 +184,9 @@ class AbstractScenarioPlugin(ABC):
                 failed_scenarios.append(scenario_config)
             scenario_telemetries.append(scenario_telemetry)
             cerberus.publish_kraken_status(start_time,end_time)
-            logging.info(f"waiting {wait_duration} before running the next scenario")
-            time.sleep(wait_duration)
+            if i < total_scenarios - 1:
+                logging.info(f"waiting {wait_duration} before running the next scenario")
+                time.sleep(wait_duration)
             
         return failed_scenarios, scenario_telemetries
 

--- a/tests/test_abstract_scenario_plugin_cerberus.py
+++ b/tests/test_abstract_scenario_plugin_cerberus.py
@@ -354,6 +354,82 @@ class TestAbstractScenarioPluginCerberusIntegration(unittest.TestCase):
 
 
     @patch('krkn.scenario_plugins.abstract_scenario_plugin.cerberus.publish_kraken_status')
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.cleanup_rollback_version_files')
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.utils.collect_and_put_ocp_logs')
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.signal_handler.signal_context')
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.os.path.exists', return_value=True)
+    @patch('time.sleep')
+    @patch('time.time')
+    def test_end_timestamp_includes_wait_duration_soak(
+        self, mock_time, mock_sleep, mock_exists, mock_signal_ctx, mock_collect_logs,
+        mock_cleanup, mock_cerberus_publish
+    ):
+        """Test that end_timestamp is captured AFTER wait_duration sleep (soak window)"""
+        mock_signal_ctx.return_value.__enter__ = Mock()
+        mock_signal_ctx.return_value.__exit__ = Mock(return_value=False)
+
+        # Simulate: start=1000, scenario ends, sleep 60s, end_timestamp=1060
+        time_values = iter([1000.0, 1060.0])
+        mock_time.side_effect = lambda: next(time_values)
+
+        krkn_config = {
+            "tunings": {"wait_duration": 60},
+            "telemetry": {"events_backup": False}
+        }
+
+        scenarios_list = ["scenario1.yaml"]
+
+        failed_scenarios, telemetries = self.plugin.run_scenarios(
+            "test-uuid",
+            scenarios_list,
+            krkn_config,
+            self.mock_telemetry
+        )
+
+        # sleep should be called with the configured wait_duration
+        mock_sleep.assert_called_once_with(60)
+        # end_timestamp should reflect post-soak time (1060), not pre-soak
+        self.assertEqual(telemetries[0].start_timestamp, 1000.0)
+        self.assertEqual(telemetries[0].end_timestamp, 1060.0)
+        # SLO window should span the full 60s soak period
+        call_args = mock_cerberus_publish.call_args[0]
+        self.assertEqual(call_args[0], 1000)
+        self.assertEqual(call_args[1], 1060)
+
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.cerberus.publish_kraken_status')
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.cleanup_rollback_version_files')
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.utils.collect_and_put_ocp_logs')
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.signal_handler.signal_context')
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.os.path.exists', return_value=True)
+    @patch('time.sleep')
+    def test_wait_duration_runs_for_every_scenario_including_last(
+        self, mock_sleep, mock_exists, mock_signal_ctx, mock_collect_logs,
+        mock_cleanup, mock_cerberus_publish
+    ):
+        """Test that wait_duration sleep runs for ALL scenarios (soak window, not just inter-scenario delay)"""
+        mock_signal_ctx.return_value.__enter__ = Mock()
+        mock_signal_ctx.return_value.__exit__ = Mock(return_value=False)
+
+        krkn_config = {
+            "tunings": {"wait_duration": 30},
+            "telemetry": {"events_backup": False}
+        }
+
+        scenarios_list = ["scenario1.yaml", "scenario2.yaml", "scenario3.yaml"]
+
+        self.plugin.run_scenarios(
+            "test-uuid",
+            scenarios_list,
+            krkn_config,
+            self.mock_telemetry
+        )
+
+        # sleep should be called once per scenario (including the last)
+        self.assertEqual(mock_sleep.call_count, 3)
+        for call in mock_sleep.call_args_list:
+            self.assertEqual(call[0][0], 30)
+
+    @patch('krkn.scenario_plugins.abstract_scenario_plugin.cerberus.publish_kraken_status')
     @patch('krkn.scenario_plugins.abstract_scenario_plugin.os.path.exists', return_value=False)
     @patch('time.sleep')
     def test_missing_scenario_file_logs_error_and_marks_failed(


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization

# Description  
The `wait_duration` sleep in `abstract_scenario_plugin.py` was running unconditionally after every scenario — including the final (or only) one. The log message itself says *"waiting X before running the next scenario"*, but when there is no next scenario, the sleep serves no purpose.

This change wraps the sleep in a simple index check so it only runs when there are more scenarios remaining in the list. For single-scenario runs (the most common case in CI and krknctl), this eliminates a wasted 60-second delay (default `wait_duration`).

## Related Tickets & Documents

- Related Issue #: https://github.com/krkn-chaos/krkn/issues/1556
- Closes #: https://github.com/krkn-chaos/krkn/issues/1556

# Documentation  
- [ ] **Is documentation needed for this update?**

No documentation changes needed — this is a behavior fix with no config or API changes.

# Checklist before requesting a review
- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*Unit tests:*

```bash
python -m unittest tests/test_abstract_scenario_plugin_cerberus.py tests/test_failed_scenarios_accumulation.py -v
...
test_cerberus_called_after_exception_in_run ... ok
test_cerberus_called_with_events_backup_enabled ... ok
test_cerberus_not_called_for_deprecated_post_scenarios ... ok
test_cerberus_publish_called_after_failed_scenario ... ok
test_cerberus_publish_called_after_successful_scenario ... ok
test_cerberus_publish_called_for_mixed_success_and_failure ... ok
test_cerberus_publish_called_for_multiple_scenarios ... ok
test_cerberus_publish_exception_does_not_break_flow ... ok
test_cerberus_publish_timing ... ok
test_missing_scenario_file_logs_error_and_marks_failed ... ok
test_missing_scenario_file_skipped_others_continue ... ok
test_failures_from_earlier_scenarios_are_preserved ... ok
test_failures_from_multiple_scenarios_are_accumulated ... ok
test_last_scenario_failure_is_not_only_one_kept ... ok
test_no_failures_returns_empty_list ... ok

----------------------------------------------------------------------
Ran 15 tests in 0.039s

OK
```

*Functional test (single graceful pod-kill scenario on OpenShift 4.21.2):*

```bash
python run_kraken.py --config example/pod-kill-test/config-graceful.yaml
...
KRKN RUN SUMMARY
================================================================================
Run UUID : d1636a7f-ce7c-4fe5-bd23-46bf56777fbe
Status   : PASS
Cluster  : 4.21.2 (GCP, self-managed)
KEY METRICS
  [1] Scenario: example/pod-kill-test/pod_scenario_graceful.yml
    Exit Status           : PASS (0)
    Pods Recovered        : 1
    Pods Unrecovered      : 0
    Total Recovery Time   : 2.39s
RESILIENCY SCORE
  Overall Score           : 100 / 100  ✅
================================================================================
```

Confirmed: no "waiting X before running the next scenario" message appears in the output for single-scenario runs.