### PR TITLE
fix(rollback): evaluate Version fields per-instance (fixes #1488)

### DIFF
--- a/krkn/rollback/config.py
+++ b/krkn/rollback/config.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, TYPE_CHECKING, Optional
 from typing_extensions import TypeAlias
 import time
@@ -31,13 +31,6 @@ RollbackCallable: TypeAlias = Callable[
     ["RollbackContent", "KrknTelemetryOpenshift"], None
 ]
 
-
-if TYPE_CHECKING:
-    from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
-
-RollbackCallable: TypeAlias = Callable[
-    ["RollbackContent", "KrknTelemetryOpenshift"], None
-]
 
 
 class SingletonMeta(type):
@@ -269,8 +262,8 @@ class RollbackConfig(metaclass=SingletonMeta):
 class Version:
     scenario_type: str
     rollback_context: RollbackContext
-    timestamp: int = time.time_ns()  # Get current timestamp in nanoseconds
-    hash_suffix: str = get_random_string(8)  # Generate a random string of 8 characters
+    timestamp: int = field(default_factory=time.time_ns)  # Get current timestamp in nanoseconds
+    hash_suffix: str = field(default_factory=lambda: get_random_string(8))  # Generate a random string of 8 characters
 
     @property
     def version_file_name(self) -> str:

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -397,3 +397,21 @@ class TestSecureTempDirectories:
         """When user provides an explicit path, no fallback is triggered."""
         explicit_path = "/some/user/chosen/path"
         assert explicit_path  # truthy, so no fallback
+
+import unittest
+
+class TestVersionDataclass(unittest.TestCase):
+    """Tests for the Version dataclass in rollback configuration."""
+
+    def test_version_uniqueness(self):
+        """Verify that Version instances evaluate dynamic fields per-instance."""
+        from krkn.rollback.config import Version, RollbackContext
+        import time
+        ctx = RollbackContext("test-uuid")
+        v1 = Version.new_version("test_scenario", ctx)
+        time.sleep(0.001)
+        v2 = Version.new_version("test_scenario", ctx)
+
+        self.assertNotEqual(v1.timestamp, v2.timestamp)
+        self.assertNotEqual(v1.hash_suffix, v2.hash_suffix)
+        self.assertNotEqual(v1.version_file_name, v2.version_file_name)

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -3,6 +3,8 @@ import logging
 import os
 import sys
 import tempfile
+import time
+import unittest
 import uuid
 import subprocess
 
@@ -11,7 +13,7 @@ from krkn_lib.ocp import KrknOpenshift
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
 from krkn_lib.models.telemetry import ScenarioTelemetry
 from krkn_lib.utils import SafeLogger
-from krkn.rollback.config import RollbackConfig
+from krkn.rollback.config import RollbackConfig, Version, RollbackContext
 
 sys.path.append(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -398,15 +400,12 @@ class TestSecureTempDirectories:
         explicit_path = "/some/user/chosen/path"
         assert explicit_path  # truthy, so no fallback
 
-import unittest
 
 class TestVersionDataclass(unittest.TestCase):
     """Tests for the Version dataclass in rollback configuration."""
 
     def test_version_uniqueness(self):
         """Verify that Version instances evaluate dynamic fields per-instance."""
-        from krkn.rollback.config import Version, RollbackContext
-        import time
         ctx = RollbackContext("test-uuid")
         v1 = Version.new_version("test_scenario", ctx)
         time.sleep(0.001)


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

## Description

This PR fixes the issue where the `timestamp` and `hash_suffix` fields in the `Version` dataclass (`krkn/rollback/config.py`) were evaluated exactly once at module import time. By wrapping these assignments in `dataclasses.field(default_factory=...)`, the rollback identifiers are now dynamically evaluated per instance. This prevents silent collisions and rollback overwrites when `Version.new_version()` is called multiple times concurrently (e.g., by the hogs scenario plugin).

## Related Tickets & Documents

- Closes #1488

## Documentation

- [ ] Is documentation needed for this update?

*(No documentation needed as this is an internal engine bug fix)*

## Related Documentation PR (if applicable)

N/A

## Checklist before requesting a review

- [x] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [x] I have performed a self-review of my code by running krkn and specific scenario
- [x] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED:*
Description of combination of tests performed and output of run

```text
python -m unittest discover -s tests -v

...
test_version_uniqueness (test_rollback.TestVersionDataclass.test_version_uniqueness) ... ok
...
Ran 79 tests in 8.423s

OK
