### PR TITLE
Scenario weight

### DIFF
--- a/config/config_weighted_scenarios.yaml
+++ b/config/config_weighted_scenarios.yaml
@@ -1,0 +1,71 @@
+kraken:
+    kubeconfig_path: ~/.kube/config
+    exit_on_failure: False
+    auto_rollback: True
+    publish_kraken_status: True
+    signal_state: RUN
+    signal_address: 0.0.0.0
+    port: 8081
+    report_formats:                                          # List of report formats to generate (pdf, html)
+        - pdf
+        - html
+    # Example: Weighted chaos scenarios for resiliency scoring
+    # Scenarios with higher weights contribute more to the final resiliency score
+    chaos_scenarios:
+       # Critical infrastructure scenarios - highest weight (3x)
+       - pod_disruption_scenarios:
+           weight: 3
+           files:
+             - scenarios/kind/pod_etcd.yml
+
+       # Important pod api server - high weight (2x)
+       - pod_disruption_scenarios:
+           weight: 2
+           files:
+             - scenarios/kind/pod_apiserver.yml
+
+       # Pod DNS failures - medium-high weight (1x)
+       - pod_disruption_scenarios:
+           - scenarios/kind/pod_dns.yml
+
+telemetry:
+    enabled: False                                         # enable/disables the telemetry collection feature
+    archive_path:                                          # local path where the archive files will be temporarily stored. If empty, a secure temp directory is created automatically.
+    events_backup: True                                    # enables/disables cluster events collection
+    logs_backup: False                                     # OCP-specific logs - disabled for KinD
+
+resiliency:
+  resiliency_run_mode: standalone  # Options: standalone, detailed, disabled
+  resiliency_file: config/alerts.yaml
+
+cerberus:
+    cerberus_enabled: False
+    cerberus_url:
+    check_application_routes: False
+
+performance_monitoring:
+    prometheus_url: ''
+    prometheus_bearer_token: ''
+    uuid:
+    enable_alerts: False
+    enable_metrics: False
+    alert_profile: config/alerts.yaml
+    metrics_profile: config/metrics-report.yaml
+    check_critical_alerts: False
+
+elastic:
+    enable_elastic: False
+    verify_certs: False
+    elastic_url: ""
+    elastic_port: 32766
+    username: "elastic"
+    password: "test"
+    metrics_index: "krkn-metrics"
+    alerts_index: "krkn-alerts"
+    telemetry_index: "krkn-telemetry"
+    run_tag: ""
+
+tunings:
+    wait_duration: 1
+    iterations: 1
+    daemon_mode: False

--- a/krkn/resiliency/resiliency.py
+++ b/krkn/resiliency/resiliency.py
@@ -113,11 +113,25 @@ class Resiliency:
             prom_cli: Initialized KrknPrometheus instance.
             start_time: Window start.
             end_time: Window end.
