### PR TITLE
[DRAFT] fix: replace VMware vsphere-automation-sdk-python git dependency with…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,8 @@ service_identity==24.1.0
 PyYAML==6.0.1
 colorlog==6.10.1
 
-git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0
+vmware-vcenter==9.1.0.0  # Replaces git+vsphere-automation-sdk-python (pulled in proprietary NSX/VMC SDKs); MIT licensed
+vmware-vapi-runtime==9.1.0.0  # Apache-2.0 licensed
+vmware-vapi-common-client==9.1.0.0  # Apache-2.0 licensed
 cryptography>=46.0.7 # pinned to avoid multiple CVEs (subgroup attack, buffer overflow, DNS constraints)
 protobuf>=4.25.8 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
… PyPI packages

The git dependency's setup.py hardcoded the entire VMware SDK bundle, pulling in nsx-python-sdk, nsx-policy-python-sdk, nsx-vmc-*-sdk, and vapi-*/vmc-* packages licensed "Confidential and proprietary to VMware, Inc." — a CNCF license compliance violation. krkn only uses vCenter VM power APIs (no NSX/VMC), so swap to the equivalent PyPI-published packages (vmware-vcenter, vmware-vapi-runtime, vmware-vapi-common-client), all under MIT/Apache-2.0.

# Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
<-- Provide a brief description of the changes made in this PR. -->  

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: 
- Closes #: 

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

```bash
python run_kraken.py
...
<---insert test results output--->
```

OR


```bash
python -m coverage run -a -m unittest discover -s tests -v
...
<---insert test results output--->
```
