### PR TITLE
fix: reduce startup log noise and surface only relevant plugin mappings

### DIFF
--- a/run_kraken.py
+++ b/run_kraken.py
@@ -404,49 +404,63 @@ def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
         chaos_telemetry.tag = elastic_run_tag
         scenario_plugin_factory = ScenarioPluginFactory()
         health_check_factory = HealthCheckFactory()
-        classes_and_types: dict[str, list[str]] = {}
-        for loaded in scenario_plugin_factory.loaded_plugins.keys():
-            if (
-                    scenario_plugin_factory.loaded_plugins[loaded].__name__
-                    not in classes_and_types.keys()
-            ):
-                classes_and_types[
-                    scenario_plugin_factory.loaded_plugins[loaded].__name__
-                ] = []
-            classes_and_types[
-                scenario_plugin_factory.loaded_plugins[loaded].__name__
-            ].append(loaded)
+
+        # Determine which scenario types are configured for this run
+        configured_types: set[str] = set()
+        for scenario in chaos_scenarios:
+            if isinstance(scenario, dict):
+                configured_types.add(list(scenario.keys())[0])
+
+        # Log only the plugins that will actually execute (INFO)
         logging.info(
-            "📣 `ScenarioPluginFactory`: types from config.yaml mapped to respective classes for execution:"
+            f"📣 `ScenarioPluginFactory`: {len(scenario_plugin_factory.loaded_plugins)} scenario types loaded"
+            f" ({len(scenario_plugin_factory.failed_plugins)} failed)"
         )
-        for class_loaded in classes_and_types.keys():
-            if len(classes_and_types[class_loaded]) <= 1:
-                logging.info(
-                    f"  ✅ type: {classes_and_types[class_loaded][0]} ➡️ `{class_loaded}` "
-                )
-            else:
-                logging.info(
-                    f"  ✅ types: [{', '.join(classes_and_types[class_loaded])}] ➡️ `{class_loaded}` "
-                )
-        logging.info("\n")
+        if configured_types:
+            logging.info("Scenario plugins for this run:")
+            for stype in sorted(configured_types):
+                if stype in scenario_plugin_factory.loaded_plugins:
+                    cls_name = scenario_plugin_factory.loaded_plugins[stype].__name__
+                    logging.info(f"  ✅ {stype} ➡️ `{cls_name}`")
+                else:
+                    logging.warning(f"  ⚠️ {stype} ➡️ no matching plugin found")
+
+        # Full plugin registry at DEBUG for troubleshooting
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            classes_and_types: dict[str, list[str]] = {}
+            for loaded in scenario_plugin_factory.loaded_plugins.keys():
+                cls_name = scenario_plugin_factory.loaded_plugins[loaded].__name__
+                if cls_name not in classes_and_types:
+                    classes_and_types[cls_name] = []
+                classes_and_types[cls_name].append(loaded)
+            logging.debug("Full plugin registry:")
+            for class_loaded, types in classes_and_types.items():
+                if len(types) <= 1:
+                    logging.debug(f"  type: {types[0]} ➡️ `{class_loaded}`")
+                else:
+                    logging.debug(
+                        f"  types: [{', '.join(types)}] ➡️ `{class_loaded}`"
+                    )
+
         if len(scenario_plugin_factory.failed_plugins) > 0:
-            logging.info("Failed to load Scenario Plugins:\n")
             for failed in scenario_plugin_factory.failed_plugins:
                 module_name, class_name, error = failed
                 logging.error(f"⛔ Class: {class_name} Module: {module_name}")
-                logging.error(f"⚠️ {error}\n")
+                logging.error(f"⚠️ {error}")
 
-        # Log loaded health check plugins
+        # Log health check plugins
         logging.info(
-            "📣 `HealthCheckFactory`: Available health check plugins: "
-            f"{list(health_check_factory.loaded_plugins.keys())}"
+            f"📣 `HealthCheckFactory`: {len(health_check_factory.loaded_plugins)} health check plugins loaded"
+            f" ({len(health_check_factory.failed_plugins)} failed)"
+        )
+        logging.debug(
+            f"Available health check plugins: {list(health_check_factory.loaded_plugins.keys())}"
         )
         if len(health_check_factory.failed_plugins) > 0:
