### PR TITLE
fix(hogs): drain all worker exceptions in run_scenario

### DIFF
--- a/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
+++ b/krkn/scenario_plugins/hogs/hogs_scenario_plugin.py
@@ -168,12 +168,17 @@ class HogsScenarioPlugin(AbstractScenarioPlugin):
         for worker in workers:
             worker.join()
 
-        try:
-            while True:
-                exception = exception_queue.get_nowait()
-                raise exception
-        except queue.Empty:
-            pass
+        errors = []
+        while True:
+            try:
+                errors.append(str(exception_queue.get_nowait()))
+            except queue.Empty:
+                break
+        if errors:
+            raise Exception(
+                f"hog scenario execution failed on {len(errors)} node(s): "
+                + "; ".join(errors)
+            )
 
     @staticmethod
     def rollback_hog_pod(rollback_content: RollbackContent, lib_telemetry: KrknTelemetryOpenshift):

--- a/tests/test_hogs_scenario_plugin.py
+++ b/tests/test_hogs_scenario_plugin.py
@@ -42,6 +42,7 @@ class TestHogsScenarioPlugin(unittest.TestCase):
         return config
 
     def test_run_scenario_drains_all_exceptions(self):
+        """Multiple worker failures are aggregated into one exception."""
         q = queue.Queue()
         q.put(Exception("node-a failed"))
         q.put(Exception("node-b failed"))
@@ -54,6 +55,7 @@ class TestHogsScenarioPlugin(unittest.TestCase):
         self.assertTrue(q.empty())
 
     def test_run_scenario_single_exception(self):
+        """A single worker failure propagates in the combined exception."""
         q = queue.Queue()
         q.put(Exception("only failure"))
         with self.assertRaises(Exception) as ctx:
@@ -61,6 +63,7 @@ class TestHogsScenarioPlugin(unittest.TestCase):
         self.assertIn("only failure", str(ctx.exception))
 
     def test_run_scenario_no_exception(self):
+        """Empty exception queue means run_scenario does not raise."""
         q = queue.Queue()
         # should not raise when queue is empty
         self.plugin.run_scenario(self._stub_config(), MagicMock(), [], q)

--- a/tests/test_hogs_scenario_plugin.py
+++ b/tests/test_hogs_scenario_plugin.py
@@ -9,6 +9,7 @@ Usage:
 Assisted By: Claude Code
 """
 
+import queue
 import unittest
 from unittest.mock import MagicMock
 
@@ -34,6 +35,35 @@ class TestHogsScenarioPlugin(unittest.TestCase):
 
         self.assertEqual(result, ["hog_scenarios"])
         self.assertEqual(len(result), 1)
+
+    def _stub_config(self):
+        config = MagicMock()
+        config.type.value = "cpu"
+        return config
+
+    def test_run_scenario_drains_all_exceptions(self):
+        q = queue.Queue()
+        q.put(Exception("node-a failed"))
+        q.put(Exception("node-b failed"))
+        with self.assertRaises(Exception) as ctx:
+            self.plugin.run_scenario(self._stub_config(), MagicMock(), [], q)
+        msg = str(ctx.exception)
+        self.assertIn("2 node(s)", msg)
+        self.assertIn("node-a failed", msg)
+        self.assertIn("node-b failed", msg)
+        self.assertTrue(q.empty())
+
+    def test_run_scenario_single_exception(self):
+        q = queue.Queue()
+        q.put(Exception("only failure"))
+        with self.assertRaises(Exception) as ctx:
+            self.plugin.run_scenario(self._stub_config(), MagicMock(), [], q)
+        self.assertIn("only failure", str(ctx.exception))
+
+    def test_run_scenario_no_exception(self):
+        q = queue.Queue()
+        # should not raise when queue is empty
+        self.plugin.run_scenario(self._stub_config(), MagicMock(), [], q)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Related Tickets & Documents
Closes #1490

## Why
`HogsScenarioPlugin.run_scenario()` drains the shared exception queue with `raise` inside the `try`, so only the first worker exception propagates and the rest are silently discarded. Operators targeting multiple nodes see a single error line with no indication other nodes also failed.

## What
- Collect every queued worker error into `errors[]` via `get_nowait()` loop breaking on `queue.Empty`
- Raise one combined `Exception("hog scenario execution failed on N node(s): ...")` matching `network_chaos_ng run_parallel()` pattern
- Add regression tests in `tests/test_hogs_scenario_plugin.py` (multi-exception combined, single, empty-queue)

## Test plan
- `python -m unittest tests.test_hogs_scenario_plugin -v` (new regression tests)
- Syntax verified via `py_compile`; drain logic verified in isolation (full suite needs `krkn-lib` in CI)