### PR TITLE
fix: remove redundant find_kraken_node() call that adds ~7s to startup

### DIFF
--- a/run_kraken.py
+++ b/run_kraken.py
@@ -270,9 +270,6 @@ def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
             distribution = "openshift"
         logging.info("Detected distribution %s" % (distribution))
 
-        # find node kraken might be running on
-        kubecli.find_kraken_node()
-
         # Set up kraken url to track signal
         if not 0 <= int(port) <= 65535:
             logging.error("%s isn't a valid port number, please check" % (port))


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization

# Description  
Remove the redundant `kubecli.find_kraken_node()` call on line 274 of `run_kraken.py` that adds **~7 seconds** to every krkn startup.

`find_kraken_node()` internally calls `get_all_pods()`, which fetches **every pod across all namespaces** via `list_pod_for_all_namespaces()` just to search for one named `kraken-deployment`. However:

1. **The return value is discarded** — it is not assigned to any variable.
2. **The method has no side effects** — it does not set any instance variable or global state.
3. **It is called again later anyway** — `list_killable_nodes()` in krkn-lib calls `find_kraken_node()` internally when node scenarios actually run.

### Observed impact

From a real run on an OpenShift 4.21.2 cluster:

```
11:57:08,188 [INFO] Detected distribution openshift
                        ← ~7 seconds spent in find_kraken_node() →
11:57:14,972 [INFO] Fetching cluster info
```

This delay occurs on every single krkn invocation, regardless of whether a node scenario is configured.

## Related Tickets & Documents

- Related Issue #: https://github.com/krkn-chaos/krkn/issues/1566
- Closes #: 1566

# Documentation  
- [ ] **Is documentation needed for this update?**

No documentation changes needed — this is a pure dead-code removal.

## Related Documentation PR (if applicable)  
N/A

# Checklist before requesting a review
[x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [x] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
This is a 3-line deletion of dead code (comment + method call + blank line). No new logic is introduced, so no new tests are needed. The existing `list_killable_nodes()` behavior in krkn-lib is unchanged — it continues to call `find_kraken_node()` internally when node scenarios run.

```diff
-        # find node kraken might be running on
-        kubecli.find_kraken_node()
-
         # Set up kraken url to track signal
```

Made with [Cursor](https://cursor.com)