-            logging.info("Failed to load Health Check Plugins:\n")
             for failed in health_check_factory.failed_plugins:
                 module_name, class_name, error = failed
                 logging.error(f"⛔ Class: {class_name} Module: {module_name}")
-                logging.error(f"⚠️ {error}\n")
+                logging.error(f"⚠️ {error}")
 
         # Evaluate top-level triggers before starting health checks or chaos
         trigger_config = config.get("triggers")

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -405,25 +405,16 @@ def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
         scenario_plugin_factory = ScenarioPluginFactory()
         health_check_factory = HealthCheckFactory()
 
-        # Determine which scenario types are configured for this run
-        configured_types: set[str] = set()
-        for scenario in chaos_scenarios:
-            if isinstance(scenario, dict):
-                configured_types.add(list(scenario.keys())[0])
-
-        # Log only the plugins that will actually execute (INFO)
+        # Log loaded/failed plugin counts (INFO)
         logging.info(
             f"📣 `ScenarioPluginFactory`: {len(scenario_plugin_factory.loaded_plugins)} scenario types loaded"
             f" ({len(scenario_plugin_factory.failed_plugins)} failed)"
         )
-        if configured_types:
-            logging.info("Scenario plugins for this run:")
-            for stype in sorted(configured_types):
-                if stype in scenario_plugin_factory.loaded_plugins:
-                    cls_name = scenario_plugin_factory.loaded_plugins[stype].__name__
-                    logging.info(f"  ✅ {stype} ➡️ `{cls_name}`")
-                else:
-                    logging.warning(f"  ⚠️ {stype} ➡️ no matching plugin found")
+        if len(scenario_plugin_factory.failed_plugins) > 0:
+            for failed in scenario_plugin_factory.failed_plugins:
+                module_name, class_name, error = failed
+                logging.error(f"⛔ Class: {class_name} Module: {module_name}")
+                logging.error(f"⚠️ {error}")
 
         # Full plugin registry at DEBUG for troubleshooting
         if logging.getLogger().isEnabledFor(logging.DEBUG):
@@ -442,20 +433,16 @@ def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
                         f"  types: [{', '.join(types)}] ➡️ `{class_loaded}`"
                     )
 
-        if len(scenario_plugin_factory.failed_plugins) > 0:
-            for failed in scenario_plugin_factory.failed_plugins:
-                module_name, class_name, error = failed
-                logging.error(f"⛔ Class: {class_name} Module: {module_name}")
-                logging.error(f"⚠️ {error}")
-
         # Log health check plugins
         logging.info(
             f"📣 `HealthCheckFactory`: {len(health_check_factory.loaded_plugins)} health check plugins loaded"
             f" ({len(health_check_factory.failed_plugins)} failed)"
         )
-        logging.debug(
-            f"Available health check plugins: {list(health_check_factory.loaded_plugins.keys())}"
-        )
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            logging.debug(
+                "Available health check plugins: %s",
+                list(health_check_factory.loaded_plugins.keys()),
+            )
         if len(health_check_factory.failed_plugins) > 0:
             for failed in health_check_factory.failed_plugins:
                 module_name, class_name, error = failed
@@ -491,6 +478,20 @@ def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
             except ValueError as e:
                 logging.error("invalid trigger configuration: %s", e)
                 return 1
+
+        # Log run-specific plugin mappings (after triggers may have cleared chaos_scenarios)
+        configured_types: set[str] = set()
+        for scenario in chaos_scenarios:
+            if isinstance(scenario, dict):
+                configured_types.add(list(scenario.keys())[0])
+        if configured_types:
+            logging.info("Scenario plugins for this run:")
+            for stype in sorted(configured_types):
+                if stype in scenario_plugin_factory.loaded_plugins:
+                    cls_name = scenario_plugin_factory.loaded_plugins[stype].__name__
+                    logging.info(f"  ✅ {stype} ➡️ `{cls_name}`")
+                else:
+                    logging.warning(f"  ⚠️ {stype} ➡️ no matching plugin found")
 
         # Start all health check plugins discovered via config_key_map.
         # Returns list of (plugin, worker_thread, telemetry_queue);


### PR DESCRIPTION
# Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization

# Description

The startup logging in `run_kraken.py` dumped every loaded plugin class at INFO level regardless of whether it was used in the current run. With 20+ plugins loaded this added visual noise that obscured the information operators actually need.