-            weight: Weight to use for the final weighted average calculation.
+            weight: Weight to use for the final weighted average calculation (must be > 0).
             health_check_results: Optional mapping of custom health-check name ➡ bool.
         Returns:
             The calculated integer resiliency score (0-100) for this scenario.
         """
+        # Validate weight
+        try:
+            weight = float(weight)
+            if weight <= 0:
+                logging.warning(
+                    f"Invalid weight {weight} for scenario '{scenario_name}' (must be > 0). Using default weight=1"
+                )
+                weight = 1
+        except (TypeError, ValueError):
+            logging.warning(
+                f"Invalid weight type '{weight}' for scenario '{scenario_name}' (must be numeric). Using default weight=1"
+            )
+            weight = 1
+
         slo_results = evaluate_slos(
             prom_cli=prom_cli,
             slo_list=self._slos,
@@ -158,9 +172,19 @@ class Resiliency:
 
         # ---------------- Weighted average (primary resiliency_score) ----------
         total_weight = sum(rep["weight"] for rep in self.scenario_reports)
-        resiliency_score = int(
-            sum(rep["score"] * rep["weight"] for rep in self.scenario_reports) / total_weight
-        )
+
+        if total_weight <= 0:
+            logging.error(
+                f"Invalid total weight {total_weight} (sum of all scenario weights). "
+                "All scenario weights must be positive numbers. Defaulting to simple average."
+            )
+            # Fallback to simple average if weights are invalid
+            resiliency_score = int(sum(rep["score"] for rep in self.scenario_reports) / len(self.scenario_reports))
+        else:
+            weighted_sum = sum(rep["score"] * rep["weight"] for rep in self.scenario_reports)
+            resiliency_score = int(weighted_sum / total_weight)
+
+        logging.info(f"Calculated weighted resiliency score: {resiliency_score}/100 (weighted average of {len(self.scenario_reports)} scenarios)")
 
         # ---------------- Overall SLO evaluation across full test window -----------------------------
         full_slo_results = evaluate_slos(

--- a/krkn/scenario_config_parser.py
+++ b/krkn/scenario_config_parser.py
@@ -1,0 +1,165 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+#!/usr/bin/env python
+"""
+Scenario configuration parser for weighted scenarios.
+
+This module provides utilities to parse scenario configurations from the chaos_scenarios
+config, supporting multiple formats:
+1. Explicit format: {scenario_type: str, weight: float, files: []}
+2. Weighted format: {scenario_type: {weight: float, files: []}}
+3. Old format: {scenario_type: [files]}
+"""
+
+import logging
+from typing import Tuple, List, Any
+
+
+def parse_scenario_config(scenario: dict) -> Tuple[str, List[str], float]:
+    """
+    Parse a scenario configuration entry and extract type, files, and weight.
+
+    Supports three config formats:
+    1. Explicit format: {scenario_type: str, weight: N, files: [...]}
+    2. Weighted format: {scenario_type: {weight: N, files: [...]}}
+    3. Old format: {scenario_type: [...]} (backward compatible)
+
+    Args:
+        scenario: Dictionary containing scenario configuration
+
+    Returns:
+        Tuple of (scenario_type, scenarios_list, scenario_weight)
+        - scenario_type: string identifier for the scenario plugin
+        - scenarios_list: list of scenario file paths
+        - scenario_weight: validated numeric weight (>0), defaults to 1
+
+    Examples:
+        >>> # Weighted format
+        >>> parse_scenario_config({
+        ...     "pod_disruption_scenarios": {
+        ...         "weight": 3,
+        ...         "files": ["scenarios/openshift/etcd.yml"]
+        ...     }
+        ... })
+        ('pod_disruption_scenarios', ['scenarios/openshift/etcd.yml'], 3.0)
+
+        >>> # Old format
+        >>> parse_scenario_config({
+        ...     "hog_scenarios": ["scenarios/kube/cpu-hog.yml"]
+        ... })
+        ('hog_scenarios', ['scenarios/kube/cpu-hog.yml'], 1.0)
+
+        >>> # Explicit format
+        >>> parse_scenario_config({
+        ...     "scenario_type": "service_disruption_scenarios",
+        ...     "weight": 2,
+        ...     "files": ["scenarios/openshift/regex_namespace.yaml"]
+        ... })
+        ('service_disruption_scenarios', ['scenarios/openshift/regex_namespace.yaml'], 2.0)
+    """
+    # Support multiple config formats:
+    # 1. New explicit format: {scenario_type: str, weight: float, files: []}
+    # 2. Extended old format: {scenario_type: {weight: float, files: []}}
+    # 3. Old format: {scenario_type: [files]}
+    if "scenario_type" in scenario and "files" in scenario:
+        # Format 1: New explicit format
+        scenario_type = scenario["scenario_type"]
+        scenarios_list = scenario["files"]
+        scenario_weight = scenario.get("weight", 1)
+    else:
+        # Formats 2 & 3: Old-style with scenario_type as key
+        scenario_type = list(scenario.keys())[0]
+        scenario_value = scenario[scenario_type]
+
+        if isinstance(scenario_value, dict):
+            # Format 2: Extended old format with weight and files
+            scenarios_list = scenario_value.get("files", [])
+            scenario_weight = scenario_value.get("weight", 1)
+        else:
+            # Format 3: Old format - simple list of files
+            scenarios_list = scenario_value
+            scenario_weight = 1
+
+    # Validate weight: must be numeric and positive
+    scenario_weight = _validate_weight(scenario_weight, scenario_type)
+
+    return scenario_type, scenarios_list, scenario_weight
+
+
+def _validate_weight(weight: Any, scenario_type: str) -> float:
+    """
+    Validate and normalize a scenario weight value.
+
+    Args:
+        weight: Raw weight value from config (could be any type)
+        scenario_type: Scenario type name for logging
+
+    Returns:
+        Validated float weight (>0), defaults to 1.0 if invalid
+
+    Validation rules:
+    - Must be numeric (int, float, or numeric string)
+    - Must be > 0 (positive)
+    - Invalid values default to 1.0 with a warning
+    """
+    try:
+        weight_float = float(weight)
+        if weight_float <= 0:
+            logging.warning(
+                f"Invalid weight {weight_float} for scenario '{scenario_type}' "
+                f"(must be > 0). Using default weight=1"
+            )
+            return 1.0
+        return weight_float
+    except (TypeError, ValueError):
+        logging.warning(
+            f"Invalid weight type '{weight}' for scenario '{scenario_type}' "
+            f"(must be numeric). Using default weight=1"
+        )
+        return 1.0
+
+
+def extract_scenario_types(chaos_scenarios: List[dict]) -> set:
+    """
+    Extract unique scenario types from a list of scenario configurations.
+
+    Used for plugin validation logging.
+
+    Args:
+        chaos_scenarios: List of scenario configuration dictionaries
+
+    Returns:
+        Set of scenario type strings
+
+    Examples:
+        >>> scenarios = [
+        ...     {"pod_disruption_scenarios": {"weight": 3, "files": ["etcd.yml"]}},
+        ...     {"hog_scenarios": ["cpu-hog.yml"]}
+        ... ]
+        >>> extract_scenario_types(scenarios)
+        {'pod_disruption_scenarios', 'hog_scenarios'}
+    """
+    configured_types = set()
+    for scenario in chaos_scenarios:
+        if isinstance(scenario, dict):
+            # Parse scenario type using same logic as execution loop
+            if "scenario_type" in scenario and "files" in scenario:
+                # Explicit format: {scenario_type: str, weight: N, files: []}
+                configured_types.add(scenario["scenario_type"])
+            else:
+                # Old/weighted format: {scenario_type: ...}
+                configured_types.add(list(scenario.keys())[0])
+    return configured_types

--- a/krkn/scenario_plugins/abstract_scenario_plugin.py
+++ b/krkn/scenario_plugins/abstract_scenario_plugin.py
@@ -17,6 +17,7 @@ import time
 from abc import ABC, abstractmethod
 from krkn_lib.models.telemetry import ScenarioTelemetry
 from krkn_lib.telemetry.ocp import KrknTelemetryOpenshift
+from krkn_lib.utils.functions import get_yaml_item_value
 
 from krkn import utils, cerberus
 from krkn.rollback.handler import (
@@ -85,8 +86,9 @@ class AbstractScenarioPlugin(ABC):
 
         scenario_telemetries: list[ScenarioTelemetry] = []
         failed_scenarios = []
-        wait_duration = krkn_config["tunings"]["wait_duration"]
-        events_backup = krkn_config["telemetry"]["events_backup"]
+        wait_duration = get_yaml_item_value(krkn_config["tunings"], "wait_duration", 30)
+        events_backup = get_yaml_item_value(krkn_config["telemetry"], "events_backup", True)
+
         for scenario_config in scenarios_list:
             if isinstance(scenario_config, list):
                 logging.error(

--- a/krkn/summarized_reports/transform.py
+++ b/krkn/summarized_reports/transform.py
@@ -632,9 +632,25 @@ def build_chaos_report(chaos_output: dict) -> str:
 
     # --- Resiliency Score ---
     lines.append("RESILIENCY SCORE")
+
+    # Extract weights from detailed report
+    weight_map = {}
+    scenario_details = chaos_output.get("resiliency_report", {}).get("scenarios", [])
+    if scenario_details:
+        for scenario_report in scenario_details:
+            weight_map[scenario_report.get("name")] = scenario_report.get("weight", 1)
+
     per_scenario_scores = resiliency.get("scenarios", {})
     for scenario_name, score in per_scenario_scores.items():
-        lines.append(f"  {scenario_name:<28} : {score} / 100")
+        weight = weight_map.get(scenario_name, 1)
+        lines.append(f"  {scenario_name:<28} : {score} / 100 (weight: {weight}x)")
+
+    # Calculate and display weighted average explanation
+    if weight_map and per_scenario_scores:
+        total_weight = sum(weight_map.get(name, 1) for name in per_scenario_scores.keys())
+        weighted_sum = sum(per_scenario_scores.get(name, 0) * weight_map.get(name, 1) for name in per_scenario_scores.keys())
+        weighted_avg = int(weighted_sum / total_weight) if total_weight > 0 else 0
+        lines.append(f"  Calculation: ({' + '.join(f'{score}×{weight_map.get(name, 1)}' for name, score in per_scenario_scores.items())}) ÷ {total_weight} = {weighted_avg}")
 
     overall_score = resiliency.get("resiliency_score", "N/A")
     emoji = ""
@@ -1139,15 +1155,37 @@ def build_chaos_report_pdf(chaos_output: dict, output_path: str) -> str:
 
     # 16. Resiliency Score
     f.extend(_section_header("Resiliency Score"))
+
+    # Extract scenario weights from detailed report
+    weight_map = {}
+    scenario_details = chaos_output.get("resiliency_report", {}).get("scenarios", [])
+    if scenario_details:
+        for scenario_report in scenario_details:
+            weight_map[scenario_report.get("name")] = scenario_report.get("weight", 1)
+
+    # Build scenario scores table with weights
     if per_scenario_scores:
         rows = []
         for name, score in per_scenario_scores.items():
             c = _score_color(score)
+            weight = weight_map.get(name, 1)
             rows.append([
                 name,
+                f"Weight: {weight}x",
                 Paragraph(f'<font color="{c}"><b>{score} / 100</b></font>', _STYLE_CELL),
             ])
-        f.extend(_make_data_table(["Scenario", "Score"], rows))
+        f.extend(_make_data_table(["Scenario", "Weight", "Score"], rows))
+
+        # Add resiliency score calculation explanation
+        f.append(Spacer(1, 8))
+        total_weight = sum(weight_map.get(name, 1) for name in per_scenario_scores.keys())
+        calc_detail = (
+            f'<b>Resiliency Score Calculation:</b> Weighted average of scenario scores. '
+            f'Total weight: {total_weight}x. '
+            f'Formula: (Σ score × weight) ÷ total weight'
+        )
+        f.append(Paragraph(calc_detail, _STYLE_CELL))
+        f.append(Spacer(1, 8))
 
     c = _score_color(overall_score)
     overall_style = ParagraphStyle(

--- a/krkn/summarized_reports/transform_html.py
+++ b/krkn/summarized_reports/transform_html.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Krkn Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from datetime import datetime
 from xml.sax.saxutils import escape as _xml_escape
 
@@ -628,15 +642,34 @@ def build_chaos_report_html(chaos_output: dict, output_path: str) -> str:
 
     # 16. Resiliency Score
     score_body = []
+
+    # Extract scenario weights from detailed report
+    weight_map = {}
+    scenario_details = chaos_output.get("resiliency_report", {}).get("scenarios", [])
+    if scenario_details:
+        for scenario_report in scenario_details:
+            weight_map[scenario_report.get("name")] = scenario_report.get("weight", 1)
+
     if per_scenario_scores:
         rows = []
         for name, score in per_scenario_scores.items():
             cls = _html_score_class(score)
+            weight = weight_map.get(name, 1)
             rows.append([
                 _h(name),
+                _h(f"Weight: {weight}x"),
                 f'<span class="{cls}"><b>{_h(str(score))} / 100</b></span>',
             ])
-        score_body.append(_html_data_table(["Scenario", "Score"], rows))
+        score_body.append(_html_data_table(["Scenario", "Weight", "Score"], rows))
+
+        # Add resiliency score calculation explanation
+        total_weight = sum(weight_map.get(name, 1) for name in per_scenario_scores.keys())
+        calc_detail = (
+            f'<p><b>Resiliency Score Calculation:</b> Weighted average of scenario scores. '
+            f'Total weight: {total_weight}x. '
+            f'Formula: (Σ score × weight) ÷ total weight</p>'
+        )
+        score_body.append(calc_detail)
 
     cls = _html_score_class(overall_score)
     score_body.append(f'<div class="overall-score {cls}">Overall: {_h(str(overall_score))} / 100</div>')

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -72,6 +72,7 @@ from krkn.rollback.command import (
     list_rollback as list_rollback_command,
     execute_rollback as execute_rollback_command,
 )
+from krkn.scenario_config_parser import parse_scenario_config, extract_scenario_types
 from krkn.summarized_reports.transform import build_chaos_report, build_chaos_report_pdf
 from krkn.summarized_reports.transform_html import build_chaos_report_html
 from krkn.scenario_plugins.triggers.trigger_manager import TriggerManager
@@ -483,10 +484,7 @@ def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
                 return 1
 
         # Log run-specific plugin mappings (after triggers may have cleared chaos_scenarios)
-        configured_types: set[str] = set()
-        for scenario in chaos_scenarios:
-            if isinstance(scenario, dict):
-                configured_types.add(list(scenario.keys())[0])
+        configured_types = extract_scenario_types(chaos_scenarios)
         if configured_types:
             logging.info("Scenario plugins for this run:")
             for stype in sorted(configured_types):
@@ -523,8 +521,13 @@ def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
                     if run_signal == "STOP":
                         logging.info("Received STOP signal; ending Kraken run")
                         break
-                    scenario_type = list(scenario.keys())[0]
-                    scenarios_list = scenario[scenario_type]
+
+                    # Parse scenario config (type, files, weight)
+                    scenario_type, scenarios_list, scenario_weight = parse_scenario_config(scenario)
+
+                    if scenario_weight != 1:
+                        logging.info(f"Scenario '{scenario_type}' has weight {scenario_weight} for resiliency scoring")
+
                     if scenarios_list:
                         try:
                             scenario_plugin = scenario_plugin_factory.create_plugin(
@@ -553,6 +556,7 @@ def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
                                 scenario_type=scenario_type,
                                 batch_start_dt=batch_window_start_dt,
                                 batch_end_dt=batch_window_end_dt,
+                                weight=scenario_weight,
                             )
 
                         post_critical_alerts = 0
@@ -693,6 +697,7 @@ def main(options, command: Optional[str], out: Optional[dict] = None) -> int:
         chaos_output_dict = json.loads(chaos_output.to_json())
         if resiliency_obj and hasattr(resiliency_obj, 'scenario_reports') and resiliency_obj.scenario_reports:
             chaos_output_dict["scenario_slo_details"] = resiliency_obj.get_scenario_slo_details()
+            chaos_output_dict["resiliency_report"] = resiliency_obj.get_detailed_report()
         try:
             text_summary = build_chaos_report(chaos_output_dict)
             logging.info(f"\n{text_summary}")

--- a/scenarios/kind/pod_apiserver.yml
+++ b/scenarios/kind/pod_apiserver.yml
@@ -1,0 +1,6 @@
+- id: kill-pods
+  config:
+    namespace_pattern: "kube-system"
+    label_selector: "component=kube-apiserver"
+    krkn_pod_recovery_time: 120
+    kill: 1

--- a/scenarios/kind/pod_dns.yml
+++ b/scenarios/kind/pod_dns.yml
@@ -1,0 +1,6 @@
+- id: kill-pods
+  config:
+    namespace_pattern: "kube-system"
+    label_selector: "k8s-app=kube-dns"
+    krkn_pod_recovery_time: 120
+    kill: 1

--- a/tests/test_config_parsing_comprehensive.py
+++ b/tests/test_config_parsing_comprehensive.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python
+"""
+Comprehensive tests for chaos scenario config parsing with weighted scenarios.
+
+Tests all supported config formats:
+1. Old format: {scenario_type: [files]}
+2. Weighted format: {scenario_type: {weight: N, files: []}}
+3. Explicit format: {scenario_type: str, weight: N, files: []}
+
+How to run:
+    python -m unittest tests.test_config_parsing_comprehensive -v
+    python -m unittest tests.test_config_parsing_comprehensive.TestOldFormatCompatibility -v
+    python -m unittest tests.test_config_parsing_comprehensive.TestWeightedFormat -v
+    python -m unittest tests.test_config_parsing_comprehensive.TestEdgeCases -v
+"""
+
+import unittest
+import tempfile
+import yaml
+import os
+
+from krkn.scenario_config_parser import parse_scenario_config
+
+
+class TestOldFormatCompatibility(unittest.TestCase):
+    """Test that old config format still works (backward compatibility)."""
+
+    def test_old_format_single_file(self):
+        """Old format with a single file."""
+        scenario = {
+            "pod_disruption_scenarios": [
+                "scenarios/openshift/etcd.yml"
+            ]
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(scenario_type, "pod_disruption_scenarios")
+        self.assertEqual(files, ["scenarios/openshift/etcd.yml"])
+        self.assertEqual(weight, 1)
+
+    def test_old_format_multiple_files(self):
+        """Old format with multiple files."""
+        scenario = {
+            "pod_disruption_scenarios": [
+                "scenarios/openshift/etcd.yml",
+                "scenarios/openshift/prom_kill.yml",
+                "scenarios/openshift/openshift-apiserver.yml"
+            ]
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(scenario_type, "pod_disruption_scenarios")
+        self.assertEqual(len(files), 3)
+        self.assertEqual(weight, 1)
+        self.assertIn("scenarios/openshift/etcd.yml", files)
+
+    def test_old_format_empty_list(self):
+        """Old format with empty file list."""
+        scenario = {
+            "hog_scenarios": []
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(scenario_type, "hog_scenarios")
+        self.assertEqual(files, [])
+        self.assertEqual(weight, 1)
+
+    def test_old_format_various_scenario_types(self):
+        """Test old format works for different scenario types."""
+        test_cases = [
+            "pod_disruption_scenarios",
+            "node_scenarios",
+            "hog_scenarios",
+            "service_disruption_scenarios",
+            "network_chaos_scenarios",
+            "container_scenarios"
+        ]
+
+        for scenario_type_name in test_cases:
+            scenario = {
+                scenario_type_name: ["scenarios/test.yml"]
+            }
+            scenario_type, files, weight = parse_scenario_config(scenario)
+
+            self.assertEqual(scenario_type, scenario_type_name)
+            self.assertEqual(weight, 1)
+
+
+class TestWeightedFormat(unittest.TestCase):
+    """Test the new weighted scenario format."""
+
+    def test_weighted_format_basic(self):
+        """Basic weighted format with weight and files."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": 3,
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(scenario_type, "pod_disruption_scenarios")
+        self.assertEqual(files, ["scenarios/openshift/etcd.yml"])
+        self.assertEqual(weight, 3)
+
+    def test_weighted_format_float_weight(self):
+        """Weighted format with float weight."""
+        scenario = {
+            "node_scenarios": {
+                "weight": 1.5,
+                "files": ["scenarios/openshift/aws_node_scenarios.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1.5)
+
+    def test_weighted_format_fractional_weight(self):
+        """Weighted format with fractional weight less than 1."""
+        scenario = {
+            "hog_scenarios": {
+                "weight": 0.5,
+                "files": ["scenarios/kube/cpu-hog.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 0.5)
+
+    def test_weighted_format_multiple_files(self):
+        """Weighted format with multiple files."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": 3,
+                "files": [
+                    "scenarios/openshift/etcd.yml",
+                    "scenarios/openshift/openshift-apiserver.yml",
+                    "scenarios/openshift/openshift-kube-apiserver.yml"
+                ]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 3)
+        self.assertEqual(len(files), 3)
+
+    def test_weighted_format_missing_weight_defaults_to_1(self):
+        """Weighted format without explicit weight defaults to 1."""
+        scenario = {
+            "hog_scenarios": {
+                "files": ["scenarios/kube/cpu-hog.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1)
+
+    def test_weighted_format_weight_zero(self):
+        """Weighted format with weight=0 defaults to 1 (validated)."""
+        scenario = {
+            "test_scenarios": {
+                "weight": 0,
+                "files": ["scenarios/test.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        # Weight validation: 0 is invalid, defaults to 1
+        self.assertEqual(weight, 1.0)
+
+    def test_weighted_format_large_weight(self):
+        """Weighted format with large weight."""
+        scenario = {
+            "critical_scenarios": {
+                "weight": 10,
+                "files": ["scenarios/critical.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 10)
+
+
+class TestExplicitFormat(unittest.TestCase):
+    """Test the explicit format with scenario_type as a field."""
+
+    def test_explicit_format_with_weight(self):
+        """Explicit format: scenario_type, weight, files."""
+        scenario = {
+            "scenario_type": "pod_disruption_scenarios",
+            "weight": 3,
+            "files": ["scenarios/openshift/etcd.yml"]
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(scenario_type, "pod_disruption_scenarios")
+        self.assertEqual(weight, 3)
+        self.assertEqual(files, ["scenarios/openshift/etcd.yml"])
+
+    def test_explicit_format_without_weight(self):
+        """Explicit format without weight defaults to 1."""
+        scenario = {
+            "scenario_type": "hog_scenarios",
+            "files": ["scenarios/kube/cpu-hog.yml"]
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1)
+
+    def test_explicit_format_multiple_files(self):
+        """Explicit format with multiple files."""
+        scenario = {
+            "scenario_type": "service_disruption_scenarios",
+            "weight": 2,
+            "files": [
+                "scenarios/openshift/regex_namespace.yaml",
+                "scenarios/openshift/ingress_namespace.yaml"
+            ]
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 2)
+        self.assertEqual(len(files), 2)
+
+
+class TestMixedFormats(unittest.TestCase):
+    """Test mixing different config formats in the same configuration."""
+
+    def test_all_three_formats_together(self):
+        """Mix old format, weighted format, and explicit format."""
+        scenarios = [
+            # Old format
+            {
+                "container_scenarios": [
+                    "scenarios/openshift/container_etcd.yml"
+                ]
+            },
+            # Weighted format
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 3,
+                    "files": ["scenarios/openshift/etcd.yml"]
+                }
+            },
+            # Explicit format
+            {
+                "scenario_type": "service_disruption_scenarios",
+                "weight": 2,
+                "files": ["scenarios/openshift/regex_namespace.yaml"]
+            }
+        ]
+
+        results = [parse_scenario_config(s) for s in scenarios]
+
+        # Verify each format parsed correctly
+        self.assertEqual(results[0], ("container_scenarios", ["scenarios/openshift/container_etcd.yml"], 1))
+        self.assertEqual(results[1], ("pod_disruption_scenarios", ["scenarios/openshift/etcd.yml"], 3))
+        self.assertEqual(results[2], ("service_disruption_scenarios", ["scenarios/openshift/regex_namespace.yaml"], 2))
+
+    def test_weighted_and_unweighted_scenarios(self):
+        """Mix weighted and unweighted scenarios."""
+        scenarios = [
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 3,
+                    "files": ["scenarios/openshift/etcd.yml"]
+                }
+            },
+            {
+                "hog_scenarios": {
+                    "files": ["scenarios/kube/cpu-hog.yml"]  # No weight
+                }
+            },
+            {
+                "container_scenarios": ["scenarios/openshift/container_etcd.yml"]  # Old format
+            }
+        ]
+
+        results = [parse_scenario_config(s) for s in scenarios]
+
+        self.assertEqual(results[0][2], 3)   # Weight=3
+        self.assertEqual(results[1][2], 1)   # Default weight=1
+        self.assertEqual(results[2][2], 1)   # Default weight=1
+
+
+class TestEdgeCases(unittest.TestCase):
+    """Test edge cases and potential error conditions."""
+
+    def test_empty_files_in_weighted_format(self):
+        """Weighted format with empty files list."""
+        scenario = {
+            "test_scenarios": {
+                "weight": 2,
+                "files": []
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(files, [])
+        self.assertEqual(weight, 2)
+
+    def test_missing_files_key_in_weighted_format(self):
+        """Weighted format missing 'files' key (should return empty list)."""
+        scenario = {
+            "test_scenarios": {
+                "weight": 2
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(files, [])
+        self.assertEqual(weight, 2)
+
+    def test_weight_as_string_integer(self):
+        """Weight provided as string that looks like integer is converted to float."""
+        # Note: YAML parsing would convert "3" to int, but test the logic
+        scenario = {
+            "test_scenarios": {
+                "weight": "3",  # String, not int
+                "files": ["test.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        # Weight validation converts numeric strings to float
+        self.assertEqual(weight, 3.0)
+
+    def test_negative_weight(self):
+        """Negative weight defaults to 1 (validated)."""
+        scenario = {
+            "test_scenarios": {
+                "weight": -1,
+                "files": ["test.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        # Weight validation: negative is invalid, defaults to 1
+        self.assertEqual(weight, 1.0)
+
+
+class TestYAMLIntegration(unittest.TestCase):
+    """Test parsing actual YAML config files."""
+
+    def test_parse_old_format_yaml(self):
+        """Parse old format from actual YAML."""
+        yaml_content = """
+kraken:
+  chaos_scenarios:
+    - pod_disruption_scenarios:
+        - scenarios/openshift/etcd.yml
+        - scenarios/openshift/prom_kill.yml
+    - hog_scenarios:
+        - scenarios/kube/cpu-hog.yml
+"""
+        config = yaml.safe_load(yaml_content)
+        scenarios = config['kraken']['chaos_scenarios']
+
+        results = [parse_scenario_config(s) for s in scenarios]
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0][0], "pod_disruption_scenarios")
+        self.assertEqual(len(results[0][1]), 2)
+        self.assertEqual(results[0][2], 1)
+
+    def test_parse_weighted_format_yaml(self):
+        """Parse weighted format from actual YAML."""
+        yaml_content = """
+kraken:
+  chaos_scenarios:
+    - pod_disruption_scenarios:
+        weight: 3
+        files:
+          - scenarios/openshift/etcd.yml
+    - service_disruption_scenarios:
+        weight: 2
+        files:
+          - scenarios/openshift/regex_namespace.yaml
+    - hog_scenarios:
+        weight: 0.5
+        files:
+          - scenarios/kube/cpu-hog.yml
+"""
+        config = yaml.safe_load(yaml_content)
+        scenarios = config['kraken']['chaos_scenarios']
+
+        results = [parse_scenario_config(s) for s in scenarios]
+
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0][2], 3)     # Weight=3
+        self.assertEqual(results[1][2], 2)     # Weight=2
+        self.assertEqual(results[2][2], 0.5)   # Weight=0.5
+
+    def test_parse_mixed_format_yaml(self):
+        """Parse mixed formats from actual YAML."""
+        yaml_content = """
+kraken:
+  chaos_scenarios:
+    - pod_disruption_scenarios:
+        weight: 3
+        files:
+          - scenarios/openshift/etcd.yml
+    - hog_scenarios:
+        - scenarios/kube/cpu-hog.yml
+    - scenario_type: service_disruption_scenarios
+      weight: 2
+      files:
+        - scenarios/openshift/regex_namespace.yaml
+"""
+        config = yaml.safe_load(yaml_content)
+        scenarios = config['kraken']['chaos_scenarios']
+
+        results = [parse_scenario_config(s) for s in scenarios]
+
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0][2], 3)   # Weighted format
+        self.assertEqual(results[1][2], 1)   # Old format
+        self.assertEqual(results[2][2], 2)   # Explicit format
+
+    def test_parse_from_temp_file(self):
+        """Parse config from a temporary YAML file."""
+        yaml_content = """
+kraken:
+  chaos_scenarios:
+    - pod_disruption_scenarios:
+        weight: 3
+        files:
+          - scenarios/openshift/etcd.yml
+    - container_scenarios:
+        - scenarios/openshift/container_etcd.yml
+"""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(yaml_content)
+            temp_file = f.name
+
+        try:
+            with open(temp_file, 'r') as f:
+                config = yaml.safe_load(f)
+
+            scenarios = config['kraken']['chaos_scenarios']
+            results = [parse_scenario_config(s) for s in scenarios]
+
+            self.assertEqual(len(results), 2)
+            self.assertEqual(results[0][2], 3)  # Weighted
+            self.assertEqual(results[1][2], 1)  # Old format
+        finally:
+            os.unlink(temp_file)
+
+
+class TestRealWorldScenarios(unittest.TestCase):
+    """Test realistic scenario configurations."""
+
+    def test_production_critical_weighting(self):
+        """Test production-like config with critical scenarios weighted heavily."""
+        scenarios = [
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 5,  # Very critical
+                    "files": [
+                        "scenarios/openshift/etcd.yml",
+                        "scenarios/openshift/openshift-apiserver.yml",
+                        "scenarios/openshift/openshift-kube-apiserver.yml"
+                    ]
+                }
+            },
+            {
+                "service_disruption_scenarios": {
+                    "weight": 3,  # Important
+                    "files": [
+                        "scenarios/openshift/regex_namespace.yaml",
+                        "scenarios/openshift/ingress_namespace.yaml"
+                    ]
+                }
+            },
+            {
+                "hog_scenarios": {
+                    "weight": 0.25,  # Less important
+                    "files": [
+                        "scenarios/kube/cpu-hog.yml",
+                        "scenarios/kube/memory-hog.yml"
+                    ]
+                }
+            }
+        ]
+
+        results = [parse_scenario_config(s) for s in scenarios]
+
+        # Verify weights
+        self.assertEqual(results[0][2], 5)
+        self.assertEqual(results[1][2], 3)
+        self.assertEqual(results[2][2], 0.25)
+
+        # Verify all files parsed
+        self.assertEqual(len(results[0][1]), 3)
+        self.assertEqual(len(results[1][1]), 2)
+        self.assertEqual(len(results[2][1]), 2)
+
+    def test_gradual_adoption_config(self):
+        """Test config during gradual adoption (some weighted, some not)."""
+        scenarios = [
+            # New weighted critical scenarios
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 3,
+                    "files": ["scenarios/openshift/etcd.yml"]
+                }
+            },
+            # Old format (not yet migrated)
+            {
+                "hog_scenarios": ["scenarios/kube/cpu-hog.yml"]
+            },
+            {
+                "network_chaos_scenarios": ["scenarios/openshift/network_chaos.yaml"]
+            },
+            # Another weighted scenario
+            {
+                "service_disruption_scenarios": {
+                    "weight": 2,
+                    "files": ["scenarios/openshift/regex_namespace.yaml"]
+                }
+            }
+        ]
+
+        results = [parse_scenario_config(s) for s in scenarios]
+
+        # Weighted scenarios have custom weights
+        self.assertEqual(results[0][2], 3)
+        self.assertEqual(results[3][2], 2)
+
+        # Old format scenarios default to weight=1
+        self.assertEqual(results[1][2], 1)
+        self.assertEqual(results[2][2], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_plugin_logging.py
+++ b/tests/test_plugin_logging.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python
+"""
+Tests for scenario plugin logging with weighted scenarios.
+
+Ensures that the "Scenario plugins for this run" log correctly identifies
+scenario types even when using the explicit format where 'scenario_type' is a key.
+
+How to run:
+    python -m unittest tests.test_plugin_logging -v
+"""
+
+import unittest
+
+from krkn.scenario_config_parser import extract_scenario_types
+
+
+class TestPluginLogging(unittest.TestCase):
+    """Test that plugin logging correctly identifies scenario types."""
+
+    def test_old_format_extracts_correct_type(self):
+        """Old format should extract the scenario type correctly."""
+        chaos_scenarios = [
+            {
+                "pod_disruption_scenarios": [
+                    "scenarios/openshift/etcd.yml"
+                ]
+            }
+        ]
+
+        types = extract_scenario_types(chaos_scenarios)
+
+        self.assertIn("pod_disruption_scenarios", types)
+        self.assertNotIn("scenario_type", types)
+
+    def test_weighted_format_extracts_correct_type(self):
+        """Weighted format should extract the scenario type correctly."""
+        chaos_scenarios = [
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 3,
+                    "files": ["scenarios/openshift/etcd.yml"]
+                }
+            }
+        ]
+
+        types = extract_scenario_types(chaos_scenarios)
+
+        self.assertIn("pod_disruption_scenarios", types)
+        self.assertNotIn("scenario_type", types)
+
+    def test_explicit_format_extracts_correct_type(self):
+        """Explicit format should extract the scenario type correctly (NOT 'scenario_type')."""
+        chaos_scenarios = [
+            {
+                "scenario_type": "pod_disruption_scenarios",
+                "weight": 3,
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        ]
+
+        types = extract_scenario_types(chaos_scenarios)
+
+        # Should extract "pod_disruption_scenarios", NOT "scenario_type"
+        self.assertIn("pod_disruption_scenarios", types)
+        self.assertNotIn("scenario_type", types)
+
+    def test_mixed_formats_extract_all_types(self):
+        """Mixed formats should extract all unique scenario types."""
+        chaos_scenarios = [
+            # Old format
+            {
+                "container_scenarios": [
+                    "scenarios/openshift/container_etcd.yml"
+                ]
+            },
+            # Weighted format
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 3,
+                    "files": ["scenarios/openshift/etcd.yml"]
+                }
+            },
+            # Explicit format
+            {
+                "scenario_type": "service_disruption_scenarios",
+                "weight": 2,
+                "files": ["scenarios/openshift/regex_namespace.yaml"]
+            }
+        ]
+
+        types = extract_scenario_types(chaos_scenarios)
+
+        self.assertEqual(len(types), 3)
+        self.assertIn("container_scenarios", types)
+        self.assertIn("pod_disruption_scenarios", types)
+        self.assertIn("service_disruption_scenarios", types)
+        self.assertNotIn("scenario_type", types)
+
+    def test_duplicate_scenario_types_deduplicated(self):
+        """Duplicate scenario types should be deduplicated."""
+        chaos_scenarios = [
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 3,
+                    "files": ["scenarios/openshift/etcd.yml"]
+                }
+            },
+            {
+                "scenario_type": "pod_disruption_scenarios",
+                "weight": 2,
+                "files": ["scenarios/openshift/prom_kill.yml"]
+            },
+            {
+                "pod_disruption_scenarios": [
+                    "scenarios/openshift/openshift-apiserver.yml"
+                ]
+            }
+        ]
+
+        types = extract_scenario_types(chaos_scenarios)
+
+        # Should only have one entry for "pod_disruption_scenarios"
+        self.assertEqual(len(types), 1)
+        self.assertIn("pod_disruption_scenarios", types)
+
+    def test_empty_scenarios_returns_empty_set(self):
+        """Empty scenarios list should return empty set."""
+        chaos_scenarios = []
+
+        types = extract_scenario_types(chaos_scenarios)
+
+        self.assertEqual(len(types), 0)
+
+    def test_scenario_type_key_not_mistaken_for_plugin(self):
+        """The literal string 'scenario_type' should never appear in configured types."""
+        # This is a regression test for the bug where explicit format
+        # would cause "scenario_type ➡️ no matching plugin found" warnings
+
+        test_cases = [
+            # Explicit format
+            [{"scenario_type": "pod_disruption_scenarios", "files": ["test.yml"]}],
+            # Multiple explicit formats
+            [
+                {"scenario_type": "pod_disruption_scenarios", "files": ["test1.yml"]},
+                {"scenario_type": "hog_scenarios", "files": ["test2.yml"]}
+            ],
+            # Mixed with explicit format
+            [
+                {"pod_disruption_scenarios": ["test1.yml"]},
+                {"scenario_type": "hog_scenarios", "files": ["test2.yml"]}
+            ]
+        ]
+
+        for scenarios in test_cases:
+            with self.subTest(scenarios=scenarios):
+                types = extract_scenario_types(scenarios)
+                self.assertNotIn("scenario_type", types,
+                    f"'scenario_type' should not be in configured types for: {scenarios}")
+
+
+class TestPluginLoggingRealWorld(unittest.TestCase):
+    """Test plugin logging with real-world config scenarios."""
+
+    def test_production_weighted_config(self):
+        """Test with production-like weighted config."""
+        chaos_scenarios = [
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 3,
+                    "files": [
+                        "scenarios/openshift/etcd.yml",
+                        "scenarios/openshift/openshift-apiserver.yml",
+                        "scenarios/openshift/openshift-kube-apiserver.yml"
+                    ]
+                }
+            },
+            {
+                "service_disruption_scenarios": {
+                    "weight": 2,
+                    "files": [
+                        "scenarios/openshift/regex_namespace.yaml",
+                        "scenarios/openshift/ingress_namespace.yaml"
+                    ]
+                }
+            },
+            {
+                "node_scenarios": {
+                    "weight": 1.5,
+                    "files": ["scenarios/openshift/aws_node_scenarios.yml"]
+                }
+            },
+            {
+                "hog_scenarios": {
+                    "weight": 0.5,
+                    "files": [
+                        "scenarios/kube/cpu-hog.yml",
+                        "scenarios/kube/memory-hog.yml"
+                    ]
+                }
+            },
+            {
+                "container_scenarios": [
+                    "scenarios/openshift/container_etcd.yml"
+                ]
+            }
+        ]
+
+        types = extract_scenario_types(chaos_scenarios)
+
+        expected_types = {
+            "pod_disruption_scenarios",
+            "service_disruption_scenarios",
+            "node_scenarios",
+            "hog_scenarios",
+            "container_scenarios"
+        }
+
+        self.assertEqual(types, expected_types)
+        self.assertNotIn("scenario_type", types)
+
+    def test_gradual_migration_config(self):
+        """Test with config during gradual migration to weighted format."""
+        chaos_scenarios = [
+            # New weighted scenarios
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 3,
+                    "files": ["scenarios/openshift/etcd.yml"]
+                }
+            },
+            # Old format (not yet migrated)
+            {
+                "hog_scenarios": ["scenarios/kube/cpu-hog.yml"]
+            },
+            {
+                "network_chaos_scenarios": ["scenarios/openshift/network_chaos.yaml"]
+            },
+            # Explicit format
+            {
+                "scenario_type": "service_disruption_scenarios",
+                "weight": 2,
+                "files": ["scenarios/openshift/regex_namespace.yaml"]
+            }
+        ]
+
+        types = extract_scenario_types(chaos_scenarios)
+
+        expected_types = {
+            "pod_disruption_scenarios",
+            "hog_scenarios",
+            "network_chaos_scenarios",
+            "service_disruption_scenarios"
+        }
+
+        self.assertEqual(types, expected_types)
+        self.assertNotIn("scenario_type", types)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_weight_validation.py
+++ b/tests/test_weight_validation.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python
+"""
+Tests for weight validation in weighted scenario config parsing and resiliency scoring.
+
+These tests ensure that invalid weights (zero, negative, non-numeric) are handled gracefully
+and don't cause crashes (ZeroDivisionError, TypeError, etc.).
+
+How to run:
+    python -m unittest tests.test_weight_validation -v
+"""
+
+import datetime
+import logging
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from krkn.resiliency.resiliency import Resiliency
+from krkn.scenario_config_parser import parse_scenario_config
+
+
+class TestWeightValidation(unittest.TestCase):
+    """Test weight validation for config parsing."""
+
+    def test_zero_weight_defaults_to_1(self):
+        """Weight of 0 should default to 1 to avoid division by zero."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": 0,
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1)  # Should default to 1, not 0
+
+    def test_negative_weight_defaults_to_1(self):
+        """Negative weight should default to 1."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": -5,
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1)  # Should default to 1
+
+    def test_string_weight_defaults_to_1(self):
+        """Non-numeric string weight should default to 1."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": "invalid",
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1)  # Should default to 1
+
+    def test_numeric_string_weight_converts_to_float(self):
+        """Numeric string weight should be converted to float."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": "3",
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 3.0)
+
+    def test_none_weight_defaults_to_1(self):
+        """None weight should default to 1."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": None,
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1)
+
+    def test_list_weight_defaults_to_1(self):
+        """List weight (invalid type) should default to 1."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": [1, 2, 3],
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1)
+
+    def test_dict_weight_defaults_to_1(self):
+        """Dict weight (invalid type) should default to 1."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": {"value": 3},
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1)
+
+    def test_very_small_positive_weight_accepted(self):
+        """Very small positive weight (0.001) should be accepted."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": 0.001,
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 0.001)
+
+    def test_very_large_weight_accepted(self):
+        """Very large weight (1000) should be accepted."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": 1000,
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+        scenario_type, files, weight = parse_scenario_config(scenario)
+
+        self.assertEqual(weight, 1000)
+
+
+class TestResiliencyWeightValidation(unittest.TestCase):
+    """Test weight validation in the Resiliency class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create a minimal alerts file
+        alerts_data = [
+            {"expr": "up == 0", "severity": "critical", "description": "Instance down"},
+        ]
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            import yaml
+            yaml.dump(alerts_data, f)
+            self.temp_file = f.name
+
+        self.res = Resiliency(alerts_yaml_path=self.temp_file)
+        self.mock_prom = Mock()
+
+        # Suppress logging during tests
+        logging.disable(logging.WARNING)
+
+    def tearDown(self):
+        """Clean up."""
+        import os
+        os.unlink(self.temp_file)
+        logging.disable(logging.NOTSET)
+
+    @patch('krkn.resiliency.resiliency.evaluate_slos')
+    @patch('krkn.resiliency.resiliency.calculate_resiliency_score')
+    def test_add_scenario_report_zero_weight_defaults_to_1(self, mock_calc, mock_eval):
+        """add_scenario_report with weight=0 should default to 1."""
+        mock_eval.return_value = {"slo1": True}
+        mock_calc.return_value = (100, {"passed": 1, "failed": 0})
+
+        start = datetime.datetime(2025, 1, 1, 0, 0, 0)
+        end = datetime.datetime(2025, 1, 1, 2, 0, 0)
+
+        score = self.res.add_scenario_report(
+            scenario_name="test_scenario",
+            prom_cli=self.mock_prom,
+            start_time=start,
+            end_time=end,
+            weight=0,  # Invalid weight
+        )
+
+        # Check that weight was defaulted to 1
+        self.assertEqual(self.res.scenario_reports[0]["weight"], 1)
+
+    @patch('krkn.resiliency.resiliency.evaluate_slos')
+    @patch('krkn.resiliency.resiliency.calculate_resiliency_score')
+    def test_add_scenario_report_negative_weight_defaults_to_1(self, mock_calc, mock_eval):
+        """add_scenario_report with negative weight should default to 1."""
+        mock_eval.return_value = {"slo1": True}
+        mock_calc.return_value = (100, {"passed": 1, "failed": 0})
+
+        start = datetime.datetime(2025, 1, 1, 0, 0, 0)
+        end = datetime.datetime(2025, 1, 1, 2, 0, 0)
+
+        score = self.res.add_scenario_report(
+            scenario_name="test_scenario",
+            prom_cli=self.mock_prom,
+            start_time=start,
+            end_time=end,
+            weight=-5,  # Invalid weight
+        )
+
+        self.assertEqual(self.res.scenario_reports[0]["weight"], 1)
+
+    @patch('krkn.resiliency.resiliency.evaluate_slos')
+    @patch('krkn.resiliency.resiliency.calculate_resiliency_score')
+    def test_add_scenario_report_string_weight_defaults_to_1(self, mock_calc, mock_eval):
+        """add_scenario_report with string weight should default to 1."""
+        mock_eval.return_value = {"slo1": True}
+        mock_calc.return_value = (100, {"passed": 1, "failed": 0})
+
+        start = datetime.datetime(2025, 1, 1, 0, 0, 0)
+        end = datetime.datetime(2025, 1, 1, 2, 0, 0)
+
+        score = self.res.add_scenario_report(
+            scenario_name="test_scenario",
+            prom_cli=self.mock_prom,
+            start_time=start,
+            end_time=end,
+            weight="invalid",  # Invalid weight
+        )
+
+        self.assertEqual(self.res.scenario_reports[0]["weight"], 1)
+
+    @patch('krkn.resiliency.resiliency.evaluate_slos')
+    @patch('krkn.resiliency.resiliency.calculate_resiliency_score')
+    def test_finalize_with_all_zero_weights_uses_simple_average(self, mock_calc, mock_eval):
+        """finalize_report with all zero weights should fall back to simple average."""
+        mock_eval.return_value = {"slo1": True}
+
+        start = datetime.datetime(2025, 1, 1, 0, 0, 0)
+        end = datetime.datetime(2025, 1, 1, 2, 0, 0)
+
+        # Add scenarios that all have weight 0 (which get defaulted to 1 by validation)
+        # But let's test if someone bypasses validation
+        mock_calc.return_value = (80, {"passed": 1, "failed": 0})
+        self.res.add_scenario_report(
+            scenario_name="scenario1",
+            prom_cli=self.mock_prom,
+            start_time=start,
+            end_time=end,
+            weight=1,
+        )
+
+        # Manually corrupt the weight to test fallback
+        self.res.scenario_reports[0]["weight"] = 0
+
+        mock_calc.return_value = (60, {"passed": 0, "failed": 1})
+        self.res.add_scenario_report(
+            scenario_name="scenario2",
+            prom_cli=self.mock_prom,
+            start_time=start,
+            end_time=end,
+            weight=1,
+        )
+        self.res.scenario_reports[1]["weight"] = 0
+
+        # This should not crash, should use simple average
+        mock_calc.return_value = (100, {"passed": 1, "failed": 0})
+        self.res.finalize_report(
+            prom_cli=self.mock_prom,
+            total_start_time=start,
+            total_end_time=end,
+        )
+
+        # Simple average: (80 + 60) / 2 = 70
+        self.assertEqual(self.res.summary["resiliency_score"], 70)
+
+    @patch('krkn.resiliency.resiliency.evaluate_slos')
+    @patch('krkn.resiliency.resiliency.calculate_resiliency_score')
+    def test_finalize_with_valid_weights_uses_weighted_average(self, mock_calc, mock_eval):
+        """finalize_report with valid weights should use weighted average."""
+        mock_eval.return_value = {"slo1": True}
+
+        start = datetime.datetime(2025, 1, 1, 0, 0, 0)
+        end = datetime.datetime(2025, 1, 1, 2, 0, 0)
+
+        mock_calc.return_value = (80, {"passed": 1, "failed": 0})
+        self.res.add_scenario_report(
+            scenario_name="scenario1",
+            prom_cli=self.mock_prom,
+            start_time=start,
+            end_time=end,
+            weight=3,
+        )
+
+        mock_calc.return_value = (60, {"passed": 0, "failed": 1})
+        self.res.add_scenario_report(
+            scenario_name="scenario2",
+            prom_cli=self.mock_prom,
+            start_time=start,
+            end_time=end,
+            weight=1,
+        )
+
+        mock_calc.return_value = (100, {"passed": 1, "failed": 0})
+        self.res.finalize_report(
+            prom_cli=self.mock_prom,
+            total_start_time=start,
+            total_end_time=end,
+        )
+
+        # Weighted average: (80*3 + 60*1) / (3+1) = 300/4 = 75
+        self.assertEqual(self.res.summary["resiliency_score"], 75)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_weighted_config_parsing.py
+++ b/tests/test_weighted_config_parsing.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+"""
+Basic tests for weighted scenario config parsing.
+
+NOTE: For comprehensive tests covering all edge cases, formats, and YAML integration,
+see tests.test_config_parsing_comprehensive
+
+How to run:
+    python -m unittest tests.test_weighted_config_parsing -v
+    python -m unittest tests.test_config_parsing_comprehensive -v  # Comprehensive suite
+"""
+
+import unittest
+from krkn.scenario_config_parser import parse_scenario_config
+
+
+class TestWeightedConfigParsing(unittest.TestCase):
+    """Test weighted scenario config format parsing."""
+
+    def test_option1_format_with_weight(self):
+        """Test parsing Option 1 format: {scenario_type: {weight: N, files: []}}."""
+        scenario = {
+            "pod_disruption_scenarios": {
+                "weight": 2.5,
+                "files": ["scenarios/openshift/etcd.yml"]
+            }
+        }
+
+        scenario_type, scenarios_list, scenario_weight = parse_scenario_config(scenario)
+
+        self.assertEqual(scenario_type, "pod_disruption_scenarios")
+        self.assertEqual(scenarios_list, ["scenarios/openshift/etcd.yml"])
+        self.assertEqual(scenario_weight, 2.5)
+
+    def test_option1_format_without_weight_defaults_to_1(self):
+        """Test Option 1 format without weight defaults to 1."""
+        scenario = {
+            "hog_scenarios": {
+                "files": ["scenarios/kube/cpu-hog.yml"]
+            }
+        }
+
+        scenario_type, scenarios_list, scenario_weight = parse_scenario_config(scenario)
+
+        self.assertEqual(scenario_weight, 1.0)
+
+    def test_old_format_backward_compatible(self):
+        """Test old format still works with default weight=1."""
+        scenario = {
+            "pod_disruption_scenarios": [
+                "scenarios/openshift/etcd.yml",
+                "scenarios/openshift/prom_kill.yml"
+            ]
+        }
+
+        scenario_type, scenarios_list, scenario_weight = parse_scenario_config(scenario)
+
+        self.assertEqual(scenario_type, "pod_disruption_scenarios")
+        self.assertEqual(len(scenarios_list), 2)
+        self.assertEqual(scenario_weight, 1.0)
+
+    def test_mixed_formats(self):
+        """Test that Option 1 format and old format can coexist."""
+        scenarios = [
+            {
+                "pod_disruption_scenarios": {
+                    "weight": 3,
+                    "files": ["scenarios/openshift/etcd.yml"]
+                }
+            },
+            {
+                "hog_scenarios": ["scenarios/kube/cpu-hog.yml"]
+            }
+        ]
+
+        results = []
+        for scenario in scenarios:
+            scenario_type, scenarios_list, scenario_weight = parse_scenario_config(scenario)
+            results.append({
+                "type": scenario_type,
+                "weight": scenario_weight,
+                "files": scenarios_list
+            })
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["weight"], 3)
+        self.assertEqual(results[1]["weight"], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization

# Description  
Adding the ability to add a custom weight to each scenario when calculating the resiliency score

## Related Tickets & Documents
If no related issue, please create one and start the converasation on wants of 

- Related Issue #: 
- Closes #: https://github.com/krkn-chaos/krkn/issues/1563

# Documentation  
- [ ] **Is documentation needed for this update?**

If checked, a documentation PR must be created and merged in the [website repository](https://github.com/krkn-chaos/website/).

## Related Documentation PR (if applicable)  
<-- Add the link to the corresponding documentation PR in the website repository -->  

# Checklist before requesting a review
[ ] Ensure the changes and proposed solution have been discussed in the relevant issue and have received acknowledgment from the community or maintainers. See [contributing guidelines](https://krkn-chaos.dev/docs/contribution-guidelines/)
See [testing your changes](https://krkn-chaos.dev/docs/developers-guide/testing-changes/) and run on any Kubernetes or OpenShift cluster to validate your changes
- [ ] I have performed a self-review of my code by running krkn and specific scenario 
- [ ] If it is a core feature, I have added thorough unit tests with above 80% coverage

*REQUIRED*:
Description of combination of tests performed and output of run

debug logs I had added but removed in final commit

```bash
python run_kraken.py

2026-08-20 09:40:28,772 [INFO] ======================================================================
2026-08-20 09:40:28,772 [INFO] 🧮 CALCULATING WEIGHTED RESILIENCY SCORE
2026-08-20 09:40:28,772 [INFO] ======================================================================
2026-08-20 09:40:28,772 [INFO]   1. scenarios/kind/pod_etcd.yml: score=95, weight=3, contribution=285
2026-08-20 09:40:28,772 [INFO]   2. scenarios/kind/pod_apiserver.yml: score=95, weight=2, contribution=190
2026-08-20 09:40:28,772 [INFO]   3. scenarios/kind/pod_dns.yml: score=95, weight=1, contribution=95
2026-08-20 09:40:28,772 [INFO] ----------------------------------------------------------------------
2026-08-20 09:40:28,772 [INFO] 📐 Weighted sum: 570
2026-08-20 09:40:28,772 [INFO] 📐 Total weight: 6
2026-08-20 09:40:28,772 [INFO] 📐 Formula: 570 / 6 = 95.00
2026-08-20 09:40:28,773 [INFO] 🎯 FINAL WEIGHTED RESILIENCY SCORE: 95/100
2026-08-20 09:40:28,773 [INFO] ======================================================================
```

