### PR TITLE
fix: serialize node network chaos tests to prevent xdist race condition

### DIFF
--- a/.github/workflows/tests_v2.yml
+++ b/.github/workflows/tests_v2.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run tests_v2
         run: |
           KRKN_TEST_COVERAGE=1 python -m pytest CI/tests_v2/ -v --timeout=300 --reruns=1 --reruns-delay=5 \
-            --html=CI/tests_v2/report.html -n auto --junitxml=CI/tests_v2/results.xml
+            --html=CI/tests_v2/report.html -n auto --dist loadgroup --junitxml=CI/tests_v2/results.xml
 
       - name: Upload tests_v2 artifacts
         if: always()

--- a/CI/tests_v2/Makefile
+++ b/CI/tests_v2/Makefile
@@ -75,10 +75,10 @@ preflight:
 
 test: preflight
 	cd $(REPO_ROOT) && KRKN_TEST_COVERAGE=1 $(PYTHON) -m pytest $(TESTS_DIR)/ -v --timeout=300 --reruns=2 --reruns-delay=10 \
-		--html=$(TESTS_DIR)/report.html -n auto --junitxml=$(TESTS_DIR)/results.xml
+		--html=$(TESTS_DIR)/report.html -n auto --dist loadgroup --junitxml=$(TESTS_DIR)/results.xml
 
 test-fast: preflight
-	cd $(REPO_ROOT) && $(PYTHON) -m pytest $(TESTS_DIR)/ -v -p no:rerunfailures -n auto --timeout=120
+	cd $(REPO_ROOT) && $(PYTHON) -m pytest $(TESTS_DIR)/ -v -p no:rerunfailures -n auto --dist loadgroup --timeout=120
 
 test-debug: preflight
 	cd $(REPO_ROOT) && $(PYTHON) -m pytest $(TESTS_DIR)/ -v -s -p no:rerunfailures --timeout=300 \

--- a/CI/tests_v2/README.md
+++ b/CI/tests_v2/README.md
@@ -89,7 +89,7 @@ pytest CI/tests_v2/ -v --timeout=300 --reruns=2 --reruns-delay=10 --html=CI/test
 ### Run in parallel (faster suite)
 
 ```bash
-pytest CI/tests_v2/ -v -n 4 --timeout=300
+pytest CI/tests_v2/ -v -n 4 --dist loadgroup --timeout=300
 ```
 
 Ephemeral namespaces make tests parallel-safe; use `-n` with the number of workers (e.g. 4).

--- a/CI/tests_v2/pytest.ini
+++ b/CI/tests_v2/pytest.ini
@@ -4,7 +4,7 @@ python_files = test_*.py
 python_functions = test_*
 # Install CI/tests_v2/requirements.txt for --timeout, --reruns, --reruns-delay.
 # Example full run: pytest CI/tests_v2/ -v --timeout=300 --reruns=2 --reruns-delay=10 --html=... --junitxml=...
-addopts = -v
+addopts = -v --dist loadgroup
 markers =
     functional: marks a test as a functional test (deselect with '-m "not functional"')
     pod_disruption: marks a test as a pod disruption scenario test
@@ -19,4 +19,5 @@ markers =
     namespace_deletion: marks a test as a namespace deletion (service_disruption) scenario test
     no_workload: skip workload deployment for this test (e.g. negative tests)
     order: set test order (pytest-order)
+    xdist_group: assign tests to a named xdist group so they run on the same worker (no parallel tc conflicts)
 junit_family = xunit2

--- a/CI/tests_v2/pytest.ini
+++ b/CI/tests_v2/pytest.ini
@@ -4,7 +4,7 @@ python_files = test_*.py
 python_functions = test_*
 # Install CI/tests_v2/requirements.txt for --timeout, --reruns, --reruns-delay.
 # Example full run: pytest CI/tests_v2/ -v --timeout=300 --reruns=2 --reruns-delay=10 --html=... --junitxml=...
-addopts = -v --dist loadgroup
+addopts = -v
 markers =
     functional: marks a test as a functional test (deselect with '-m "not functional"')
     pod_disruption: marks a test as a pod disruption scenario test

--- a/CI/tests_v2/scenarios/node_network_chaos/test_node_network_chaos.py
+++ b/CI/tests_v2/scenarios/node_network_chaos/test_node_network_chaos.py
@@ -40,6 +40,7 @@ TEST_DURATION = 30
 
 @pytest.mark.functional
 @pytest.mark.node_network_chaos
+@pytest.mark.xdist_group("node_network_chaos")
 class TestNodeNetworkChaos(BaseScenarioTest):
     """Node network chaos: packet loss, latency, bandwidth, direction, targeting, safety, cleanup."""
 


### PR DESCRIPTION
Node network chaos tests share mutable tc rules on the same KinD worker node. Under pytest-xdist parallel execution, concurrent tests interfere with each other's tc state causing intermittent marker assertion failures.

Pin all TestNodeNetworkChaos tests to a single xdist worker via xdist_group marker and switch dist mode to loadgroup so the marker is respected. Other test classes remain freely distributed.

# Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
<-- Provide a brief description of the changes made in this PR. -->  

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: 
- Closes #: 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python run_kraken.py
...
<---insert test results output--->
```

OR


```bash
python -m coverage run -a -m unittest discover -s tests -v
...
<---insert test results output--->
```