Changes:
- **INFO now shows only what matters**: a one-line summary ("N scenario types loaded (M failed)") plus the specific scenario types configured for this run and their resolved plugin classes.
- **WARNING on misconfiguration**: if a scenario type in `config.yaml` doesn't match any loaded plugin, a `WARNING` is logged instead of silent skipping.
- **Full registry moved to DEBUG**: the complete plugin-to-class mapping is still available at `--log-level DEBUG` for troubleshooting, and the reverse-map build is guarded behind `isEnabledFor(DEBUG)` to skip unnecessary work at default log levels.
- **Bug fix**: the original code counted distinct plugin *classes*, not scenario types — now correctly reports `len(loaded_plugins)`.
- **Code cleanup**: removed trailing `\n` in log strings, removed bare `logging.info("\n")`, extracted `cls_name` variable to avoid repeated long dict lookups.

Same changes applied to `HealthCheckFactory` logging for consistency.

## Related Tickets & Documents

- Related Issue #: N/A (discovered during #1560 work)
- Closes #: N/A

# Documentation
- [ ] **Is documentation needed for this update?**

No — this is an internal logging improvement with no config or API changes.

## Related Documentation PR (if applicable)
N/A

# Checklist before requesting a review
[] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers.
- [x] I have performed a self-review of my code by running krkn and specific scenario
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

**Before** (INFO output on startup — every loaded plugin dumped regardless of config):
```
📣 `ScenarioPluginFactory`: types from config.yaml mapped to respective classes for execution:
  ✅ type: application_outages_scenarios ➡️ `ApplicationOutageScenarioPlugin` 
  ✅ type: container_scenarios ➡️ `ContainerScenarioPlugin` 
  ✅ type: hog_scenarios ➡️ `HogsScenarioPlugin` 
  ✅ type: http_load_scenarios ➡️ `HttpLoadScenarioPlugin` 
  ✅ type: kubevirt_vm_outage ➡️ `KubevirtVmOutageScenarioPlugin` 
  ✅ type: managedcluster_scenarios ➡️ `ManagedClusterScenarioPlugin` 
  ✅ types: [pod_network_scenarios, ingress_node_scenarios] ➡️ `NativeScenarioPlugin` 
  ✅ type: network_chaos_scenarios ➡️ `NetworkChaosScenarioPlugin` 
  ✅ type: network_chaos_ng_scenarios ➡️ `NetworkChaosNgScenarioPlugin` 
  ✅ type: node_scenarios ➡️ `NodeActionsScenarioPlugin` 
  ✅ type: pod_disruption_scenarios ➡️ `PodDisruptionScenarioPlugin` 
  ✅ type: pvc_scenarios ➡️ `PvcScenarioPlugin` 
  ✅ type: service_disruption_scenarios ➡️ `ServiceDisruptionScenarioPlugin` 
  ✅ type: service_hijacking_scenarios ➡️ `ServiceHijackingScenarioPlugin` 
  ✅ type: cluster_shut_down_scenarios ➡️ `ShutDownScenarioPlugin` 
  ✅ type: storage_throttle_scenarios ➡️ `StorageThrottleScenarioPlugin` 
  ✅ type: syn_flood_scenarios ➡️ `SynFloodScenarioPlugin` 
  ✅ type: time_scenarios ➡️ `TimeActionsScenarioPlugin` 
  ✅ type: zone_outages_scenarios ➡️ `ZoneOutageScenarioPlugin` 

📣 `HealthCheckFactory`: Available health check plugins: ['http_health_check', 'simple_health_check', 'test_health_check', 'virt_health_check', 'kubevirt_health_check', 'vm_health_check']
```

**After** (INFO output on startup — only what's relevant to this run):
```
📣 `ScenarioPluginFactory`: 20 scenario types loaded (0 failed)
Scenario plugins for this run:
  ✅ pod_disruption_scenarios ➡️ `PodDisruptionScenarioPlugin`
📣 `HealthCheckFactory`: 6 health check plugins loaded (0 failed)
```
Full registry still available at DEBUG level.

```bash
python run_kraken.py --config example/pod-kill-test/config-force.yaml
...
Overall Score: 100 / 100  ✅
```
